### PR TITLE
[TheLongNight] Prevent pass out by freezing time before 2am

### DIFF
--- a/Pathoschild.Stardew.sln
+++ b/Pathoschild.Stardew.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2036
+VisualStudioVersion = 15.0.27130.2026
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LookupAnything", "LookupAnything\LookupAnything.csproj", "{2A9C0811-B2D2-474A-A84C-DDEB16206A62}"
 EndProject
@@ -44,6 +44,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.Common", "_tests\Test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.Mods", "_tests\Tests.Mods\Tests.Mods.csproj", "{3A8B43BC-B3BB-49F1-A2E5-B17CFA94A3C1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TheLongNight", "TheLongNight\TheLongNight.csproj", "{646F11AF-51A2-4D88-8B86-B1F3FA61B853}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Common\Common.projitems*{0510e2ac-ec06-4211-b733-faf9d3a069ea}*SharedItemsImports = 4
@@ -51,6 +53,7 @@ Global
 		Common\Common.projitems*{2a9c0811-b2d2-474a-a84c-ddeb16206a62}*SharedItemsImports = 4
 		Common\Common.projitems*{3ed4784c-6ea7-4dbe-8476-4e1fa972fc3d}*SharedItemsImports = 4
 		Common\Common.projitems*{56fb522e-923d-4582-ad3d-8ec80f09237a}*SharedItemsImports = 4
+		Common\Common.projitems*{646f11af-51a2-4d88-8b86-b1f3fa61b853}*SharedItemsImports = 4
 		Common\Common.projitems*{6b9d5445-e45c-431d-a5b8-40556e553f54}*SharedItemsImports = 4
 		Common\Common.projitems*{866d7b9e-531e-4f83-95ee-b3d7f2642876}*SharedItemsImports = 4
 		Common\Common.projitems*{a72152b0-ab75-44e4-86d8-f6b8b9920b59}*SharedItemsImports = 4
@@ -116,6 +119,10 @@ Global
 		{3A8B43BC-B3BB-49F1-A2E5-B17CFA94A3C1}.Debug|x86.Build.0 = Debug|x86
 		{3A8B43BC-B3BB-49F1-A2E5-B17CFA94A3C1}.Release|x86.ActiveCfg = Release|x86
 		{3A8B43BC-B3BB-49F1-A2E5-B17CFA94A3C1}.Release|x86.Build.0 = Release|x86
+		{646F11AF-51A2-4D88-8B86-B1F3FA61B853}.Debug|x86.ActiveCfg = Debug|x86
+		{646F11AF-51A2-4D88-8B86-B1F3FA61B853}.Debug|x86.Build.0 = Debug|x86
+		{646F11AF-51A2-4D88-8B86-B1F3FA61B853}.Release|x86.ActiveCfg = Release|x86
+		{646F11AF-51A2-4D88-8B86-B1F3FA61B853}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
I simplified the mechanism to prevent pass out by freezing time at 1:50am via `Game1.gameTimeInterval`, are there issues or limitations with this approach?

I've tested:
- In multiplayer
- Fishing unlocks at limit
- Machines pause at limit
- Game end -> save -> new day as expected