### PR TITLE
Added new DataMap: NeedsWatering

### DIFF
--- a/DataMaps/DataMaps.csproj
+++ b/DataMaps/DataMaps.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>DataMaps</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,6 +41,7 @@
     <Compile Include="DataMaps\JunimoHutMap.cs" />
     <Compile Include="DataMaps\BeeHouseMap.cs" />
     <Compile Include="DataMaps\ScarecrowMap.cs" />
+    <Compile Include="DataMaps\NeedsWateringMap.cs" />
     <Compile Include="DataMaps\SprinklerMap.cs" />
     <Compile Include="DataMaps\AccessibilityMap.cs" />
     <Compile Include="Framework\DataMapOverlay.cs" />
@@ -78,11 +81,11 @@
   <Import Project="..\Common\Common.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\deploy-mod.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/DataMaps/DataMaps/NeedsWateringMap.cs
+++ b/DataMaps/DataMaps/NeedsWateringMap.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Pathoschild.Stardew.Common;
+using Pathoschild.Stardew.DataMaps.Framework;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.TerrainFeatures;
+using Rectangle = Microsoft.Xna.Framework.Rectangle;
+
+namespace Pathoschild.Stardew.DataMaps.DataMaps
+{
+    /// <summary>A data map which shows whether tiles are traversable by the player.</summary>
+    internal class NeedsWateringMap : IDataMap
+    {
+        /*********
+        ** Properties
+        *********/
+        /// <summary>The color for a dry crop.</summary>
+        private readonly Color DryColor = Color.Red;
+
+        /// <summary>The legend entries to display.</summary>
+        public LegendEntry[] Legend { get; }
+
+
+        /*********
+        ** Accessors
+        *********/
+        /// <summary>The map's display name.</summary>
+        public string Name { get; }
+
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="translations">Provides translations in stored in the mod folder's i18n folder.</param>
+        public NeedsWateringMap(ITranslationHelper translations)
+        {
+            this.Name = translations.Get("maps.needswatering.name");
+            this.Legend = new[]
+            {
+                new LegendEntry(translations.Get("maps.needswatering.dry-crops"), this.DryColor),
+            };
+        }
+
+        /// <summary>Get the updated data map tiles.</summary>
+        /// <param name="location">The current location.</param>
+        /// <param name="visibleArea">The tiles currently visible on the screen.</param>
+        /// <param name="cursorTile">The tile position under the cursor.</param>
+        public IEnumerable<TileGroup> Update(GameLocation location, Rectangle visibleArea, Vector2 cursorTile)
+        {
+            Vector2[] visibleTiles = visibleArea.GetTiles().ToArray();
+
+            // yield dry crops
+            TileData[] dryCrops = this.GetDryCrops(location, visibleTiles).Select(pos => new TileData(pos, this.DryColor)).ToArray();
+            yield return new TileGroup(dryCrops, outerBorderColor: this.DryColor);
+        }
+
+
+        /*********
+        ** Private methods
+        *********/
+
+        /// <summary>Get whether a map terrain feature is a dry-crop.</summary>
+        /// <param name="terrain">The map terrain feature.</param>
+        private bool IsDryCrop(TerrainFeature terrain)
+        {
+            return terrain is HoeDirt dirt && dirt.crop != null && dirt.state == 0;
+        }
+
+        /// <summary>Get tiles containing crops not covered by a sprinkler.</summary>
+        /// <param name="location">The current location.</param>
+        /// <param name="visibleTiles">The tiles currently visible on the screen.</param>
+        private IEnumerable<Vector2> GetDryCrops(GameLocation location, Vector2[] visibleTiles)
+        {
+            foreach (Vector2 tile in visibleTiles)
+            {
+                if (location.terrainFeatures.TryGetValue(tile, out TerrainFeature terrain) && this.IsDryCrop(terrain))
+                    yield return tile;
+            }
+        }
+    }
+}

--- a/DataMaps/DataMaps/NeedsWateringMap.cs
+++ b/DataMaps/DataMaps/NeedsWateringMap.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Pathoschild.Stardew.Common;
+using Pathoschild.Stardew.DataMaps.Framework;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.TerrainFeatures;
+using Rectangle = Microsoft.Xna.Framework.Rectangle;
+
+namespace Pathoschild.Stardew.DataMaps.DataMaps
+{
+    /// <summary>A data map which shows whether crops needs to be watered.</summary>
+    internal class NeedsWateringMap : IDataMap
+    {
+        /*********
+        ** Properties
+        *********/
+        /// <summary>The color for a dry crop.</summary>
+        private readonly Color DryColor = Color.Red;
+
+        /// <summary>The legend entries to display.</summary>
+        public LegendEntry[] Legend { get; }
+
+
+        /*********
+        ** Accessors
+        *********/
+        /// <summary>The map's display name.</summary>
+        public string Name { get; }
+
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="translations">Provides translations in stored in the mod folder's i18n folder.</param>
+        public NeedsWateringMap(ITranslationHelper translations)
+        {
+            this.Name = translations.Get("maps.needswatering.name");
+            this.Legend = new[]
+            {
+                new LegendEntry(translations.Get("maps.needswatering.dry-crops"), this.DryColor),
+            };
+        }
+
+        /// <summary>Get the updated data map tiles.</summary>
+        /// <param name="location">The current location.</param>
+        /// <param name="visibleArea">The tiles currently visible on the screen.</param>
+        /// <param name="cursorTile">The tile position under the cursor.</param>
+        public IEnumerable<TileGroup> Update(GameLocation location, Rectangle visibleArea, Vector2 cursorTile)
+        {
+            Vector2[] visibleTiles = visibleArea.GetTiles().ToArray();
+
+            // yield dry crops
+            TileData[] dryCrops = this.GetDryCrops(location, visibleTiles).Select(pos => new TileData(pos, this.DryColor)).ToArray();
+            yield return new TileGroup(dryCrops, outerBorderColor: this.DryColor);
+        }
+
+
+        /*********
+        ** Private methods
+        *********/
+
+        /// <summary>Get whether a map terrain feature is a dry-crop.</summary>
+        /// <param name="terrain">The map terrain feature.</param>
+        private bool IsDryCrop(TerrainFeature terrain)
+        {
+            return terrain is HoeDirt dirt && dirt.crop != null && dirt.state == 0;
+        }
+
+        /// <summary>Get tiles containing crops not covered by a sprinkler.</summary>
+        /// <param name="location">The current location.</param>
+        /// <param name="visibleTiles">The tiles currently visible on the screen.</param>
+        private IEnumerable<Vector2> GetDryCrops(GameLocation location, Vector2[] visibleTiles)
+        {
+            foreach (Vector2 tile in visibleTiles)
+            {
+                if (location.terrainFeatures.TryGetValue(tile, out TerrainFeature terrain) && this.IsDryCrop(terrain))
+                    yield return tile;
+            }
+        }
+    }
+}

--- a/DataMaps/Framework/DataMapOverlay.cs
+++ b/DataMaps/Framework/DataMapOverlay.cs
@@ -40,7 +40,7 @@ namespace Pathoschild.Stardew.DataMaps.Framework
         private readonly bool CombineOverlappingBorders;
 
         /// <summary>The current data map to render.</summary>
-        private IDataMap CurrentMap;
+        public IDataMap CurrentMap;
 
         /// <summary>The legend entries to show.</summary>
         private LegendEntry[] Legend;

--- a/DataMaps/Framework/ModConfig.cs
+++ b/DataMaps/Framework/ModConfig.cs
@@ -16,6 +16,8 @@ namespace Pathoschild.Stardew.DataMaps.Framework
         /// <summary>When two groups of the same color overlap, draw one border around their edges instead of their individual borders.</summary>
         public bool CombineOverlappingBorders { get; set; } = true;
 
+        /// <summary>Disabe certain DataMaps</summary>
+        public string[] DisabledMaps { get; set; } = new string[0];
 
         /*********
         ** Nested models
@@ -26,6 +28,10 @@ namespace Pathoschild.Stardew.DataMaps.Framework
             /// <summary>The control which toggles the data map overlay.</summary>
             [JsonConverter(typeof(StringEnumArrayConverter))]
             public SButton[] ToggleMap { get; set; } = { SButton.F2 };
+
+            /// <summary>The control which toggles disable of current data map overlay.</summary>
+            [JsonConverter(typeof(StringEnumArrayConverter))]
+            public SButton[] ToggleDisableOverlay { get; set; } = { SButton.F3 };
 
             /// <summary>The control which cycles foreward through data maps.</summary>
             [JsonConverter(typeof(StringEnumArrayConverter))]

--- a/DataMaps/ModEntry.cs
+++ b/DataMaps/ModEntry.cs
@@ -72,6 +72,7 @@ namespace Pathoschild.Stardew.DataMaps
                 new BeeHouseMap(helper.Translation),
                 new ScarecrowMap(helper.Translation),
                 new SprinklerMap(helper.Translation, betterSprinklers, cobalt, simpleSprinklers),
+                new NeedsWateringMap(helper.Translation),
                 new JunimoHutMap(helper.Translation, this.PelicanFiber)
             };
         }
@@ -83,6 +84,8 @@ namespace Pathoschild.Stardew.DataMaps
         {
             this.CurrentOverlay?.Dispose();
             this.CurrentOverlay = null;
+
+            this.GameEvents_FirstUpdateTick(sender, e);
         }
 
         /// <summary>The method invoked when the player presses an input button.</summary>
@@ -108,7 +111,27 @@ namespace Pathoschild.Stardew.DataMaps
                         this.CurrentOverlay = null;
                     }
                     else
-                        this.CurrentOverlay = new DataMapOverlay(this.Maps, this.CanOverlayNow, this.Config.CombineOverlappingBorders);
+                        if (this.Maps.Count() > 0)
+                            this.CurrentOverlay = new DataMapOverlay(this.Maps, this.CanOverlayNow, this.Config.CombineOverlappingBorders);
+                    e.SuppressButton();
+                }
+
+                // toggle disable data map overlay
+                else if (controls.ToggleDisableOverlay.Contains(e.Button))
+                {
+                    if (overlayVisible)
+                    {
+                        int index = Array.IndexOf(this.Maps, this.CurrentOverlay.CurrentMap);
+                        for (int a = index; a < this.Maps.Length - 1; a++)
+                        {
+                            this.Maps[a] = this.Maps[a + 1];
+                        }
+                        Array.Resize(ref this.Maps, this.Maps.Length - 1);
+                        this.CurrentOverlay.Dispose();
+                        this.CurrentOverlay = null;
+                        if (this.Maps.Count() > 0)
+                            this.CurrentOverlay = new DataMapOverlay(this.Maps, this.CanOverlayNow, this.Config.CombineOverlappingBorders);
+                    }
                     e.SuppressButton();
                 }
 

--- a/DataMaps/i18n/default.json
+++ b/DataMaps/i18n/default.json
@@ -18,5 +18,9 @@
 
   "maps.sprinklers.name": "Sprinklers",
   "maps.sprinklers.covered": "Covered",
-  "maps.sprinklers.dry-crops": "Dry Crops"
+  "maps.sprinklers.dry-crops": "Dry Crops",
+
+  "maps.needswatering.name": "Needs Watering",
+  "maps.needswatering.dry-crops": "Dry Crop"
+
 }

--- a/DataMaps/packages.config
+++ b/DataMaps/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.1" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
new DataMap: NeedsWatering
 - Display any crop that isn't watered.

Created new option to remove Data<ap from current playing session from the possible maps.
Restarting game or going to title screen will reset the maps.(at least should, and you cannot remove the last map, for now)

Added config option for key used to remove current DataMap: Default to F3
Added translations for NeedsWatering

Exposed CurrentMap from DataMapOverlay, so I could detect which map was loaded to remove from array.

Updated SMAPI NuGet package to 2.0.2