### PR TITLE
Producer Framework Mod Integration

### DIFF
--- a/Common/Common.projitems
+++ b/Common/Common.projitems
@@ -9,6 +9,8 @@
     <Import_RootNamespace>Common</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Integrations\ProducerFrameworkMod\IProducerFrameworkModApi.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Integrations\ProducerFrameworkMod\ProducerFrameworkModIntegration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShirtSpriteInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DataParsers\CropDataParser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DrawHelper.cs" />

--- a/Common/Common.projitems
+++ b/Common/Common.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\ProducerFrameworkMod\IProducerFrameworkModApi.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\ProducerFrameworkMod\ProducerFrameworkModIntegration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Integrations\ProducerFrameworkMod\ProducerFrameworkRecipe.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShirtSpriteInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DataParsers\CropDataParser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DrawHelper.cs" />

--- a/Common/Integrations/ProducerFrameworkMod/IProducerFrameworkModApi.cs
+++ b/Common/Integrations/ProducerFrameworkMod/IProducerFrameworkModApi.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using SObject = StardewValley.Object;
+
+namespace Pathoschild.Stardew.Common.Integrations.ProducerFrameworkMod
+{
+    /// <summary>The API provided by the Producer Framework Mod.</summary>
+    public interface IProducerFrameworkModApi
+    {
+        /// <summary>
+        /// Get the list of recipes
+        /// The recipe format follow the MachineRecipeData class properties from Lookup Anything mod.
+        /// There are some additional properties that are not presented on that class, these ones has the name of the content pack properties of this mod.
+        /// </summary>
+        /// <returns>The list of recipes</returns>
+        List<Dictionary<string, object>> GetRecipes();
+
+        /// <summary>
+        /// Get the list of recipes for the producer with the giving name.
+        /// The recipe format follow the MachineRecipeData class properties from Lookup Anything mod.
+        /// There are some additional properties that are not presented on that class, these ones has the name of the content pack properties of this mod.
+        /// </summary>
+        /// <param name="producerName">The name of the producer.</param>
+        /// <returns>The list of recipes</returns>
+        List<Dictionary<string, object>> GetRecipes(string producerName);
+
+        /// <summary>
+        /// Get the list of recipes for the producer.
+        /// The recipe format follow the MachineRecipeData class properties from Lookup Anything mod.
+        /// There are some additional properties that are not presented on that class, these ones has the name of the content pack properties of this mod.
+        /// </summary>
+        /// <param name="producerObject">The Stardew Valley Object for the producer.</param>
+        /// <returns>The list of recipes</returns>
+        List<Dictionary<string, object>> GetRecipes(SObject producerObject);
+    }
+}

--- a/Common/Integrations/ProducerFrameworkMod/IProducerFrameworkModApi.cs
+++ b/Common/Integrations/ProducerFrameworkMod/IProducerFrameworkModApi.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Text;
 using SObject = StardewValley.Object;
 
 namespace Pathoschild.Stardew.Common.Integrations.ProducerFrameworkMod
@@ -8,30 +6,13 @@ namespace Pathoschild.Stardew.Common.Integrations.ProducerFrameworkMod
     /// <summary>The API provided by the Producer Framework Mod.</summary>
     public interface IProducerFrameworkModApi
     {
-        /// <summary>
-        /// Get the list of recipes
-        /// The recipe format follow the MachineRecipeData class properties from Lookup Anything mod.
-        /// There are some additional properties that are not presented on that class, these ones has the name of the content pack properties of this mod.
-        /// </summary>
-        /// <returns>The list of recipes</returns>
+        /// <summary>Get the list of recipes.</summary>
+        /// <remarks>The recipe format follow the MachineRecipeData class properties from Lookup Anything mod. There are some additional properties that are not presented on that class, these ones has the name of the content pack properties of this mod.</remarks>
         List<Dictionary<string, object>> GetRecipes();
 
-        /// <summary>
-        /// Get the list of recipes for the producer with the giving name.
-        /// The recipe format follow the MachineRecipeData class properties from Lookup Anything mod.
-        /// There are some additional properties that are not presented on that class, these ones has the name of the content pack properties of this mod.
-        /// </summary>
-        /// <param name="producerName">The name of the producer.</param>
-        /// <returns>The list of recipes</returns>
-        List<Dictionary<string, object>> GetRecipes(string producerName);
-
-        /// <summary>
-        /// Get the list of recipes for the producer.
-        /// The recipe format follow the MachineRecipeData class properties from Lookup Anything mod.
-        /// There are some additional properties that are not presented on that class, these ones has the name of the content pack properties of this mod.
-        /// </summary>
-        /// <param name="producerObject">The Stardew Valley Object for the producer.</param>
-        /// <returns>The list of recipes</returns>
-        List<Dictionary<string, object>> GetRecipes(SObject producerObject);
+        /// <summary>Get the list of recipes for a machine.</summary>
+        /// <param name="machine">The machine object.</param>
+        /// <remarks>The recipe format follow the MachineRecipeData class properties from Lookup Anything mod. There are some additional properties that are not presented on that class, these ones has the name of the content pack properties of this mod.</remarks>
+        List<Dictionary<string, object>> GetRecipes(SObject machine);
     }
 }

--- a/Common/Integrations/ProducerFrameworkMod/ProducerFrameworkModIntegration.cs
+++ b/Common/Integrations/ProducerFrameworkMod/ProducerFrameworkModIntegration.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using StardewModdingAPI;
+
+namespace Pathoschild.Stardew.Common.Integrations.ProducerFrameworkMod
+{
+    /// <summary>Handles the logic for integrating with the Producer Framework Mod.</summary>
+    internal class ProducerFrameworkModIntegration : BaseIntegration
+    {
+        /*********
+        ** Fields
+        *********/
+        /// <summary>The mod's public API.</summary>
+        private readonly IProducerFrameworkModApi ModApi;
+
+        public ProducerFrameworkModIntegration(IModRegistry modRegistry, IMonitor monitor)
+            : base("Producer Framework Mod", "Digus.ProducerFrameworkMod", "1.3.0", modRegistry, monitor)
+        {
+            if (!this.IsLoaded)
+                return;
+
+            // get mod API
+            this.ModApi = this.GetValidatedApi<IProducerFrameworkModApi>();
+            this.IsLoaded = this.ModApi != null;
+        }
+
+        public IEnumerable<Dictionary<string,object>> GetRecipes(StardewValley.Object producer)
+        {
+            this.AssertLoaded();
+            return this.ModApi.GetRecipes(producer);
+        }
+
+        public IEnumerable<Dictionary<string, object>> GetRecipes()
+        {
+            this.AssertLoaded();
+            return this.ModApi.GetRecipes();
+        }
+    }
+}

--- a/Common/Integrations/ProducerFrameworkMod/ProducerFrameworkModIntegration.cs
+++ b/Common/Integrations/ProducerFrameworkMod/ProducerFrameworkModIntegration.cs
@@ -1,7 +1,7 @@
-using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 using StardewModdingAPI;
+using SObject = StardewValley.Object;
 
 namespace Pathoschild.Stardew.Common.Integrations.ProducerFrameworkMod
 {
@@ -14,6 +14,13 @@ namespace Pathoschild.Stardew.Common.Integrations.ProducerFrameworkMod
         /// <summary>The mod's public API.</summary>
         private readonly IProducerFrameworkModApi ModApi;
 
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="modRegistry">An API for fetching metadata about loaded mods.</param>
+        /// <param name="monitor">Encapsulates monitoring and logging.</param>
         public ProducerFrameworkModIntegration(IModRegistry modRegistry, IMonitor monitor)
             : base("Producer Framework Mod", "Digus.ProducerFrameworkMod", "1.3.0", modRegistry, monitor)
         {
@@ -25,16 +32,44 @@ namespace Pathoschild.Stardew.Common.Integrations.ProducerFrameworkMod
             this.IsLoaded = this.ModApi != null;
         }
 
-        public IEnumerable<Dictionary<string,object>> GetRecipes(StardewValley.Object producer)
+        /// <summary>Get the list of recipes.</summary>
+        /// <remarks>The recipe format follow the MachineRecipeData class properties from Lookup Anything mod. There are some additional properties that are not presented on that class, these ones has the name of the content pack properties of this mod.</remarks>
+        public IEnumerable<ProducerFrameworkRecipe> GetRecipes()
         {
             this.AssertLoaded();
-            return this.ModApi.GetRecipes(producer);
+
+            return this.ModApi.GetRecipes().Select(this.ReadRecipe);
         }
 
-        public IEnumerable<Dictionary<string, object>> GetRecipes()
+        /// <summary>Get the list of recipes for a machine.</summary>
+        /// <param name="machine">The machine object.</param>
+        /// <remarks>The recipe format follow the MachineRecipeData class properties from Lookup Anything mod. There are some additional properties that are not presented on that class, these ones has the name of the content pack properties of this mod.</remarks>
+        public IEnumerable<ProducerFrameworkRecipe> GetRecipes(SObject machine)
         {
             this.AssertLoaded();
-            return this.ModApi.GetRecipes();
+
+            return this.ModApi.GetRecipes(machine).Select(this.ReadRecipe);
+        }
+
+
+        /*********
+        ** Private methods
+        *********/
+        /// <summary>Read the metadata for a recipe provided by <see cref="GetRecipes()"/> or <see cref="GetRecipes(SObject)"/>.</summary>
+        /// <param name="raw">The raw recipe data.</param>
+        private ProducerFrameworkRecipe ReadRecipe(IDictionary<string, object> raw)
+        {
+            ProducerFrameworkRecipe recipe = new ProducerFrameworkRecipe();
+            recipe.InputId = raw["InputKey"] as int?;
+            recipe.MachineId = (int)raw["MachineID"];
+            recipe.Ingredients = ((List<Dictionary<string, object>>)raw["Ingredients"]).ToDictionary(p => (int)p["ID"], p => (int)p["Count"]);
+            recipe.ExceptIngredients = ((List<Dictionary<string, object>>)raw["ExceptIngredients"]).Select(p => (int)p["ID"]).ToArray();
+            recipe.OutputId = (int)raw["Output"];
+            recipe.MinOutput = (int)raw["MinOutput"];
+            recipe.MaxOutput = (int)raw["MaxOutput"];
+            recipe.PreserveType = (SObject.PreserveType?)raw["PreserveType"];
+            recipe.OutputChance = (double)raw["OutputChance"];
+            return recipe;
         }
     }
 }

--- a/Common/Integrations/ProducerFrameworkMod/ProducerFrameworkRecipe.cs
+++ b/Common/Integrations/ProducerFrameworkMod/ProducerFrameworkRecipe.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using StardewValley;
+
+namespace Pathoschild.Stardew.Common.Integrations.ProducerFrameworkMod
+{
+    /// <summary>Metadata about a recipe provided by Producer Framework Mod.</summary>
+    internal class ProducerFrameworkRecipe
+    {
+        /// <summary>The ID for the main input ingredient, or <c>null</c> for a context tag.</summary>
+        public int? InputId { get; set; }
+
+        /// <summary>The ID for the machine item.</summary>
+        public int MachineId { get; set; }
+
+        /// <summary>The items needed to craft the recipe (item ID => number needed).</summary>
+        public IDictionary<int, int> Ingredients { get; set; }
+
+        /// <summary>>The ingredients which can't be used in this recipe</summary>
+        public int[] ExceptIngredients { get; set; }
+
+        /// <summary>The item ID produced by this recipe.</summary>
+        public int OutputId { get; set; }
+
+        /// <summary>The minimum number of items output by the recipe.</summary>
+        public int MinOutput { get; set; }
+
+        /// <summary>The maximum number of items output by the recipe.</summary>
+        public int MaxOutput { get; set; }
+
+        /// <summary>The percentage chance of this recipe being produced.</summary>
+        public double OutputChance { get; set; }
+
+        /// <summary>The produced preserve type, if any.</summary>
+        public Object.PreserveType? PreserveType { get; set; }
+    }
+}

--- a/LookupAnything/ModEntry.cs
+++ b/LookupAnything/ModEntry.cs
@@ -5,6 +5,7 @@ using Microsoft.Xna.Framework;
 using Pathoschild.Stardew.Common;
 using Pathoschild.Stardew.Common.Integrations.CustomFarmingRedux;
 using Pathoschild.Stardew.Common.Integrations.JsonAssets;
+using Pathoschild.Stardew.Common.Integrations.ProducerFrameworkMod;
 using Pathoschild.Stardew.LookupAnything.Components;
 using Pathoschild.Stardew.LookupAnything.Framework;
 using Pathoschild.Stardew.LookupAnything.Framework.Constants;
@@ -116,7 +117,8 @@ namespace Pathoschild.Stardew.LookupAnything
 
             // initialize functionality
             var customFarming = new CustomFarmingReduxIntegration(this.Helper.ModRegistry, this.Monitor);
-            this.GameHelper = new GameHelper(customFarming, this.Metadata);
+            var producerFramework = new ProducerFrameworkModIntegration(this.Helper.ModRegistry, this.Monitor);
+            this.GameHelper = new GameHelper(customFarming, producerFramework, this.Metadata);
             this.TargetFactory = new TargetFactory(this.Helper.Reflection, this.GameHelper, jsonAssets, new SubjectFactory(this.Metadata, this.Helper.Translation, this.Helper.Reflection, this.GameHelper, this.Config));
             this.DebugInterface = new DebugInterface(this.GameHelper, this.TargetFactory, this.Config, this.Monitor);
         }

--- a/LookupAnything/data.json
+++ b/LookupAnything/data.json
@@ -213,40 +213,40 @@ You shouldn't change this file unless you know what you're doing.
         {
             "MachineID": 13,
             "Ingredients": [
-                { "ID": 382 },            // coal
-                { "ID": 378, "Count": 5 } // copper ore
+                { "ID": 378, "Count": 5 }, // copper ore
+                { "ID": 382 }              // coal
             ],
             "Output": 334 // copper bar
         },
         {
             "MachineID": 13,
             "Ingredients": [
-                { "ID": 382 },            // coal
-                { "ID": 380, "Count": 5 } // iron ore
+                { "ID": 380, "Count": 5 }, // iron ore
+                { "ID": 382 }              // coal
             ],
             "Output": 335 // iron bar
         },
         {
             "MachineID": 13,
             "Ingredients": [
-                { "ID": 382 },            // coal
-                { "ID": 384, "Count": 5 } // gold ore
+                { "ID": 384, "Count": 5 }, // gold ore
+                { "ID": 382 }              // coal
             ],
             "Output": 336 // gold bar
         },
         {
             "MachineID": 13,
             "Ingredients": [
-                { "ID": 382 },            // coal
-                { "ID": 386, "Count": 5 } // gold ore
+                { "ID": 386, "Count": 5 }, // gold ore
+                { "ID": 382 }              // coal
             ],
             "Output": 337 // iridium bar
         },
         {
             "MachineID": 13,
             "Ingredients": [
-                { "ID": 382 }, // coal
-                { "ID": 82 }   // fire quartz
+                { "ID": 82 },   // fire quartz
+                { "ID": 382 }   // coal
             ],
             "Output": 338, // refined quartz
             "MaxOutput": 3
@@ -254,8 +254,8 @@ You shouldn't change this file unless you know what you're doing.
         {
             "MachineID": 13,
             "Ingredients": [
-                { "ID": 382 }, // coal
-                { "ID": 80 }   // quartz
+                { "ID": 80 },   // quartz
+                { "ID": 382 }   // coal
             ],
             "Output": 338 // refined quartz
         },


### PR DESCRIPTION
- Adding Producer Framework Mod API access.
- Change order of recipes input for vanilla machines, so that input items come first in the list.
- Refactoring of the recipe cache to account for recipes from PFM.
- Method to parse PFM recipe data and integrate it with the vanilla ones.
- Changing GetRecipesForIngredient method to dynamically remove conflict recipes.

This PR does not account for context_tag recipes that PFM accept. (Current version of API also does not send this recipes to LA)
Since PFM recipes for the same machine can have different amount of ingredients, they don't align, this can be improved in a future PR.
This PR also does not show output quality or time to produce, since LA does not show it currently, this can also be improved.