### PR TITLE
Added Feature - Perform lookup on target Player is facing

### DIFF
--- a/LookupAnything/Components/LookupMenu.cs
+++ b/LookupAnything/Components/LookupMenu.cs
@@ -86,7 +86,7 @@ namespace Pathoschild.Stardew.LookupAnything.Components
         /// <param name="direction">The scroll direction.</param>
         public override void receiveScrollWheelAction(int direction)
         {
-            if (direction > 0)          // Positive number scrolls window
+            if (direction > 0)          // Positive number scrolls window content up
                 this.ScrollUp();
             else
                 this.ScrollDown();
@@ -120,6 +120,7 @@ namespace Pathoschild.Stardew.LookupAnything.Components
                     this.ScrollDown();
                     break;
                 default:
+                    base.receiveGamePadButton(button);
                     break;
             }
         }

--- a/LookupAnything/Components/LookupMenu.cs
+++ b/LookupAnything/Components/LookupMenu.cs
@@ -8,6 +8,7 @@ using Pathoschild.Stardew.LookupAnything.Framework.Subjects;
 using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Menus;
+using Microsoft.Xna.Framework.Input;
 
 namespace Pathoschild.Stardew.LookupAnything.Components
 {
@@ -35,6 +36,13 @@ namespace Pathoschild.Stardew.LookupAnything.Components
         /// <summary>The number of pixels to scroll.</summary>
         private int CurrentScroll;
 
+        /// <summary>Scroll amount configured by the user.</summary>
+        private int ScrollAmount;
+
+        /// <summary>Arrow icon locations for click functionality.</summary>
+        private Rectangle UpIcon;
+        private Rectangle DownIcon;
+
 
         /*********
         ** Public methods
@@ -46,12 +54,14 @@ namespace Pathoschild.Stardew.LookupAnything.Components
         /// <param name="subject">The metadata to display.</param>
         /// <param name="metadata">Provides metadata that's not available from the game data directly.</param>
         /// <param name="monitor">Encapsulates logging and monitoring.</param>
-        public LookupMenu(ISubject subject, Metadata metadata, IMonitor monitor)
+        /// <param name="scroll">Scroll amount configured by the user.</param>
+        public LookupMenu(ISubject subject, Metadata metadata, IMonitor monitor, int scroll)
         {
             this.Subject = subject;
             this.Fields = subject.GetData(metadata).Where(p => p.HasValue).ToArray();
             this.Monitor = monitor;
             this.CalculateDimensions();
+            this.ScrollAmount = scroll;
         }
 
         /****
@@ -63,8 +73,7 @@ namespace Pathoschild.Stardew.LookupAnything.Components
         /// <param name="playSound">Whether to enable sound.</param>
         public override void receiveLeftClick(int x, int y, bool playSound = true)
         {
-            if (!this.isWithinBounds(x, y))
-                this.exitThisMenu();
+            this.HandleCursorLeftClick(x, y);
         }
 
         /// <summary>The method invoked when the player right-clicks on the lookup UI.</summary>
@@ -77,7 +86,10 @@ namespace Pathoschild.Stardew.LookupAnything.Components
         /// <param name="direction">The scroll direction.</param>
         public override void receiveScrollWheelAction(int direction)
         {
-            this.CurrentScroll -= direction; // down direction == increased scroll
+            if (direction > 0)          // Positive number scrolls window
+                this.ScrollUp();
+            else
+                this.ScrollDown();
         }
 
         /// <summary>The method called when the game window changes size.</summary>
@@ -88,21 +100,59 @@ namespace Pathoschild.Stardew.LookupAnything.Components
             this.CalculateDimensions();
         }
 
+        /// <summary>The method called when the game window changes size.</summary>
+        /// <param name="button">The controller button pressed.</param>
+        public override void receiveGamePadButton(Buttons button)
+        {
+            switch (button)
+            {
+                case Buttons.A:
+                    Point p = Game1.getMousePosition();
+                    this.HandleCursorLeftClick(p.X, p.Y);
+                    break;
+                case Buttons.B:
+                    this.exitThisMenu();
+                    break;
+                case Buttons.RightThumbstickUp:
+                    this.ScrollUp();
+                    break;
+                case Buttons.RightThumbstickDown:
+                    this.ScrollDown();
+                    break;
+                default:
+                    break;
+            }
+        }
+
         /****
         ** Methods
         ****/
         /// <summary>Scroll up the menu content by the specified amount (if possible).</summary>
-        /// <param name="amount">The number of pixels to scroll.</param>
-        public void ScrollUp(int amount)
+        public void ScrollUp()
         {
-            this.CurrentScroll -= amount;
+            this.CurrentScroll -= this.ScrollAmount;
         }
 
         /// <summary>Scroll down the menu content by the specified amount (if possible).</summary>
-        /// <param name="amount">The number of pixels to scroll.</param>
-        public void ScrollDown(int amount)
+        public void ScrollDown()
         {
-            this.CurrentScroll += amount;
+            this.CurrentScroll += this.ScrollAmount;
+        }
+
+        /// <summary>Combines the Left Click action with the equivalent controller button. All left click actions should be handled here only.</summary>
+        /// <param name="x">The X-position of the cursor.</param>
+        /// <param name="y">The Y-position of the cursor.</param>
+        public void HandleCursorLeftClick(int x, int y)
+        {
+            // Close menu when clicking outside of it
+            if (!this.isWithinBounds(x, y))
+                this.exitThisMenu();
+
+            // Add click action to scroll icons
+            if (UpIcon.Contains(x, y))
+                this.ScrollUp();
+            if (DownIcon.Contains(x, y))
+                this.ScrollDown();
         }
 
         /// <summary>Render the UI.</summary>
@@ -231,10 +281,14 @@ namespace Pathoschild.Stardew.LookupAnything.Components
                     this.MaxScroll = Math.Max(0, (int)(topOffset - contentHeight + this.CurrentScroll));
 
                     // draw scroll icons
+                    Rectangle Up = Sprites.Icons.UpArrow;       // Shorter name to make code cleaner
+                    Rectangle Down = Sprites.Icons.DownArrow;   // Shorter name to make code cleaner
+                    this.UpIcon = new Rectangle(x + gutter, (int)(y + contentHeight - Up.Height - gutter - Down.Height), Up.Height, Up.Width);
+                    this.DownIcon = new Rectangle(x + gutter, (int)(y + contentHeight - Down.Height), Down.Height, Down.Width);
                     if (this.MaxScroll > 0 && this.CurrentScroll > 0)
-                        contentBatch.DrawSprite(Sprites.Icons.Sheet, Sprites.Icons.UpArrow, x + gutter, y + contentHeight - Sprites.Icons.DownArrow.Height - gutter - Sprites.Icons.UpArrow.Height);
+                        contentBatch.DrawSprite(Sprites.Icons.Sheet, Sprites.Icons.UpArrow, this.UpIcon.X, this.UpIcon.Y);
                     if (this.MaxScroll > 0 && this.CurrentScroll < this.MaxScroll)
-                        contentBatch.DrawSprite(Sprites.Icons.Sheet, Sprites.Icons.DownArrow, x + gutter, y + contentHeight - Sprites.Icons.DownArrow.Height);
+                        contentBatch.DrawSprite(Sprites.Icons.Sheet, Sprites.Icons.DownArrow, this.DownIcon.X, this.DownIcon.Y);
 
                     // end draw
                     contentBatch.End();

--- a/LookupAnything/Components/LookupMenu.cs
+++ b/LookupAnything/Components/LookupMenu.cs
@@ -100,7 +100,7 @@ namespace Pathoschild.Stardew.LookupAnything.Components
             this.CalculateDimensions();
         }
 
-        /// <summary>The method called when the game window changes size.</summary>
+        /// <summary>The method called when the User presses a controller button.</summary>
         /// <param name="button">The controller button pressed.</param>
         public override void receiveGamePadButton(Buttons button)
         {

--- a/LookupAnything/Components/LookupMenu.cs
+++ b/LookupAnything/Components/LookupMenu.cs
@@ -100,7 +100,7 @@ namespace Pathoschild.Stardew.LookupAnything.Components
             this.CalculateDimensions();
         }
 
-        /// <summary>The method called when the User presses a controller button.</summary>
+        /// <summary>The method called when the player presses a controller button.</summary>
         /// <param name="button">The controller button pressed.</param>
         public override void receiveGamePadButton(Buttons button)
         {

--- a/LookupAnything/Components/LookupMenu.cs
+++ b/LookupAnything/Components/LookupMenu.cs
@@ -9,6 +9,7 @@ using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Menus;
 using Microsoft.Xna.Framework.Input;
+using System.Collections.Generic;
 
 namespace Pathoschild.Stardew.LookupAnything.Components
 {
@@ -259,10 +260,48 @@ namespace Pathoschild.Stardew.LookupAnything.Components
                                 // draw label & value
                                 Vector2 labelSize = contentBatch.DrawTextBlock(font, field.Label, new Vector2(x + leftOffset + cellPadding, y + topOffset + cellPadding), wrapWidth);
                                 Vector2 valuePosition = new Vector2(x + leftOffset + labelWidth + cellPadding * 3, y + topOffset + cellPadding);
-                                Vector2 valueSize =
-                                    field.DrawValue(contentBatch, font, valuePosition, valueWidth)
-                                    ?? contentBatch.DrawTextBlock(font, field.Value, valuePosition, valueWidth);
-                                Vector2 rowSize = new Vector2(labelWidth + valueWidth + cellPadding * 4, Math.Max(labelSize.Y, valueSize.Y));
+                                float valueSize = 0f;
+                                if (field.Label.Contains("gifts"))
+                                {
+                                    string[] items = field.Value.Split(new[] { ", " }, StringSplitOptions.RemoveEmptyEntries);
+                                    IEnumerable<Item> OwnedItems = GameHelper.GetAllOwnedItems();
+                                    string last = items.Last();
+                                    Vector2 nextPosition = valuePosition;
+                                    float AvailableWidth = valuePosition.X + valueWidth;
+                                    foreach (string item in items)
+                                    {
+                                        float strWidth = font.MeasureString(item + ",").X;
+                                        if (nextPosition.X + strWidth > AvailableWidth)
+                                        {
+                                            nextPosition.X = valuePosition.X;
+                                            nextPosition.Y += labelSize.Y;
+                                            valueSize += labelSize.Y;
+                                        }
+
+                                        Vector2 usedSpace;
+                                        if (OwnedItems.FirstOrDefault(i => i.Name.Equals(item)) != null)
+                                            usedSpace = contentBatch.DrawTextBlock(font, item, nextPosition, valueWidth, color: Color.Green);
+                                        else
+                                            usedSpace = contentBatch.DrawTextBlock(font, item, nextPosition, valueWidth);
+
+                                        nextPosition.X += usedSpace.X;
+
+                                        if (!item.Equals(last))
+                                        {
+                                            usedSpace = contentBatch.DrawTextBlock(font, ", ", nextPosition, valueWidth);
+                                            nextPosition.X += font.MeasureString(", ").X;
+                                        }
+                                    }
+                                    valueSize += labelSize.Y;
+                                }
+                                else
+                                {
+                                    Vector2 vector =
+                                        field.DrawValue(contentBatch, font, valuePosition, valueWidth)
+                                        ?? contentBatch.DrawTextBlock(font, field.Value, valuePosition, valueWidth);
+                                    valueSize = vector.Y;
+                                }
+                                Vector2 rowSize = new Vector2(labelWidth + valueWidth + cellPadding * 4, Math.Max(labelSize.Y, valueSize));
 
                                 // draw table row
                                 Color lineColor = Color.Gray;
@@ -273,7 +312,7 @@ namespace Pathoschild.Stardew.LookupAnything.Components
                                 contentBatch.DrawLine(x + leftOffset + rowSize.X, y + topOffset, new Vector2(tableBorderWidth, rowSize.Y), lineColor); // right
 
                                 // update offset
-                                topOffset += Math.Max(labelSize.Y, valueSize.Y);
+                                topOffset += Math.Max(labelSize.Y, valueSize);
                             }
                         }
                     }

--- a/LookupAnything/Framework/InputMapConfiguration.cs
+++ b/LookupAnything/Framework/InputMapConfiguration.cs
@@ -12,6 +12,9 @@ namespace Pathoschild.Stardew.LookupAnything.Framework
         /// <summary>The control which toggles the lookup UI.</summary>
         public T ToggleLookup { get; set; }
 
+        /// <summary>The control which toggles the lookup UI for whatever the user is facing.</summary>
+        public T ToggleLookupFront { get; set; }
+
         /// <summary>The control which scrolls up long content.</summary>
         public T ScrollUp { get; set; }
 
@@ -35,7 +38,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework
         /// <summary>Get whether any keys are configured.</summary>
         public bool HasAny()
         {
-            return new[] { this.ToggleLookup, this.ScrollUp, this.ScrollDown, this.ToggleDebug }.Any(this.IsValidKey);
+            return new[] { this.ToggleLookup, this.ToggleLookupFront, this.ScrollUp, this.ScrollDown, this.ToggleDebug }.Any(this.IsValidKey);
         }
     }
 }

--- a/LookupAnything/Framework/RawModConfig.cs
+++ b/LookupAnything/Framework/RawModConfig.cs
@@ -35,6 +35,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework
             this.Keyboard = new InputMapConfiguration<string>
             {
                 ToggleLookup = Keys.F1.ToString(),
+                ToggleLookupFront = "",
                 ScrollUp = Keys.Up.ToString(),
                 ScrollDown = Keys.Down.ToString(),
                 ToggleDebug = ""
@@ -42,6 +43,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework
             this.Controller = new InputMapConfiguration<string>
             {
                 ToggleLookup = "",
+                ToggleLookupFront = "",
                 ScrollUp = "",
                 ScrollDown = "",
                 ToggleDebug = ""
@@ -59,6 +61,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework
                 Keyboard = new InputMapConfiguration<Keys>
                 {
                     ToggleLookup = this.TryParse(this.Keyboard.ToggleLookup, Keys.F1),
+                    ToggleLookupFront = this.TryParse(this.Keyboard.ToggleLookupFront, Keys.F1),
                     ScrollUp = this.TryParse(this.Keyboard.ScrollUp, Keys.Up),
                     ScrollDown = this.TryParse(this.Keyboard.ScrollDown, Keys.Down),
                     ToggleDebug = this.TryParse(this.Keyboard.ToggleDebug, Keys.None)
@@ -66,6 +69,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework
                 Controller = new InputMapConfiguration<Buttons>
                 {
                     ToggleLookup = this.TryParse<Buttons>(this.Controller.ToggleLookup),
+                    ToggleLookupFront = this.TryParse<Buttons>(this.Controller.ToggleLookupFront),
                     ScrollUp = this.TryParse<Buttons>(this.Controller.ScrollUp),
                     ScrollDown = this.TryParse<Buttons>(this.Controller.ScrollDown),
                     ToggleDebug = this.TryParse<Buttons>(this.Controller.ToggleDebug)

--- a/LookupAnything/Framework/TargetFactory.cs
+++ b/LookupAnything/Framework/TargetFactory.cs
@@ -126,27 +126,39 @@ namespace Pathoschild.Stardew.LookupAnything.Framework
         /// <param name="location">The current location.</param>
         /// <param name="tile">The tile to search.</param>
         /// <param name="position">The viewport-relative coordinates to search.</param>
-        public ITarget GetTargetFrom(GameLocation location, Vector2 tile, Vector2 position)
+        /// <param name="BehindPlayer">Whether or not you're searching behind the player sprite.</param>
+        public ITarget GetTargetFrom(GameLocation location, Vector2 tile, Vector2 position, bool BehindPlayer = false)
         {
             // get target sprites overlapping cursor position
             Rectangle tileArea = GameHelper.GetScreenCoordinatesFromTile(tile);
-            return (
-                // select targets whose sprites may overlap the cursor position
-                from target in this.GetNearbyTargets(location, tile)
-                let spriteArea = target.GetSpriteArea()
-                where target.Type != TargetType.Unknown
-                where target.IsAtTile(tile) || spriteArea.Intersects(tileArea)
+            if (!BehindPlayer)
+                return (
+                    // select targets whose sprites may overlap the cursor position
+                    from target in this.GetNearbyTargets(location, tile)
+                    let spriteArea = target.GetSpriteArea()
+                    where target.Type != TargetType.Unknown
+                    where target.IsAtTile(tile) || spriteArea.Intersects(tileArea)
 
-                // sort targets by layer
-                // (A higher Y value is closer to the foreground, and will occlude any sprites
-                // behind it. If two sprites at the same Y coordinate overlap, assume the left
-                // sprite occludes the right.)
-                orderby spriteArea.Y descending, spriteArea.X ascending
+                    // sort targets by layer
+                    // (A higher Y value is closer to the foreground, and will occlude any sprites
+                    // behind it. If two sprites at the same Y coordinate overlap, assume the left
+                    // sprite occludes the right.)
+                    orderby spriteArea.Y descending, spriteArea.X ascending
 
-                where target.SpriteIntersectsPixel(tile, position, spriteArea)
+                    where target.SpriteIntersectsPixel(tile, position, spriteArea)
 
-                select target
-            ).FirstOrDefault();
+                    select target
+                ).FirstOrDefault();
+            else
+                return (
+                    // select targets whose sprites may overlap the cursor position
+                    from target in this.GetNearbyTargets(location, tile)
+                    let spriteArea = target.GetSpriteArea()
+                    where target.Type != TargetType.Unknown
+                    where target.IsAtTile(tile)
+
+                    select target
+                ).FirstOrDefault();
         }
 
         /****
@@ -156,9 +168,10 @@ namespace Pathoschild.Stardew.LookupAnything.Framework
         /// <param name="location">The current location.</param>
         /// <param name="tile">The tile to search.</param>
         /// <param name="position">The viewport-relative coordinates to search.</param>
-        public ISubject GetSubjectFrom(GameLocation location, Vector2 tile, Vector2 position)
+        /// <param name="BehindPlayer">Whether or not you're searching behind the player sprite.</param>
+        public ISubject GetSubjectFrom(GameLocation location, Vector2 tile, Vector2 position, bool BehindPlayer = false)
         {
-            ITarget target = this.GetTargetFrom(location, tile, position);
+            ITarget target = this.GetTargetFrom(location, tile, position, BehindPlayer);
             return target != null
                 ? this.GetSubjectFrom(target)
                 : null;

--- a/LookupAnything/LookupAnything.csproj
+++ b/LookupAnything/LookupAnything.csproj
@@ -2,6 +2,9 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <GamePath>C:\Steam\steamapps\common\Stardew Valley</GamePath>
+  </PropertyGroup>
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{2A9C0811-B2D2-474A-A84C-DDEB16206A62}</ProjectGuid>
@@ -28,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/LookupAnything/LookupAnythingMod.cs
+++ b/LookupAnything/LookupAnythingMod.cs
@@ -203,9 +203,9 @@ namespace Pathoschild.Stardew.LookupAnything
                 if (key.Equals(map.ToggleLookup))
                     this.ToggleLookup();
                 if (key.Equals(map.ScrollUp))
-                    (Game1.activeClickableMenu as LookupMenu)?.ScrollUp(this.Config.ScrollAmount);
+                    (Game1.activeClickableMenu as LookupMenu)?.ScrollUp();
                 else if (key.Equals(map.ScrollDown))
-                    (Game1.activeClickableMenu as LookupMenu)?.ScrollDown(this.Config.ScrollAmount);
+                    (Game1.activeClickableMenu as LookupMenu)?.ScrollDown();
                 else if (key.Equals(map.ToggleDebug))
                     this.DebugInterface.Enabled = !this.DebugInterface.Enabled;
             });
@@ -308,7 +308,7 @@ namespace Pathoschild.Stardew.LookupAnything
                     // show lookup UI
                     this.Monitor.Log($"{logMessage} showing {subject.GetType().Name}::{subject.Type}::{subject.Name}.", LogLevel.Trace);
                     this.PreviousMenu = Game1.activeClickableMenu;
-                    Game1.activeClickableMenu = new LookupMenu(subject, this.Metadata, this.Monitor);
+                    Game1.activeClickableMenu = new LookupMenu(subject, this.Metadata, this.Monitor, this.Config.ScrollAmount);
                 }
                 catch
                 {


### PR DESCRIPTION
Ok, I know I requested it, but game frustration mixed with a little bit of impatience convinced me to do it myself lol

I will say that I'm not the best at programming, and I may have done things in the wrong way, but what I've changed does work within the game (fully tested). That being said, if you can see a way to change it to make it more proper, feel free to do so.

What these changes do, is add a new hotkey for both keyboard and controller, which will attempt a lookup on the object the player is facing (if any). It even solves the problem of looking up something which is covered by a sprite (by only checking the tile location and ignoring the sprites visually covering it).