### PR TITLE
Fixed German Translation Typo

### DIFF
--- a/LookupAnything/i18n/de.json
+++ b/LookupAnything/i18n/de.json
@@ -207,7 +207,7 @@
   "item.likes-this": "Mag das",
   "item.loves-this": "Liebt das",
   "item.fence-health": "Leben",
-  "item.recipes": "Recepte",
+  "item.recipes": "Rezepte",
   "item.number-owned": "Besitzt",
   "item.see-also": "sieh auch",
 


### PR DESCRIPTION
In german it's called "Rezepte", not "Recepte"