### PR TITLE
[Fast Animations] speed up game load delay

### DIFF
--- a/FastAnimations/FastAnimations.csproj
+++ b/FastAnimations/FastAnimations.csproj
@@ -39,6 +39,7 @@
     <Compile Include="Handlers\CasinoSlotsHandler.cs" />
     <Compile Include="Handlers\BreakingGeodeHandler.cs" />
     <Compile Include="Handlers\FishingHandler.cs" />
+    <Compile Include="Handlers\LoadGameMenuHandler.cs" />
     <Compile Include="Handlers\TitleMenuHandler.cs" />
     <Compile Include="Handlers\TreeFallingHandler.cs" />
     <Compile Include="Handlers\ShearingHandler.cs" />

--- a/FastAnimations/Framework/ModConfig.cs
+++ b/FastAnimations/Framework/ModConfig.cs
@@ -32,5 +32,8 @@ namespace Pathoschild.Stardew.FastAnimations.Framework
 
         /// <summary>The speed multiplier for title menu transitions.</summary>
         public int TitleMenuTransitionSpeed { get; set; } = 10;
+
+        /// <summary>The speed multiplier for loading a game.</summary>
+        public int LoadGameMenuSlotBlinkSpeed { get; set; } = 2;
     }
 }

--- a/FastAnimations/Handlers/LoadGameMenuHandler.cs
+++ b/FastAnimations/Handlers/LoadGameMenuHandler.cs
@@ -1,0 +1,63 @@
+using Pathoschild.Stardew.FastAnimations.Framework;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.Menus;
+
+namespace Pathoschild.Stardew.FastAnimations.Handlers
+{
+    /// <summary>Handles loading slot delay.</summary>
+    /// <remarks>See game logic in <see cref="LoadGameMenu"/>.</remarks>
+    class LoadGameMenuHandler : BaseAnimationHandler
+    {
+        /*********
+        ** Properties
+        *********/
+        /// <summary>Simplifies access to private game code.</summary>
+        private readonly IReflectionHelper Reflection;
+
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="multiplier">The animation speed multiplier to apply.</param>
+        /// <param name="reflection">Simplifies access to private game code.</param>
+        public LoadGameMenuHandler(int multiplier, IReflectionHelper reflection)
+            : base(multiplier)
+        {
+            this.Reflection = reflection;
+        }
+
+        /// <summary>Get whether the animation is currently active.</summary>
+        /// <param name="playerAnimationID">The player's current animation ID.</param>
+        public override bool IsEnabled(int playerAnimationID)
+        {
+            return
+                Game1.activeClickableMenu is TitleMenu
+                && this.Reflection.GetField<IClickableMenu>(typeof(TitleMenu), "_subMenu").GetValue() is LoadGameMenu loadGameMenu
+                && this.GetTimerToLoad(loadGameMenu).GetValue() > 0;
+        }
+
+        /// <summary>Perform any logic needed on update while the animation is active.</summary>
+        /// <param name="playerAnimationID">The player's current animation ID.</param>
+        public override void Update(int playerAnimationID)
+        {
+            LoadGameMenu loadGameMenu =
+                (LoadGameMenu)this.Reflection.GetField<IClickableMenu>(typeof(TitleMenu), "_subMenu").GetValue();
+            var timerToLoad = this.GetTimerToLoad(loadGameMenu);
+            for (int i = 1; i < this.Multiplier && timerToLoad.GetValue() > 0; i++)
+                loadGameMenu.update(Game1.currentGameTime);
+        }
+
+
+        /*********
+        ** Private methods
+        *********/
+        /// <summary>Get the protected load game menu field which indicates whether it's currently counting down before loading a save.</summary>
+        /// <param name="menu">The load game menu.</param>
+        private IReflectedField<int> GetTimerToLoad(LoadGameMenu menu)
+        {
+            return this.Reflection.GetField<int>(menu, "timerToLoad");
+        }
+    }
+}

--- a/FastAnimations/ModEntry.cs
+++ b/FastAnimations/ModEntry.cs
@@ -107,6 +107,8 @@ namespace Pathoschild.Stardew.FastAnimations
                 yield return new TreeFallingHandler(config.TreeFallSpeed, this.Helper.Reflection);
             if (config.TitleMenuTransitionSpeed > 1)
                 yield return new TitleMenuHandler(config.TitleMenuTransitionSpeed, this.Helper.Reflection);
+            if(config.LoadGameMenuSlotBlinkSpeed > 1)
+                yield return new LoadGameMenuHandler(config.LoadGameMenuSlotBlinkSpeed, this.Helper.Reflection);
         }
     }
 }

--- a/FastAnimations/README.md
+++ b/FastAnimations/README.md
@@ -27,6 +27,7 @@ setting              | default | what it affects
 `MilkSpeed`          | 5×      | How fast you use the milk pail.
 `ShearSpeed`         | 5×      | How fast you use the shears.
 `TitleMenuTransitionSpeed` | 10× | How fast the title menu transitions between screens.
+`LoadGameMenuSlotBlinkSpeed` | 2× | How fast the game loads when you click a save slot.
 `FishingSpeed`       | 1×      | How fast you cast and reel when fishing (doesn't affect the minigame).<br /><small>(Suggested value: 2×.)</small>
 `TreeFallingSpeed`   | 1×      | How fast trees fall after you chop them down.<br /><small>(Suggested value: 3×.)</small>
 

--- a/FastAnimations/release-notes.md
+++ b/FastAnimations/release-notes.md
@@ -1,6 +1,9 @@
 [← back to readme](README.md)
 
 # Release notes
+## 1.7
+* Added support for the load game menu delay.
+
 ## 1.6
 * Updated for Stardew Valley 1.3 (including multiplayer support).
 * Added support for title menu transitions.


### PR DESCRIPTION
This pull request adds support for fast animations to shorten the delay that occurs before the game actually starts loading when the player clicks on a save slot.

My naming of the config variable/description is not ideal, so I would appreciate advice on a better way to describe what is being sped up.

Please let me know of any changes I should make :)