### PR TITLE
Fix compatibility between tractor mod & harvest with scythe mod

### DIFF
--- a/TractorMod/Framework/Attachments/ScytheAttachment.cs
+++ b/TractorMod/Framework/Attachments/ScytheAttachment.cs
@@ -182,9 +182,10 @@ namespace Pathoschild.Stardew.TractorMod.Framework.Attachments
             // harvest
             if (this.ShouldHarvest(dirt.crop))
             {
-                return dirt.crop.harvestMethod.Value == Crop.sickleHarvest
-                    ? dirt.performToolAction(tool, 0, tile, location)
-                    : dirt.performUseAction(tile, location);
+                bool uses_scythe = dirt.crop.harvestMethod.Value == Crop.sickleHarvest;
+                if (dirt.crop.harvest((int)tile.X, (int)tile.Y, dirt, null)) {
+                    dirt.destroyCrop(tile, uses_scythe, location);
+                }
             }
 
             return false;


### PR DESCRIPTION
This fixes the weird incompatibility issue between those two mods.

The problem is that Harvest with scythe slightly modifies the meaning of `Crop.harvestMethod.Value`. This results in the tractor mod to call `HoeDirt.performUseAction` on a crop that subsequently is considered a `Crop.sickleHarvest` crop causing it to trigger a harvest with scythe animation. By calling `dirt.crop.harvest` directly this problem is circumvented.