### PR TITLE
[Automate] add API to let mods extend Automate's logic

### DIFF
--- a/Automate/Automate.csproj
+++ b/Automate/Automate.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DebugType>pdbonly</DebugType>
@@ -40,6 +41,8 @@
     <Compile Include="..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AutomateAPI.cs" />
+    <Compile Include="IAutomateAPI.cs" />
     <Compile Include="ModEntry.cs" />
     <Compile Include="IConsumable.cs" />
     <Compile Include="IStorage.cs" />

--- a/Automate/AutomateAPI.cs
+++ b/Automate/AutomateAPI.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using Pathoschild.Stardew.Automate.Framework;
+using StardewValley;
+
+namespace Pathoschild.Stardew.Automate
+{
+    public class AutomateAPI : IAutomateAPI
+    {
+        /// <summary>A list of delegates to call to get a machine at a particular tile.</summary>
+        internal static List<GetMachineHook> GetMachineHooks = new List<GetMachineHook>();
+
+        /// <summary>A list of delegates to call to get a container at a particular tile.</summary>
+        internal static List<GetContainerHook> GetContainerHooks = new List<GetContainerHook>();
+
+        /// <summary>A lock that synchronizes access to our event handlers.</summary>
+        private static object eventLock = new object();
+
+        /// <summary>An event that is dispatched when the machines are reloaded for the given location.</summary>
+        private static event EventHandler<EventArgsLocationMachinesChanged> _LocationMachinesChanged;
+
+        /// <summary>Registers a delegate to be called to check if there is a machine at a given tile.</summary>
+        /// <param name="hook">The delegate to call.</param>
+        public void RegisterGetMachineHook(GetMachineHook hook)
+        {
+            GetMachineHooks.Add(hook);
+        }
+
+        /// <summary>Registers a delegate to be called to check if there is a container at a given tile.</summary>
+        /// <param name="hook">The delegate to call.</param>
+        public void RegisterGetContainerHook(GetContainerHook hook)
+        {
+            GetContainerHooks.Add(hook);
+        }
+
+        /// <summary>An event that is dispatched when the machines are reloaded for the given location.</summary>
+        public event EventHandler<EventArgsLocationMachinesChanged> LocationMachinesChanged
+        {
+            add
+            {
+                lock (eventLock)
+                {
+                    _LocationMachinesChanged += value;
+                }
+            }
+            remove
+            {
+                lock (eventLock)
+                {
+                    _LocationMachinesChanged -= value;
+                }
+            }
+        }
+
+        /// <summary>Called when the machines are reloaded for the given location.</summary>
+        internal static void OnLocationMachinesChanged(object sender, GameLocation location, MachineGroup[] machineGroups)
+        {
+            if (_LocationMachinesChanged != null)
+                _LocationMachinesChanged(sender, new EventArgsLocationMachinesChanged(location, machineGroups));
+        }
+    }
+}

--- a/Automate/Framework/MachineGroup.cs
+++ b/Automate/Framework/MachineGroup.cs
@@ -4,7 +4,7 @@ using StardewValley;
 namespace Pathoschild.Stardew.Automate.Framework
 {
     /// <summary>A collection of machines and storage which work as one unit.</summary>
-    internal class MachineGroup
+    public class MachineGroup
     {
         /*********
         ** Accessors

--- a/Automate/IAutomateAPI.cs
+++ b/Automate/IAutomateAPI.cs
@@ -1,0 +1,47 @@
+using System;
+using Microsoft.Xna.Framework;
+using Pathoschild.Stardew.Automate.Framework;
+using StardewValley;
+
+namespace Pathoschild.Stardew.Automate
+{
+    /// <summary>The public API provided to other mods.</summary>
+    public interface IAutomateAPI
+    {
+        /// <summary>Registers a delegate to be called to check if there is a machine at a given tile.</summary>
+        /// <param name="hook">The delegate to call.</param>
+        void RegisterGetMachineHook(GetMachineHook hook);
+
+        /// <summary>Registers a delegate to be called to check if there is a container at a given tile.</summary>
+        /// <param name="hook">The delegate to call.</param>
+        void RegisterGetContainerHook(GetContainerHook hook);
+
+        /// <summary>An event that is dispatched when the machines are reloaded for the given location.</summary>
+        event EventHandler<EventArgsLocationMachinesChanged> LocationMachinesChanged;
+    }
+
+    /// <summary>A delegate to be called to check if there is a machine at a given tile.</summary>
+    public delegate IMachine GetMachineHook(GameLocation location, Vector2 tile, out Vector2 size);
+
+    /// <summary>A delegate to be called to check if there is a container at a given tile.</summary>
+    public delegate IContainer GetContainerHook(GameLocation location, Vector2 tile, out Vector2 size);
+
+    /// <summary>The event args to LocationMachinesChanged.</summary>
+    public class EventArgsLocationMachinesChanged : EventArgs
+    {
+        /// <summary>The location where machines were changed.</summary>
+        public GameLocation Location { get; }
+
+        /// <summary>The set of machine groups at this location.</summary>
+        public MachineGroup[] MachineGroups { get; }
+
+        /// <summary>Construct an instance.</summary>
+        /// <param name="location">The location where machines were changed.</param>
+        /// <param name="machineGroups">The set of machine groups at this location.</param>
+        public EventArgsLocationMachinesChanged(GameLocation location, MachineGroup[] machineGroups)
+        {
+            this.Location = location;
+            this.MachineGroups = machineGroups;
+        }
+    }
+}

--- a/Automate/IConsumable.cs
+++ b/Automate/IConsumable.cs
@@ -3,7 +3,7 @@ using StardewValley;
 namespace Pathoschild.Stardew.Automate
 {
     /// <summary>An ingredient stack (or stacks) which can be consumed by a machine.</summary>
-    internal interface IConsumable
+    public interface IConsumable
     {
         /*********
         ** Accessors

--- a/Automate/IContainer.cs
+++ b/Automate/IContainer.cs
@@ -5,7 +5,7 @@ using StardewValley;
 namespace Pathoschild.Stardew.Automate
 {
     /// <summary>Provides and stores items for machines.</summary>
-    internal interface IContainer : IEnumerable<ITrackedStack>
+    public interface IContainer : IEnumerable<ITrackedStack>
     {
         /*********
         ** Accessors

--- a/Automate/IMachine.cs
+++ b/Automate/IMachine.cs
@@ -1,7 +1,7 @@
 namespace Pathoschild.Stardew.Automate
 {
     /// <summary>A machine that accepts input and provides output.</summary>
-    internal interface IMachine
+    public interface IMachine
     {
         /*********
         ** Public methods

--- a/Automate/IStorage.cs
+++ b/Automate/IStorage.cs
@@ -5,7 +5,7 @@ using Pathoschild.Stardew.Automate.Framework;
 namespace Pathoschild.Stardew.Automate
 {
     /// <summary>Manages access to items in the underlying containers.</summary>
-    internal interface IStorage
+    public interface IStorage
     {
         /*********
         ** Public methods

--- a/Automate/ITrackedStack.cs
+++ b/Automate/ITrackedStack.cs
@@ -3,7 +3,7 @@ using StardewValley;
 namespace Pathoschild.Stardew.Automate
 {
     /// <summary>An item stack in an input pipe which can be reduced or taken.</summary>
-    internal interface ITrackedStack
+    public interface ITrackedStack
     {
         /*********
         ** Accessors

--- a/Automate/MachineState.cs
+++ b/Automate/MachineState.cs
@@ -1,7 +1,7 @@
 namespace Pathoschild.Stardew.Automate
 {
     /// <summary>A machine processing state.</summary>
-    internal enum MachineState
+    public enum MachineState
     {
         /// <summary>The machine has no input.</summary>
         Empty,

--- a/Automate/ModEntry.cs
+++ b/Automate/ModEntry.cs
@@ -62,6 +62,10 @@ namespace Pathoschild.Stardew.Automate
             this.VerboseLog($"Initialised with automation every {this.Config.AutomationInterval} ticks.");
         }
 
+        public override object GetApi()
+        {
+            return new AutomateAPI();
+        }
 
         /*********
         ** Private methods
@@ -201,6 +205,7 @@ namespace Pathoschild.Stardew.Automate
             this.VerboseLog($"Reloading machines in {location.Name}...");
 
             this.MachineGroups[location] = this.Factory.GetActiveMachinesGroups(location, this.Helper.Reflection).ToArray();
+            AutomateAPI.OnLocationMachinesChanged(this, location, this.MachineGroups[location]);
         }
 
         /// <summary>Log an error and warn the user.</summary>

--- a/Automate/Recipe.cs
+++ b/Automate/Recipe.cs
@@ -5,7 +5,7 @@ using SObject = StardewValley.Object;
 namespace Pathoschild.Stardew.Automate
 {
     /// <summary>Describes a generic recipe based on item input and output.</summary>
-    internal class Recipe
+    public class Recipe
     {
         /*********
         ** Accessors


### PR DESCRIPTION
Hi Pathos,

I was wondering if you'd be open to this change to Automate. It exposes an API for Automate to allow other mods to add their own custom machine and container types. This is really useful for a mod that I'm writing here: https://github.com/mpcomplete/StardewMods/blob/master/Tubes/Mod.cs#L124

My mod adds 2 features to Automate:
1. Any machine group that reaches the door of a building (like a shed or barn) will connect to the machine groups inside that building, so you can automate through buildings.
2. A new terrain feature (a Pneumatic Tube) coded as a do-nothing machine, which links distant machine groups together. The player can walk over it, so it won't block paths.

If you're open to the idea, I'm happy to make changes to the code to get it into a state you'd accept.

Thanks!