### PR TITLE
Add Automation for Slime Incubator and Coop Incubator

### DIFF
--- a/Automate/Automate.csproj
+++ b/Automate/Automate.csproj
@@ -79,7 +79,7 @@
     <Compile Include="Machines\Objects\SodaMachine.cs" />
     <Compile Include="Machines\Objects\StatueOfEndlessFortuneMachine.cs" />
     <Compile Include="Machines\Objects\StatueOfPerfectionMachine.cs" />
-    <Compile Include="Machines\Tiles\CoopIncubatorMachine.cs" />
+    <Compile Include="Machines\Objects\CoopIncubatorMachine.cs" />
     <Compile Include="Machines\Tiles\ShippingBinMachine.cs" />
     <Compile Include="Machines\Tiles\TrashCanMachine.cs" />
     <Compile Include="Machines\Objects\TapperMachine.cs" />

--- a/Automate/Automate.csproj
+++ b/Automate/Automate.csproj
@@ -75,9 +75,11 @@
     <Compile Include="Machines\Objects\RecyclingMachine.cs" />
     <Compile Include="Machines\Objects\SeedMakerMachine.cs" />
     <Compile Include="Machines\Objects\SlimeEggPressMachine.cs" />
+    <Compile Include="Machines\Objects\SlimeIncubatorMachine.cs" />
     <Compile Include="Machines\Objects\SodaMachine.cs" />
     <Compile Include="Machines\Objects\StatueOfEndlessFortuneMachine.cs" />
     <Compile Include="Machines\Objects\StatueOfPerfectionMachine.cs" />
+    <Compile Include="Machines\Tiles\CoopIncubatorMachine.cs" />
     <Compile Include="Machines\Tiles\ShippingBinMachine.cs" />
     <Compile Include="Machines\Tiles\TrashCanMachine.cs" />
     <Compile Include="Machines\Objects\TapperMachine.cs" />

--- a/Automate/Automate.csproj
+++ b/Automate/Automate.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Machines\Objects\CaskMachine.cs" />
     <Compile Include="Machines\Objects\CharcoalKilnMachine.cs" />
     <Compile Include="Machines\Objects\CheesePressMachine.cs" />
+    <Compile Include="Machines\Objects\CoopIncubatorMachine.cs" />
     <Compile Include="Machines\Objects\CrabPotMachine.cs" />
     <Compile Include="Machines\Objects\CrystalariumMachine.cs" />
     <Compile Include="Machines\Objects\FurnaceMachine.cs" />
@@ -79,7 +80,6 @@
     <Compile Include="Machines\Objects\SodaMachine.cs" />
     <Compile Include="Machines\Objects\StatueOfEndlessFortuneMachine.cs" />
     <Compile Include="Machines\Objects\StatueOfPerfectionMachine.cs" />
-    <Compile Include="Machines\Objects\CoopIncubatorMachine.cs" />
     <Compile Include="Machines\Tiles\ShippingBinMachine.cs" />
     <Compile Include="Machines\Tiles\TrashCanMachine.cs" />
     <Compile Include="Machines\Objects\TapperMachine.cs" />

--- a/Automate/MachineFactory.cs
+++ b/Automate/MachineFactory.cs
@@ -172,6 +172,10 @@ namespace Pathoschild.Stardew.Automate
                 return new TapperMachine(obj, location, tile);
             if (obj.name == "Worm Bin")
                 return new WormBinMachine(obj);
+            if (obj.name == "Slime Incubator")
+                return new SlimeIncubatorMachine(obj);
+            if (obj.name == "Incubator")
+                return new CoopIncubatorMachine(obj);
 
             return null;
         }

--- a/Automate/Machines/Objects/CoopIncubatorMachine.cs
+++ b/Automate/Machines/Objects/CoopIncubatorMachine.cs
@@ -3,7 +3,7 @@ using Pathoschild.Stardew.Automate.Framework;
 using StardewValley;
 using SObject = StardewValley.Object;
 
-namespace Pathoschild.Stardew.Automate.Machines.Tiles
+namespace Pathoschild.Stardew.Automate.Machines.Objects
 {
     /// <summary>A coop incubator that accepts eggs and spawns chickens.</summary>
     internal class CoopIncubatorMachine : GenericMachine
@@ -37,7 +37,7 @@ namespace Pathoschild.Stardew.Automate.Machines.Tiles
                 new Recipe(
                     input: 107,
                     inputCount: 1,
-                    output: item => new SObject(item.parentSheetIndex, 1),
+                    output: item => new SObject(107, 1),
                     minutes: minutesUntilReady
                 )
             };

--- a/Automate/Machines/Objects/CoopIncubatorMachine.cs
+++ b/Automate/Machines/Objects/CoopIncubatorMachine.cs
@@ -21,7 +21,7 @@ namespace Pathoschild.Stardew.Automate.Machines.Objects
         /// <param name="machine">The underlying machine.</param>
         public CoopIncubatorMachine(SObject machine) : base(machine)
         {
-            int minutesUntilReady = Game1.player.professions.Contains(2) ? 18000 : 9000;
+            int minutesUntilReady = Game1.player.professions.Contains(2) ? 9000 : 18000;
 
             this.Recipes = new Recipe[]
             {

--- a/Automate/Machines/Objects/SlimeIncubatorMachine.cs
+++ b/Automate/Machines/Objects/SlimeIncubatorMachine.cs
@@ -28,7 +28,7 @@ namespace Pathoschild.Stardew.Automate.Machines.Objects
                 new Recipe(
                     input: 413,
                     inputCount: 1,
-                    output: input => new SObject(413,1,false,-1,0),
+                    output: input => new SObject(413,1),
                     minutes: minutesUntilReady
                 ),
 
@@ -36,7 +36,7 @@ namespace Pathoschild.Stardew.Automate.Machines.Objects
                 new Recipe(
                     input: 437,
                     inputCount: 1,
-                    output: input => new SObject(437,1,false,-1,0),
+                    output: input => new SObject(437,1),
                     minutes: minutesUntilReady
                 ),
 

--- a/Automate/Machines/Objects/SlimeIncubatorMachine.cs
+++ b/Automate/Machines/Objects/SlimeIncubatorMachine.cs
@@ -1,0 +1,89 @@
+﻿using Pathoschild.Stardew.Automate.Framework;
+using StardewValley;
+using SObject = StardewValley.Object;
+
+namespace Pathoschild.Stardew.Automate.Machines.Objects
+{
+    /// <summary>A slime incubator that accepts slime eggs and spawns slime monsters.</summary>
+    internal class SlimeIncubatorMachine : GenericMachine
+    {
+        /*********
+       ** Properties
+       *********/
+        /// <summary>The recipes to process.</summary>
+        private Recipe[] Recipes;
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="machine">The underlying machine.</param>
+        public SlimeIncubatorMachine(SObject machine) : base(machine)
+        {
+            int minutesUntilReady = Game1.player.professions.Contains(2) ? 2000 : 4000;
+            
+
+            this.Recipes = new Recipe[]{
+                // blue slime egg => object with parentSheetIndex of blue slime egg
+                new Recipe(
+                    input: 413,
+                    inputCount: 1,
+                    output: input => new SObject(413,1,false,-1,0),
+                    minutes: minutesUntilReady
+                ),
+
+                // red slime egg => object with parentSheetIndex of red slime egg
+                new Recipe(
+                    input: 437,
+                    inputCount: 1,
+                    output: input => new SObject(437,1,false,-1,0),
+                    minutes: minutesUntilReady
+                ),
+
+                // purple slime egg => object with parentSheetIndex of purple slime egg
+                new Recipe(
+                    input: 439,
+                    inputCount: 1,
+                    output: input => new SObject(439,1,false,-1,0),
+                    minutes: minutesUntilReady
+                ),
+
+                // green slime egg => object with parentSheetIndex of green slime egg
+                new Recipe(
+                    input: 680,
+                    inputCount: 1,
+                    output: input => new SObject(680,1,false,-1,0),
+                    minutes: minutesUntilReady
+                )
+            };
+        }
+
+        /// <summary>Get the machine's processing state.</summary>
+        /// <remarks>The slime incubator does not produce an output object, so its never considered done.</remarks>
+        public override MachineState GetState()
+        {
+            if (this.Machine.heldObject == null)
+                return MachineState.Empty;
+
+            return MachineState.Processing;
+        }
+
+        /// <summary>Get the output item.</summary>
+        /// <remarks>The slime incubator does not produce an output object.</remarks>
+        public override ITrackedStack GetOutput()
+        {
+            return null;
+        }
+
+        /// <summary>Pull items from the connected pipes.</summary>
+        /// <param name="pipes">The connected IO pipes.</param>
+        /// <returns>Returns whether the machine started processing an item.</returns>
+        public override bool Pull(IPipe[] pipes)
+        {
+            bool result = this.GenericPullRecipe(pipes, this.Recipes);
+            if (result)
+                this.Machine.parentSheetIndex = 157;
+            return result;
+        }       
+    }
+}

--- a/Automate/Machines/Objects/SlimeIncubatorMachine.cs
+++ b/Automate/Machines/Objects/SlimeIncubatorMachine.cs
@@ -8,8 +8,8 @@ namespace Pathoschild.Stardew.Automate.Machines.Objects
     internal class SlimeIncubatorMachine : GenericMachine
     {
         /*********
-       ** Properties
-       *********/
+        ** Properties
+        *********/
         /// <summary>The recipes to process.</summary>
         private readonly Recipe[] Recipes;
 

--- a/Automate/Machines/Objects/SlimeIncubatorMachine.cs
+++ b/Automate/Machines/Objects/SlimeIncubatorMachine.cs
@@ -11,7 +11,7 @@ namespace Pathoschild.Stardew.Automate.Machines.Objects
        ** Properties
        *********/
         /// <summary>The recipes to process.</summary>
-        private Recipe[] Recipes;
+        private readonly Recipe[] Recipes;
 
         /*********
         ** Public methods
@@ -21,7 +21,7 @@ namespace Pathoschild.Stardew.Automate.Machines.Objects
         public SlimeIncubatorMachine(SObject machine) : base(machine)
         {
             int minutesUntilReady = Game1.player.professions.Contains(2) ? 2000 : 4000;
-            
+
 
             this.Recipes = new Recipe[]{
                 // blue slime egg => object with parentSheetIndex of blue slime egg
@@ -44,7 +44,7 @@ namespace Pathoschild.Stardew.Automate.Machines.Objects
                 new Recipe(
                     input: 439,
                     inputCount: 1,
-                    output: input => new SObject(439,1,false,-1,0),
+                    output: input => new SObject(439,1),
                     minutes: minutesUntilReady
                 ),
 
@@ -52,14 +52,14 @@ namespace Pathoschild.Stardew.Automate.Machines.Objects
                 new Recipe(
                     input: 680,
                     inputCount: 1,
-                    output: input => new SObject(680,1,false,-1,0),
+                    output: input => new SObject(680,1),
                     minutes: minutesUntilReady
                 )
             };
         }
 
         /// <summary>Get the machine's processing state.</summary>
-        /// <remarks>The slime incubator does not produce an output object, so its never considered done.</remarks>
+        /// <remarks>The slime incubator does not produce an output object, so it is never done.</remarks>
         public override MachineState GetState()
         {
             if (this.Machine.heldObject == null)
@@ -84,6 +84,6 @@ namespace Pathoschild.Stardew.Automate.Machines.Objects
             if (result)
                 this.Machine.parentSheetIndex = 157;
             return result;
-        }       
+        }
     }
 }

--- a/Automate/Machines/Tiles/CoopIncubatorMachine.cs
+++ b/Automate/Machines/Tiles/CoopIncubatorMachine.cs
@@ -12,7 +12,7 @@ namespace Pathoschild.Stardew.Automate.Machines.Tiles
         ** Properties
         *********/
         /// <summary>The recipes to process.</summary>
-        private Recipe[] Recipes;
+        private readonly Recipe[] Recipes;
 
         /*********
         ** Public methods
@@ -29,7 +29,7 @@ namespace Pathoschild.Stardew.Automate.Machines.Tiles
                 new Recipe(
                     input: -5,
                     inputCount: 1,
-                    output: item => new SObject(item.parentSheetIndex, 1, false, -1, 0),
+                    output: item => new SObject(item.parentSheetIndex, 1),
                     minutes: minutesUntilReady/2
                 ),
 
@@ -37,7 +37,7 @@ namespace Pathoschild.Stardew.Automate.Machines.Tiles
                 new Recipe(
                     input: 107,
                     inputCount: 1,
-                    output: item => new SObject(item.parentSheetIndex, 1, false, -1, 0),
+                    output: item => new SObject(item.parentSheetIndex, 1),
                     minutes: minutesUntilReady
                 )
             };

--- a/Automate/Machines/Tiles/CoopIncubatorMachine.cs
+++ b/Automate/Machines/Tiles/CoopIncubatorMachine.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using Pathoschild.Stardew.Automate.Framework;
+using StardewValley;
+using SObject = StardewValley.Object;
+
+namespace Pathoschild.Stardew.Automate.Machines.Tiles
+{
+    /// <summary>A coop incubator that accepts eggs and spawns chickens.</summary>
+    internal class CoopIncubatorMachine : GenericMachine
+    {
+        /*********
+        ** Properties
+        *********/
+        /// <summary>The recipes to process.</summary>
+        private Recipe[] Recipes;
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="machine">The underlying machine.</param>
+        public CoopIncubatorMachine(SObject machine) : base(machine)
+        {
+            int minutesUntilReady = Game1.player.professions.Contains(2) ? 18000 : 9000;
+
+            this.Recipes = new Recipe[]
+            {
+                // egg => chicken
+                new Recipe(
+                    input: -5,
+                    inputCount: 1,
+                    output: item => new SObject(item.parentSheetIndex, 1, false, -1, 0),
+                    minutes: minutesUntilReady/2
+                ),
+
+                // dinosaur egg => dinosaur
+                new Recipe(
+                    input: 107,
+                    inputCount: 1,
+                    output: item => new SObject(item.parentSheetIndex, 1, false, -1, 0),
+                    minutes: minutesUntilReady
+                )
+            };
+
+        }
+
+        /// <summary>Get the machine's processing state.</summary>
+        /// <remarks>The coop incubator never produces an object output so it is never done.</remarks>
+        public override MachineState GetState()
+        {
+            if (this.Machine.heldObject == null)
+                return MachineState.Empty;
+
+            return MachineState.Processing;
+        }
+
+        /// <summary>Get the output item.</summary>
+        /// <remarks>The coop incubator never produces an object output.</remarks>
+        public override ITrackedStack GetOutput()
+        {
+            return null;
+        }
+
+        /// <summary>Pull items from the connected pipes.</summary>
+        /// <param name="pipes">The connected IO pipes.</param>
+        /// <returns>Returns whether the machine started processing an item.</returns>
+        public override bool Pull(IPipe[] pipes)
+        {
+            bool processing = this.GenericPullRecipe(pipes, this.Recipes);
+
+            if (processing)
+            {
+                int eggIndex = this.Machine.heldObject.parentSheetIndex;
+                this.Machine.parentSheetIndex = eggIndex == 180 || eggIndex == 182 || eggIndex == 305 ? this.Machine.parentSheetIndex + 2 : this.Machine.parentSheetIndex + 1;
+            }
+
+            return processing;
+        }
+    }
+}


### PR DESCRIPTION
Adds a slime incubator machine and coop incubator machine. Sets the state of the new machines to never be done and GetOutput to always return null because when the machines are finished, they spawn a slime/chicken and then go back to being empty - they don't produce an output object.

AnimalHouse contains an incubator method, which seems to also incubate coop eggs. I tried making a coop incubator machine using that, but it was not functional - it looks unused and old.