### PR TITLE
[Fast Animations] Add support for non-integral update rates.

### DIFF
--- a/FastAnimations/Framework/BaseAnimationHandler.cs
+++ b/FastAnimations/Framework/BaseAnimationHandler.cs
@@ -8,10 +8,16 @@ namespace Pathoschild.Stardew.FastAnimations.Framework
     internal abstract class BaseAnimationHandler : IAnimationHandler
     {
         /*********
+        ** Fields
+        *********/
+        /// <summary>Tracks the number of updates.</summary>
+        private float UpdateCounter = 0;
+
+        /*********
         ** Accessors
         *********/
         /// <summary>The animation speed multiplier to apply.</summary>
-        protected readonly int Multiplier;
+        protected readonly float Multiplier;
 
 
         /*********
@@ -35,14 +41,14 @@ namespace Pathoschild.Stardew.FastAnimations.Framework
         *********/
         /// <summary>Construct an instance.</summary>
         /// <param name="multiplier">The animation speed multiplier to apply.</param>
-        protected BaseAnimationHandler(int multiplier)
+        protected BaseAnimationHandler(float multiplier)
         {
             this.Multiplier = multiplier;
         }
 
         /// <summary>Speed up the player by the given multiplier for the current update tick.</summary>
         /// <param name="multiplier">The multiplier to apply to the player.</param>
-        protected void SpeedUpPlayer(int multiplier)
+        protected void SpeedUpPlayer(float multiplier)
         {
             this.SpeedUpPlayer(multiplier, () => true);
         }
@@ -50,12 +56,19 @@ namespace Pathoschild.Stardew.FastAnimations.Framework
         /// <summary>Speed up the player by the given multiplier for the current update tick.</summary>
         /// <param name="multiplier">The multiplier to apply to the player.</param>
         /// <param name="isActive">A lambda which returns whether the animation is still active.</param>
-        protected void SpeedUpPlayer(int multiplier, Func<bool> isActive)
+        protected void SpeedUpPlayer(float multiplier, Func<bool> isActive)
         {
+            // Account for one update that happens by default.
+            this.UpdateCounter = Math.Max(0, this.UpdateCounter + multiplier - 1);
+
             GameTime gameTime = Game1.currentGameTime;
             GameLocation location = Game1.player.currentLocation;
-            for (int i = 1; i < multiplier && isActive(); i++)
-                Game1.player.Update(gameTime, location);
+            while (this.UpdateCounter >= 1)
+            {
+                --this.UpdateCounter;
+                if (isActive())
+                    Game1.player.Update(gameTime, location);
+            }
         }
     }
 }

--- a/FastAnimations/Framework/ModConfig.cs
+++ b/FastAnimations/Framework/ModConfig.cs
@@ -13,45 +13,45 @@ namespace Pathoschild.Stardew.FastAnimations.Framework
         public bool DisableEatAndDrinkConfirmation { get; set; } = false;
 
         /// <summary>The speed multiplier for eating and drinking.</summary>
-        public int EatAndDrinkSpeed { get; set; } = 5;
+        public float EatAndDrinkSpeed { get; set; } = 5;
 
         /// <summary>The speed multiplier for fishing.</summary>
-        public int FishingSpeed { get; set; } = 1;
+        public float FishingSpeed { get; set; } = 1;
 
         /// <summary>The speed multiplier for milking.</summary>
-        public int MilkSpeed { get; set; } = 5;
+        public float MilkSpeed { get; set; } = 5;
 
         /// <summary>The speed multiplier for shearing.</summary>
-        public int ShearSpeed { get; set; } = 5;
+        public float ShearSpeed { get; set; } = 5;
 
         /// <summary>The speed multiplier for using tools.</summary>
-        public int ToolSwingSpeed { get; set; } = 1;
+        public float ToolSwingSpeed { get; set; } = 1;
 
         /// <summary>The speed multiplier for using weapons.</summary>
-        public int WeaponSwingSpeed { get; set; } = 1;
+        public float WeaponSwingSpeed { get; set; } = 1;
 
         /****
         ** World animations
         ****/
         /// <summary>The speed multiplier for breaking geodes.</summary>
-        public int BreakGeodeSpeed { get; set; } = 20;
+        public float BreakGeodeSpeed { get; set; } = 20;
 
         /// <summary>The speed multiplier for the casino slots minigame.</summary>
-        public int CasinoSlotsSpeed { get; set; } = 8;
+        public float CasinoSlotsSpeed { get; set; } = 8;
 
         /// <summary>The speed multiplier when Pam's bus is driving to/from the desert.</summary>
-        public int PamBusSpeed { get; set; } = 6;
+        public float PamBusSpeed { get; set; } = 6;
 
         /// <summary>The speed multiplier for falling trees.</summary>
-        public int TreeFallSpeed { get; set; } = 1;
+        public float TreeFallSpeed { get; set; } = 1;
 
         /****
         ** UI animations
         ****/
         /// <summary>The speed multiplier for title menu transitions.</summary>
-        public int TitleMenuTransitionSpeed { get; set; } = 10;
+        public float TitleMenuTransitionSpeed { get; set; } = 10;
 
         /// <summary>The speed multiplier for the blinking-slot delay after clicking a load slot.</summary>
-        public int LoadGameBlinkSpeed { get; set; } = 2;
+        public float LoadGameBlinkSpeed { get; set; } = 2;
     }
 }

--- a/FastAnimations/Handlers/BreakingGeodeHandler.cs
+++ b/FastAnimations/Handlers/BreakingGeodeHandler.cs
@@ -13,7 +13,7 @@ namespace Pathoschild.Stardew.FastAnimations.Handlers
         *********/
         /// <summary>Construct an instance.</summary>
         /// <param name="multiplier">The animation speed multiplier to apply.</param>
-        public BreakingGeodeHandler(int multiplier)
+        public BreakingGeodeHandler(float multiplier)
             : base(multiplier) { }
 
         /// <summary>Get whether the animation is currently active.</summary>

--- a/FastAnimations/Handlers/CasinoSlotsHandler.cs
+++ b/FastAnimations/Handlers/CasinoSlotsHandler.cs
@@ -22,7 +22,7 @@ namespace Pathoschild.Stardew.FastAnimations.Handlers
         /// <summary>Construct an instance.</summary>
         /// <param name="multiplier">The animation speed multiplier to apply.</param>
         /// <param name="reflection">Simplifies access to private game code.</param>
-        public CasinoSlotsHandler(int multiplier, IReflectionHelper reflection)
+        public CasinoSlotsHandler(float multiplier, IReflectionHelper reflection)
             : base(multiplier)
         {
             this.Reflection = reflection;

--- a/FastAnimations/Handlers/EatingHandler.cs
+++ b/FastAnimations/Handlers/EatingHandler.cs
@@ -32,7 +32,7 @@ namespace Pathoschild.Stardew.FastAnimations.Handlers
         /// <param name="reflection">Simplifies access to private code.</param>
         /// <param name="multiplier">The animation speed multiplier to apply.</param>
         /// <param name="disableConfirmation">Whether to disable the confirmation dialogue before eating or drinking.</param>
-        public EatingHandler(IReflectionHelper reflection, int multiplier, bool disableConfirmation)
+        public EatingHandler(IReflectionHelper reflection, float multiplier, bool disableConfirmation)
             : base(multiplier)
         {
             this.Reflection = reflection;

--- a/FastAnimations/Handlers/FishingHandler.cs
+++ b/FastAnimations/Handlers/FishingHandler.cs
@@ -14,7 +14,7 @@ namespace Pathoschild.Stardew.FastAnimations.Handlers
         *********/
         /// <summary>Construct an instance.</summary>
         /// <param name="multiplier">The animation speed multiplier to apply.</param>
-        public FishingHandler(int multiplier)
+        public FishingHandler(float multiplier)
             : base(multiplier) { }
 
         /// <summary>Get whether the animation is currently active.</summary>

--- a/FastAnimations/Handlers/LoadGameMenuHandler.cs
+++ b/FastAnimations/Handlers/LoadGameMenuHandler.cs
@@ -22,7 +22,7 @@ namespace Pathoschild.Stardew.FastAnimations.Handlers
         /// <summary>Construct an instance.</summary>
         /// <param name="multiplier">The animation speed multiplier to apply.</param>
         /// <param name="reflection">Simplifies access to private game code.</param>
-        public LoadGameMenuHandler(int multiplier, IReflectionHelper reflection)
+        public LoadGameMenuHandler(float multiplier, IReflectionHelper reflection)
             : base(multiplier)
         {
             this.Reflection = reflection;

--- a/FastAnimations/Handlers/MilkingHandler.cs
+++ b/FastAnimations/Handlers/MilkingHandler.cs
@@ -13,7 +13,7 @@ namespace Pathoschild.Stardew.FastAnimations.Handlers
         *********/
         /// <summary>Construct an instance.</summary>
         /// <param name="multiplier">The animation speed multiplier to apply.</param>
-        public MilkingHandler(int multiplier)
+        public MilkingHandler(float multiplier)
             : base(multiplier) { }
 
         /// <summary>Get whether the animation is currently active.</summary>

--- a/FastAnimations/Handlers/PamBusHandler.cs
+++ b/FastAnimations/Handlers/PamBusHandler.cs
@@ -13,7 +13,7 @@ namespace Pathoschild.Stardew.FastAnimations.Handlers
         *********/
         /// <summary>Construct an instance.</summary>
         /// <param name="multiplier">The animation speed multiplier to apply.</param>
-        public PamBusHandler(int multiplier)
+        public PamBusHandler(float multiplier)
             : base(multiplier) { }
 
         /// <summary>Get whether the animation is currently active.</summary>

--- a/FastAnimations/Handlers/ShearingHandler.cs
+++ b/FastAnimations/Handlers/ShearingHandler.cs
@@ -13,7 +13,7 @@ namespace Pathoschild.Stardew.FastAnimations.Handlers
         *********/
         /// <summary>Construct an instance.</summary>
         /// <param name="multiplier">The animation speed multiplier to apply.</param>
-        public ShearingHandler(int multiplier)
+        public ShearingHandler(float multiplier)
             : base(multiplier) { }
 
         /// <summary>Get whether the animation is currently active.</summary>

--- a/FastAnimations/Handlers/TitleMenuHandler.cs
+++ b/FastAnimations/Handlers/TitleMenuHandler.cs
@@ -22,7 +22,7 @@ namespace Pathoschild.Stardew.FastAnimations.Handlers
         /// <summary>Construct an instance.</summary>
         /// <param name="multiplier">The animation speed multiplier to apply.</param>
         /// <param name="reflection">Simplifies access to private game code.</param>
-        public TitleMenuHandler(int multiplier, IReflectionHelper reflection)
+        public TitleMenuHandler(float multiplier, IReflectionHelper reflection)
             : base(multiplier)
         {
             this.Reflection = reflection;

--- a/FastAnimations/Handlers/ToolSwingHandler.cs
+++ b/FastAnimations/Handlers/ToolSwingHandler.cs
@@ -12,7 +12,7 @@ namespace Pathoschild.Stardew.FastAnimations.Handlers
         *********/
         /// <summary>Construct an instance.</summary>
         /// <param name="multiplier">The animation speed multiplier to apply.</param>
-        public ToolSwingHandler(int multiplier)
+        public ToolSwingHandler(float multiplier)
             : base(multiplier) { }
 
         /// <summary>Get whether the animation is currently active.</summary>

--- a/FastAnimations/Handlers/TreeFallingHandler.cs
+++ b/FastAnimations/Handlers/TreeFallingHandler.cs
@@ -30,7 +30,7 @@ namespace Pathoschild.Stardew.FastAnimations.Handlers
         /// <summary>Construct an instance.</summary>
         /// <param name="multiplier">The animation speed multiplier to apply.</param>
         /// <param name="reflection">Simplifies access to private game code.</param>
-        public TreeFallingHandler(int multiplier, IReflectionHelper reflection)
+        public TreeFallingHandler(float multiplier, IReflectionHelper reflection)
             : base(multiplier)
         {
             this.Reflection = reflection;

--- a/FastAnimations/Handlers/WeaponSwingHandler.cs
+++ b/FastAnimations/Handlers/WeaponSwingHandler.cs
@@ -12,7 +12,7 @@ namespace Pathoschild.Stardew.FastAnimations.Handlers
         *********/
         /// <summary>Construct an instance.</summary>
         /// <param name="multiplier">The animation speed multiplier to apply.</param>
-        public WeaponSwingHandler(int multiplier)
+        public WeaponSwingHandler(float multiplier)
             : base(multiplier) { }
 
         /// <summary>Get whether the animation is currently active.</summary>


### PR DESCRIPTION
Fixes #541.

Verified the new logic works by recording gameplay and counting frames of animation of a weapon swing (from the first appearance of the sword to the character resuming a standing pose).

|Rate|Frame Count|
|---|---|
|1.0|24|
|1.5|16|
|2.0|12|

NOTE: Your coding conventions differ from mine for C#, so I hope I have matched your style properly.  Let me know if I need to correct anything.