### PR TITLE
Enhance recipe information in Lookup Anything

### DIFF
--- a/LookupAnything/Framework/Constants/L10n.cs
+++ b/LookupAnything/Framework/Constants/L10n.cs
@@ -318,6 +318,12 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Constants
             /// <summary>A value like <c>Owned</c>.</summary>
             public const string Owned = "item.number-owned";
 
+            /// <summary>A value like <c>Cooked</c>.</summary>
+            public const string Cooked = "item.number-cooked";
+
+            /// <summary>A value like <c>Crafted</c>.</summary>
+            public const string Crafted = "item.number-crafted";
+
             /// <summary>A value like <c>See also</c>.</summary>
             public const string SeeAlso = "item.see-also";
 
@@ -377,6 +383,12 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Constants
 
             /// <summary>A value like <c>you own {{count}} of these</c>.</summary>
             public const string OwnedSummary = "item.number-owned.summary";
+
+            /// <summary>A value like <c>you have cooked {{count}} of these</c>.</summary>
+            public const string CookedSummary = "item.number-cooked.summary";
+
+            /// <summary>A value like <c>you have crafted {{count}} of these</c>.</summary>
+            public const string CraftedSummary = "item.number-crafted.summary";
         }
 
         /// <summary>Monster lookup translations.</summary>

--- a/LookupAnything/Framework/Constants/L10n.cs
+++ b/LookupAnything/Framework/Constants/L10n.cs
@@ -357,6 +357,12 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Constants
             /// <summary>A value like <c>full collection achievement (donate one to museum)</c>.</summary>
             public const string NeededForFullCollection = "item.needed-for.full-collection";
 
+            /// <summary>A value like <c>gourmet chef achievement (cook {{recipes}})</c>.</summary>
+            public const string NeededForGourmetChef = "item.needed-for.gourmet-chef";
+
+            /// <summary>A value like <c>craft master achievement (make {{recipes}})</c>.</summary>
+            public const string NeededForCraftMaster = "item.needed-for.craft-master";
+
             /// <summary>A value like <c>shipping box</c>.</summary>
             public const string SellsToShippingBox = "item.sells-to.shipping-box";
 

--- a/LookupAnything/Framework/InternalExtensions.cs
+++ b/LookupAnything/Framework/InternalExtensions.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using Netcode;
 using Pathoschild.Stardew.LookupAnything.Framework.Constants;
 using StardewValley;
 using StardewValley.Objects;
@@ -36,6 +38,31 @@ namespace Pathoschild.Stardew.LookupAnything.Framework
                 return ItemSpriteType.Tool;
 
             return ItemSpriteType.Unknown;
+        }
+
+        /// <summary>Get the value stored for the key. If the value doesn't exist, return that type's default value.</summary>
+        /// <typeparam name="TKey">The type of the dictionary keys</typeparam>
+        /// <typeparam name="TValue">The type of the dictionary values</typeparam>
+        /// <param name="dictionary">This dictionary</param>
+        /// <param name="key">The key to look up</param>
+        /// <returns>Either the value store for the key or a default</returns>
+        public static TValue GetValueOrDefault<TKey, TValue>( this IDictionary<TKey, TValue> dictionary, TKey key )
+        {
+            return dictionary.TryGetValue( key, out var ret ) ? ret : default;
+        }
+
+        /// <summary>Get the value stored for the key. If the value doesn't exist, return that type's default value.</summary>
+        /// <typeparam name="TKey">The type of the dictionary keys</typeparam>
+        /// <typeparam name="TValue">The type of the dictionary values</typeparam>
+        /// <param name="dictionary">This dictionary</param>
+        /// <param name="key">The key to look up</param>
+        /// <returns>Either the value store for the key or a default</returns>
+        public static TValue GetValueOrDefault<TKey, TValue, TField, TSerialDict, TSelf> ( this NetDictionary<TKey, TValue, TField, TSerialDict, TSelf> dictionary, TKey key )
+            where TField : class, INetObject<INetSerializable>, new()
+            where TSerialDict : IDictionary<TKey, TValue>, new()
+            where TSelf : NetDictionary<TKey, TValue, TField, TSerialDict, TSelf>
+        {
+            return dictionary.TryGetValue( key, out var ret ) ? ret : default;
         }
     }
 }

--- a/LookupAnything/Framework/Models/RecipeModel.cs
+++ b/LookupAnything/Framework/Models/RecipeModel.cs
@@ -16,6 +16,15 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Models
         /// <summary>The item that be created by this recipe, given the ingredient.</summary>
         private readonly Func<Item, Item> Item;
 
+        /// <summary>The item id produced by this recipe</summary>
+        private readonly int ItemIndex;
+
+        /// <summary>If available, a cached copy of the localized name for the cooking recipe types</summary>
+        private readonly string DisplayTypeCooking;
+
+        /// <summary>If available, a cached copy of the localized name for the craftingrecipe types</summary>
+        private readonly string DisplayTypeCrafting;
+
 
         /*********
         ** Accessors
@@ -35,6 +44,21 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Models
         /// <summary>Whether the recipe must be learned before it can be used.</summary>
         public bool MustBeLearned { get; }
 
+        /// <summary>The number of times this receipe has been made. -1 indicates an unknown quantity.</summary>
+        public int TimesCrafted
+        {
+            get
+            {
+                // TODO: Is Game1.getFarmer(0) still appropriate in multiplayer?
+
+                if ( this.DisplayType.Equals( this.DisplayTypeCooking ) )
+                    return Game1.getFarmer(0).recipesCooked.GetValueOrDefault( this.ItemIndex );
+                else if ( this.DisplayType.Equals( this.DisplayTypeCrafting ) )
+                    return Game1.getFarmer(0).craftingRecipes.GetValueOrDefault( this.Key );
+                else
+                    return -1; // Other recipe types (e.g. furnace) have no obvious way of tracking the times they have been crafted
+            }
+        }
 
         /*********
         ** Public methods
@@ -49,7 +73,9 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Models
                 displayType: translations.Get(recipe.isCookingRecipe ? L10n.RecipeTypes.Cooking : L10n.RecipeTypes.Crafting),
                 ingredients: reflectionHelper.GetField<Dictionary<int, int>>(recipe, "recipeList").GetValue(),
                 item: item => recipe.createItem(),
-                mustBeLearned: true
+                mustBeLearned: true,
+                itemIndex: reflectionHelper.GetField<List<int>>( recipe, "itemToProduce" ).GetValue()[0],
+                translations: translations
             )
         { }
 
@@ -60,7 +86,9 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Models
         /// <param name="item">The item that be created by this recipe.</param>
         /// <param name="mustBeLearned">Whether the recipe must be learned before it can be used.</param>
         /// <param name="exceptIngredients">The ingredients which can't be used in this recipe (typically exceptions for a category ingredient).</param>
-        public RecipeModel(string key, string displayType, IDictionary<int, int> ingredients, Func<Item, Item> item, bool mustBeLearned, int[] exceptIngredients = null)
+        /// <param name="itemIndex">The index of the item created by this recipe.</param>
+        /// <param name="translations">Provides translations stored in the mod folder.</param>
+        public RecipeModel(string key, string displayType, IDictionary<int, int> ingredients, Func<Item, Item> item, bool mustBeLearned, int[] exceptIngredients = null, int itemIndex = -1, ITranslationHelper translations = null )
         {
             this.Key = key;
             this.DisplayType = displayType;
@@ -68,6 +96,12 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Models
             this.ExceptIngredients = exceptIngredients ?? new int[0];
             this.Item = item;
             this.MustBeLearned = mustBeLearned;
+            this.ItemIndex = itemIndex;
+            if ( translations != null )
+            {
+                this.DisplayTypeCooking = translations.Get( L10n.RecipeTypes.Cooking );
+                this.DisplayTypeCrafting = translations.Get( L10n.RecipeTypes.Crafting );
+            }
         }
 
         /// <summary>Create the item crafted by this recipe.</summary>

--- a/LookupAnything/Framework/Models/RecipeModel.cs
+++ b/LookupAnything/Framework/Models/RecipeModel.cs
@@ -16,9 +16,6 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Models
         /// <summary>The item that be created by this recipe, given the ingredient.</summary>
         private readonly Func<Item, Item> Item;
 
-        /// <summary>The item id produced by this recipe</summary>
-        private readonly int ItemIndex;
-
         /// <summary>If available, a cached copy of the localized name for the cooking recipe types</summary>
         private readonly string DisplayTypeCooking;
 
@@ -37,6 +34,9 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Models
 
         /// <summary>The items needed to craft the recipe (item ID => number needed).</summary>
         public IDictionary<int, int> Ingredients { get; }
+
+        /// <summary>The item id produced by this recipe</summary>
+        public int ItemIndex { get; }
 
         /// <summary>The ingredients which can't be used in this recipe (typically exceptions for a category ingredient).</summary>
         public int[] ExceptIngredients { get; }

--- a/LookupAnything/Framework/Subjects/ItemSubject.cs
+++ b/LookupAnything/Framework/Subjects/ItemSubject.cs
@@ -521,6 +521,25 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Subjects
             if (museum != null && museum.isItemSuitableForDonation(obj))
                 neededFor.Add(this.Translate(L10n.Item.NeededForFullCollection));
 
+
+            // Gourmet Chef & Craft Master achievements
+            string displayTypeCooking = this.Translate( L10n.RecipeTypes.Cooking );
+            var unmadeRecipes = (
+                from recipe in this.GameHelper.GetRecipesForIngredient( this.DisplayItem )
+                where recipe.TimesCrafted <= 0
+                select new {
+                    isCooking = recipe.DisplayType.Equals( displayTypeCooking ),
+                    name = recipe.CreateItem( this.DisplayItem ).DisplayName }
+            );
+
+            IEnumerable<string> cookingRecipes = from r in unmadeRecipes where r.isCooking orderby r.name select r.name;
+            if ( cookingRecipes.Any() )
+                neededFor.Add(this.Translate(L10n.Item.NeededForGourmetChef, new { recipes = string.Join(", ", cookingRecipes) }));
+
+            IEnumerable<string> craftingRecipes = from r in unmadeRecipes where !r.isCooking orderby r.name select r.name;
+            if ( craftingRecipes.Any() )
+                neededFor.Add(this.Translate(L10n.Item.NeededForCraftMaster, new { recipes = string.Join(", ", craftingRecipes ) }));
+
             // yield
             if (neededFor.Any())
                 yield return new GenericField(this.GameHelper, this.Translate(L10n.Item.NeededFor), string.Join(", ", neededFor));

--- a/LookupAnything/i18n/default.json
+++ b/LookupAnything/i18n/default.json
@@ -219,6 +219,8 @@
   "item.loves-this": "Loves this",
   "item.needed-for": "Needed for",
   "item.number-owned": "Owned",
+  "item.number-cooked": "Cooked",
+  "item.number-crafted": "Crafted",
   "item.recipes": "Recipes",
   "item.see-also": "See also",
   "item.sells-for": "Sells for",
@@ -243,6 +245,8 @@
   "item.fence-health.summary": "{{percent}}% (roughly {{count}} days left)",
   "item.recipes.entry": "{{name}} (needs {{count}})",
   "item.number-owned.summary": "you own {{count}} of these",
+  "item.number-cooked.summary": "you have cooked {{count}} of these",
+  "item.number-crafted.summary": "you have crafted {{count}} of these",
 
   // monster lookup labels
   "monster.invincible": "Invincible",

--- a/LookupAnything/i18n/default.json
+++ b/LookupAnything/i18n/default.json
@@ -236,6 +236,8 @@
   "item.needed-for.full-shipment": "full shipment achievement (ship one)",
   "item.needed-for.polyculture": "polyculture achievement (ship {{count}} more)",
   "item.needed-for.full-collection": "full collection achievement (donate one to museum)",
+  "item.needed-for.gourmet-chef": "gourmet chef achievement (cook {{recipes}})",
+  "item.needed-for.craft-master": "craft master achievement (make {{recipes}})",
   "item.sells-to.shipping-box": "shipping box",
   "item.fence-health.gold-clock": "no decay with Gold Clock",
   "item.fence-health.summary": "{{percent}}% (roughly {{count}} days left)",


### PR DESCRIPTION
This resolves ticket #195 by adding support for Gourmet Chef & Craft Master in the "needed for" portion of Lookup Anything. This makes it a lot easier to decide what crops to sell vs. keep for crafting. It also adds an entry in craftable/cookable items lookup dialog that displays the number of times the item has been crafted/cooked. This is especially handy in the cooking window.