### PR TITLE
Add steam fallback to build.

### DIFF
--- a/LookupAnything/LookupAnything.csproj
+++ b/LookupAnything/LookupAnything.csproj
@@ -31,6 +31,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <GamePath>C:\Program Files (x86)\GalaxyClient\Games\Stardew Valley</GamePath>
+    <GamePath Condition="!Exists('$(GamePath)')">C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley</GamePath>
     <StartAction>Program</StartAction>
     <StartProgram>$(GamePath)\StardewModdingAPI.exe</StartProgram>
     <StartWorkingDirectory>$(GamePath)</StartWorkingDirectory>


### PR DESCRIPTION
Maintains preference for the current path, adds fallback to a common steam path. You could append more like this line in the future to support other paths if needed.
