### PR TITLE
ChestsAnywhere: add option to stack items

### DIFF
--- a/ChestsAnywhere/ChestInventoryStacker.cs
+++ b/ChestsAnywhere/ChestInventoryStacker.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Pathoschild.Stardew.ChestsAnywhere.Framework;
+using StardewValley;
+
+namespace Pathoschild.Stardew.ChestsAnywhere
+{
+    internal class ChestInventoryStacker
+    {
+        public static void StackItemsInInventory(List<ManagedChest> chests)
+        {
+            // Combine an item stack with another of the same type.
+            //
+            // Returns whether the item stack has been completely combined.
+            Func<Item, Func<Item, bool>> combineItems = item => itemInChest =>
+            {
+                int space = item.getStack();
+                int availableSpace = Math.Min(space, itemInChest.getRemainingStackSpace());
+
+                if (availableSpace > 0)
+                {
+                    itemInChest.addToStack(availableSpace);
+                    item.addToStack(-1 * availableSpace);
+                }
+
+                return Math.Max(0, space - availableSpace) == 0;
+            };
+
+            // Index all available items in all chests for O(1) access later.
+            var itemsInChests = chests
+                .Aggregate(new List<Item> { }, (list, managedChest) =>
+                {
+                    return list.Concat(managedChest.Chest.items).ToList();
+                })
+                .Aggregate(new Dictionary<string, List<Item>> { }, (map, item) =>
+                {
+                    if (!map.ContainsKey(item.Name))
+                    {
+                        map.Add(item.Name, new List<Item> { });
+                    }
+
+                    map[item.Name].Add(item);
+
+                    return map;
+                })
+            ;
+
+            // Player inventory items; the check is necessary because empty items are included
+            var items = Game1.player.items.Where(x => x != null);
+
+            // Items that have an existing stack in some of the chests
+            var eligibleItems = items.Where(item => (
+                itemsInChests.ContainsKey(item.Name) &&
+                itemsInChests[item.Name].Any(itemInChest => itemInChest.canStackWith(item))
+            ));
+
+            var moves = eligibleItems.Select(item =>
+            {
+                return new
+                {
+                    item,
+                    // keep combining the stack until it is drained, if possible:
+                    drained = (
+                        itemsInChests[item.Name]
+                            .Where(itemInChest => itemInChest.canStackWith(item))
+                            .Any(combineItems(item))
+                    )
+                };
+            });
+
+            // Remove the items that were completely stacked from the player's inventory.
+            moves
+                .Where(move => move.drained)
+                .Select(move => move.item)
+                .ToList()
+                .ForEach(item => Game1.player.removeItemFromInventory(item))
+            ;
+
+            if (eligibleItems.Count() > 0) {
+                Game1.playSound("Ship");
+            }
+        }
+    }
+}

--- a/ChestsAnywhere/ChestsAnywhere.csproj
+++ b/ChestsAnywhere/ChestsAnywhere.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Menus\Overlays\Element.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Menus\Components\Tab.cs" />
+    <Compile Include="ChestInventoryStacker.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="i18n\de.json">

--- a/ChestsAnywhere/ChestsAnywhereMod.cs
+++ b/ChestsAnywhere/ChestsAnywhereMod.cs
@@ -153,6 +153,8 @@ namespace Pathoschild.Stardew.ChestsAnywhere
                 // open menu
                 if (key.Equals(map.Toggle) && (Game1.activeClickableMenu == null || (Game1.activeClickableMenu as GameMenu)?.currentTab == 0))
                     this.OpenMenu();
+                else if (key.Equals(map.StackItems))
+                    this.StackItemsInInventory();
             }
             catch (Exception ex)
             {
@@ -172,6 +174,10 @@ namespace Pathoschild.Stardew.ChestsAnywhere
                 Game1.activeClickableMenu = selectedChest.OpenMenu();
             else
                 CommonHelper.ShowInfoMessage("You don't have any chests yet. :)", duration: 1000);
+        }
+        
+        private void StackItemsInInventory() {
+            ChestInventoryStacker.StackItemsInInventory(this.ChestFactory.GetChestsForDisplay().ToList());
         }
 
         /// <summary>Validate that the game versions match the minimum requirements, and return an appropriate error message if not.</summary>

--- a/ChestsAnywhere/Framework/InputMapConfiguration.cs
+++ b/ChestsAnywhere/Framework/InputMapConfiguration.cs
@@ -30,6 +30,9 @@ namespace Pathoschild.Stardew.ChestsAnywhere.Framework
         /// <summary>The control which sorts items in the chest.</summary>
         public T SortItems { get; set; }
 
+        /// <summary>The control which stacks items in the inventory.</summary>
+        public T StackItems { get; set; }
+
 
         /*********
         ** Public methods

--- a/ChestsAnywhere/Framework/RawModConfig.cs
+++ b/ChestsAnywhere/Framework/RawModConfig.cs
@@ -36,7 +36,8 @@ namespace Pathoschild.Stardew.ChestsAnywhere.Framework
                 PrevCategory = Keys.Up.ToString(),
                 NextCategory = Keys.Down.ToString(),
                 EditChest = "",
-                SortItems = ""
+                SortItems = "",
+                StackItems = ""
             };
             this.Controller = new InputMapConfiguration<string>
             {
@@ -46,7 +47,8 @@ namespace Pathoschild.Stardew.ChestsAnywhere.Framework
                 PrevCategory = Buttons.LeftTrigger.ToString(),
                 NextCategory = Buttons.RightTrigger.ToString(),
                 EditChest = "",
-                SortItems = ""
+                SortItems = "",
+                StackItems = ""
             };
             this.CheckForUpdates = true;
             this.ShowHoverTooltips = true;
@@ -65,7 +67,8 @@ namespace Pathoschild.Stardew.ChestsAnywhere.Framework
                     PrevCategory = this.TryParse(this.Keyboard.PrevCategory, Keys.Up),
                     NextCategory = this.TryParse(this.Keyboard.NextCategory, Keys.Down),
                     EditChest = this.TryParse<Keys>(this.Keyboard.EditChest),
-                    SortItems = this.TryParse<Keys>(this.Keyboard.SortItems)
+                    SortItems = this.TryParse<Keys>(this.Keyboard.SortItems),
+                    StackItems = this.TryParse<Keys>(this.Keyboard.StackItems)
                 },
                 Controller = new InputMapConfiguration<Buttons>
                 {
@@ -75,7 +78,8 @@ namespace Pathoschild.Stardew.ChestsAnywhere.Framework
                     PrevCategory = this.TryParse(this.Controller.PrevCategory, Buttons.LeftTrigger),
                     NextCategory = this.TryParse(this.Controller.NextCategory, Buttons.RightTrigger),
                     EditChest = this.TryParse<Buttons>(this.Controller.EditChest),
-                    SortItems = this.TryParse<Buttons>(this.Keyboard.SortItems)
+                    SortItems = this.TryParse<Buttons>(this.Keyboard.SortItems),
+                    StackItems = this.TryParse<Buttons>(this.Keyboard.StackItems)
                 },
                 CheckForUpdates = this.CheckForUpdates,
                 ShowHoverTooltips = this.ShowHoverTooltips

--- a/ChestsAnywhere/Menus/Components/Sprites.cs
+++ b/ChestsAnywhere/Menus/Components/Sprites.cs
@@ -118,6 +118,8 @@ namespace Pathoschild.Stardew.ChestsAnywhere.Menus.Components
 
             /// <summary>The inventory 'organize' button.</summary>
             public static readonly Rectangle Organize = new Rectangle(162, 440, 16, 16);
+
+            public static readonly Rectangle Stack = new Rectangle(108, 491, 16, 16);
         }
 
         /// <summary>Sprites used to draw a textbox.</summary>

--- a/ChestsAnywhere/Menus/Overlays/ManageChestOverlay.cs
+++ b/ChestsAnywhere/Menus/Overlays/ManageChestOverlay.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
@@ -10,7 +9,6 @@ using Pathoschild.Stardew.Common;
 using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Menus;
-using Chest = StardewValley.Objects.Chest;
 
 namespace Pathoschild.Stardew.ChestsAnywhere.Menus.Overlays
 {
@@ -173,62 +171,7 @@ namespace Pathoschild.Stardew.ChestsAnywhere.Menus.Overlays
         /// <summary> Stacks items in the player's inventory with others found in the chests.</summary>
         public void StackItemsInInventory()
         {
-            // Combine an item stack with another of the same type.
-            //
-            // Returns whether the item stack has been completely combined.
-            Func<Item, Func<Item, bool>> combineItems = item => itemInChest => {
-                int space = item.getStack();
-                int availableSpace = Math.Min(space, itemInChest.getRemainingStackSpace());
-
-                if (availableSpace > 0)
-                {
-                    itemInChest.addToStack(availableSpace);
-                    item.addToStack(-1 * availableSpace);
-                }
-
-                return Math.Max(0, space - availableSpace) == 0;
-            };
-
-            // Index all available items in all chests for O(1) access later.
-            var itemsInChests = this.Chests
-                .Aggregate(new List<Item>{}, (list, managedChest) => {
-                    return list.Concat(managedChest.Chest.items).ToList();
-                })
-                .Aggregate(new Dictionary<string, List<Item>>{}, (map, item) => {
-                    if (!map.ContainsKey(item.Name))
-                    {
-                        map.Add(item.Name, new List<Item>{});
-                    }
-
-                    map[item.Name].Add(item);
-
-                    return map;
-                })
-            ;
-
-            // Player inventory items; the check is necessary because empty items are included
-            var items = Game1.player.items.Where(x => x != null);
-
-            // Items that have an existing stack in some of the chests
-            var eligibleItems = items.Where(x => itemsInChests.ContainsKey(x.Name));
-
-            var moves = eligibleItems.Select(item => {
-                return new {
-                    item,
-                    // keep combining the stack until it is drained, if possible:
-                    drained = itemsInChests[item.Name].Any(combineItems(item))
-                };
-            });
-
-            // Remove the items that were completely stacked from the player's inventory.
-            moves
-                .Where(move => move.drained)
-                .Select(move => move.item)
-                .ToList()
-                .ForEach(item => Game1.player.removeItemFromInventory(item))
-            ;
-
-            Game1.playSound("Ship");
+            ChestInventoryStacker.StackItemsInInventory(this.Chests.ToList());
         }
 
         /// <summary>Switch to the specified chest.</summary>
@@ -412,8 +355,6 @@ namespace Pathoschild.Stardew.ChestsAnywhere.Menus.Overlays
                         this.OpenEdit();
                     else if (input.Equals(config.SortItems))
                         this.SortInventory();
-                    else if (input.Equals(config.StackItems))
-                        this.StackItemsInInventory();
                     else
                         return false;
                     return true;

--- a/ChestsAnywhere/i18n/default.json
+++ b/ChestsAnywhere/i18n/default.json
@@ -15,5 +15,6 @@
     // button labels
     "button.edit-chest": "edit chest",
     "button.sort-inventory": "sort inventory",
+    "button.stack-items": "stack items in inventory",
     "button.ok": "OK"
 }


### PR DESCRIPTION
This patch extends the ChestsAnywhere mod to allow the player to push a
button and have all the items in her inventory that already have stacks
in her chests be "stacked" with them.

I've noticed that quite a lot of my time playing the game is spent on
putting each item in the respective chest after looting, which is
irritating to the point that spoils the enjoyment of the game (to me, at
least.)

With this option, it only takes a single click (or keypress) to combine
items found in the inventory with existing stacks that have been placed
in the chest before-hand.

Future Improvements
-------------------

I'd like to be able to assign "specialties" to each chest, like
Vegetables or Fish, and have the stacking functionality utilize this
piece of data such that it can stack items even if they are not present
in the chest already. This would be useful for new seasons where you're
foraging and fishing new items, in which case it will reduce the manual
labor.

Problems
--------

- I couldn't find a proper place for the button so right now it's to the
  side of the existing Organize button
- For some reason, the hover text is not being honored in the chest
  menu; it would be nice to have a tooltip for the button since it may
  not be very intuitive. (Granted, this seems to be the case for the
  existing Sort/Organize button, so maybe we can fix both...)