### PR TITLE
[Automate] Add the option to always keep a certain amount of each item

### DIFF
--- a/Automate/Framework/AutomationFactory.cs
+++ b/Automate/Framework/AutomationFactory.cs
@@ -50,6 +50,9 @@ namespace Pathoschild.Stardew.Automate.Framework
         /// <summary>Whether to pull gemstones out of Junimo huts.</summary>
         public bool PullGemstonesFromJunimoHuts { get; set; }
 
+        /// <summary>Minimum number of each item to keep.</summary>
+        private readonly int KeepAtLeast;
+
 
         /*********
         ** Public methods
@@ -63,7 +66,8 @@ namespace Pathoschild.Stardew.Automate.Framework
         /// <param name="betterJunimosCompat">Whether to enable compatibility with the Better Junimos mod.</param>
         /// <param name="autoGrabberModCompat">Whether to enable compatibility with Auto-Grabber Mod.</param>
         /// <param name="pullGemstonesFromJunimoHuts">Whether to pull gemstones out of Junimo huts.</param>
-        public AutomationFactory(string[] connectors, bool automateShippingBin, IMonitor monitor, IReflectionHelper reflection, DataModel data, bool betterJunimosCompat, bool autoGrabberModCompat, bool pullGemstonesFromJunimoHuts)
+        /// <param name="keepAtLeast">Minimum number of each item to keep.</param>
+        public AutomationFactory(string[] connectors, bool automateShippingBin, IMonitor monitor, IReflectionHelper reflection, DataModel data, bool betterJunimosCompat, bool autoGrabberModCompat, bool pullGemstonesFromJunimoHuts, int keepAtLeast)
         {
             this.Connectors = new HashSet<string>(connectors, StringComparer.InvariantCultureIgnoreCase);
             this.AutomateShippingBin = automateShippingBin;
@@ -73,6 +77,7 @@ namespace Pathoschild.Stardew.Automate.Framework
             this.BetterJunimosCompat = betterJunimosCompat;
             this.AutoGrabberModCompat = autoGrabberModCompat;
             this.PullGemstonesFromJunimoHuts = pullGemstonesFromJunimoHuts;
+            this.KeepAtLeast = keepAtLeast;
         }
 
         /// <summary>Get a machine, container, or connector instance for a given object.</summary>
@@ -185,9 +190,9 @@ namespace Pathoschild.Stardew.Automate.Framework
             if (building is JunimoHut hut)
                 return new JunimoHutMachine(hut, location, ignoreSeedOutput: this.BetterJunimosCompat, ignoreFertilizerOutput: this.BetterJunimosCompat, pullGemstonesFromJunimoHuts: this.PullGemstonesFromJunimoHuts);
             if (building is Mill mill)
-                return new MillMachine(mill, location);
+                return new MillMachine(mill, location, KeepAtLeast);
             if (this.AutomateShippingBin && building is ShippingBin bin)
-                return new ShippingBinMachine(bin, location, Game1.getFarm());
+                return new ShippingBinMachine(bin, location, Game1.getFarm(), this.KeepAtLeast);
             if (building.buildingType.Value == "Silo")
                 return new FeedHopperMachine(building, location);
             return null;
@@ -203,7 +208,7 @@ namespace Pathoschild.Stardew.Automate.Framework
             // shipping bin
             if (this.AutomateShippingBin && location is Farm farm && (int)tile.X == this.ShippingBinArea.X && (int)tile.Y == this.ShippingBinArea.Y)
             {
-                return new ShippingBinMachine(farm, this.ShippingBinArea);
+                return new ShippingBinMachine(farm, this.ShippingBinArea, this.KeepAtLeast);
             }
 
             // garbage can

--- a/Automate/Framework/MachineGroup.cs
+++ b/Automate/Framework/MachineGroup.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
+using Pathoschild.Stardew.Automate.Framework.Models;
 using Pathoschild.Stardew.Common.Utilities;
 using StardewValley;
 using SObject = StardewValley.Object;
@@ -51,13 +52,14 @@ namespace Pathoschild.Stardew.Automate.Framework
         /// <param name="machines">The machines in the group.</param>
         /// <param name="containers">The containers in the group.</param>
         /// <param name="tiles">The tiles comprising the group.</param>
-        public MachineGroup(GameLocation location, IMachine[] machines, IContainer[] containers, Vector2[] tiles)
+        /// <param name="config">The mod configuration.</param>
+        public MachineGroup(GameLocation location, IMachine[] machines, IContainer[] containers, Vector2[] tiles, ModConfig config)
         {
             this.Location = location;
             this.Machines = machines;
             this.Containers = containers;
             this.Tiles = tiles;
-            this.StorageManager = new StorageManager(containers);
+            this.StorageManager = new StorageManager(containers, config.KeepAtLeast);
         }
 
         /// <summary>Automate the machines inside the group.</summary>

--- a/Automate/Framework/MachineGroupBuilder.cs
+++ b/Automate/Framework/MachineGroupBuilder.cs
@@ -87,7 +87,7 @@ namespace Pathoschild.Stardew.Automate.Framework
                 .Select(machine => (IMachine)new MachineWrapper(machine))
                 .ToArray();
 
-            return new MachineGroup(this.Location, machines, this.Containers.ToArray(), this.Tiles.ToArray());
+            return new MachineGroup(this.Location, machines, this.Containers.ToArray(), this.Tiles.ToArray(), this.Config);
         }
 
         /// <summary>Clear the saved data.</summary>

--- a/Automate/Framework/Machines/Buildings/ShippingBinMachine.cs
+++ b/Automate/Framework/Machines/Buildings/ShippingBinMachine.cs
@@ -1,7 +1,10 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
 using StardewValley;
 using StardewValley.Buildings;
+using StardewValley.Objects;
 using SObject = StardewValley.Object;
 
 namespace Pathoschild.Stardew.Automate.Framework.Machines.Buildings
@@ -18,6 +21,9 @@ namespace Pathoschild.Stardew.Automate.Framework.Machines.Buildings
         /// <summary>The constructed shipping bin, if applicable.</summary>
         private readonly ShippingBin Bin;
 
+        /// <summary>Minimum number of each item to keep.</summary>
+        private readonly int KeepAtLeast;
+
 
         /*********
         ** Public methods
@@ -25,22 +31,26 @@ namespace Pathoschild.Stardew.Automate.Framework.Machines.Buildings
         /// <summary>Construct an instance.</summary>
         /// <param name="farm">The farm containing the shipping bin.</param>
         /// <param name="tileArea">The tile area covered by the machine.</param>
-        public ShippingBinMachine(Farm farm, Rectangle tileArea)
+        /// <param name="keepAtLeast">Minimum number of each item to keep.</param>
+        public ShippingBinMachine(Farm farm, Rectangle tileArea, int keepAtLeast)
             : base(farm, tileArea)
         {
             this.Farm = farm;
             this.Bin = null;
+            this.KeepAtLeast = keepAtLeast;
         }
 
         /// <summary>Construct an instance.</summary>
         /// <param name="bin">The constructed shipping bin.</param>
         /// <param name="location">The location which contains the machine.</param>
         /// <param name="farm">The farm which has the shipping bin data.</param>
-        public ShippingBinMachine(ShippingBin bin, GameLocation location, Farm farm)
+        /// <param name="keepAtLeast">Minimum number of each item to keep.</param>
+        public ShippingBinMachine(ShippingBin bin, GameLocation location, Farm farm, int keepAtLeast)
             : base(location, BaseMachine.GetTileAreaFor(bin))
         {
             this.Farm = farm;
             this.Bin = bin;
+            this.KeepAtLeast = keepAtLeast;
         }
 
         /// <summary>Get the machine's processing state.</summary>
@@ -63,14 +73,25 @@ namespace Pathoschild.Stardew.Automate.Framework.Machines.Buildings
         /// <returns>Returns whether the machine started processing an item.</returns>
         public override bool SetInput(IStorage input)
         {
-            ITrackedStack tracker = input.GetItems().Where(p => p.Sample is SObject obj && obj.canBeShipped()).Take(1).FirstOrDefault();
-            if (tracker != null)
+            IDictionary<int, int> itemCounter = new SortedList<int, int>();
+            Func<ITrackedStack,bool> predicate = p => p.Sample is SObject obj && obj.canBeShipped() && p.Count > KeepAtLeast;
+            foreach (ITrackedStack tracker in input.GetItemsAscendingQuality(itemCounter, predicate))
             {
-                SObject item = (SObject)tracker.Take(tracker.Count);
-                this.Farm.getShippingBin(Game1.MasterPlayer).Add(item);
-                this.Farm.lastItemShipped = item;
-                this.Farm.showShipment(item, false);
-                return true;
+                int itemCount=0;
+                if (KeepAtLeast > 0 && !itemCounter.TryGetValue(tracker.Sample.ParentSheetIndex, out itemCount))
+                {
+                    string error = $"Failed to retrieve item count #{tracker.Sample.ParentSheetIndex} ('{tracker.Sample.Name}')";
+                    throw new InvalidOperationException(error);
+                }
+
+                if (KeepAtLeast <= 0 || itemCounter[tracker.Sample.ParentSheetIndex] > KeepAtLeast)
+                {
+                  SObject item = (SObject)tracker.Take(Math.Min(tracker.Count, itemCount-KeepAtLeast));
+                  this.Farm.getShippingBin(Game1.MasterPlayer).Add(item);
+                  this.Farm.lastItemShipped = item;
+                  this.Farm.showShipment(item, false);
+                  return true;
+                }
             }
             return false;
         }

--- a/Automate/Framework/Models/ModConfig.cs
+++ b/Automate/Framework/Models/ModConfig.cs
@@ -24,6 +24,9 @@ namespace Pathoschild.Stardew.Automate.Framework.Models
         /// <summary>The in-game object names through which machines can connect.</summary>
         public string[] ConnectorNames { get; set; } = { "Workbench" };
 
+        /// <summary>The minimum number of each items to keep.</summary>
+        public int KeepAtLeast { get; set; } = 0;
+
         /// <summary>Options affecting compatibility with other mods.</summary>
         public ModCompatibilityConfig ModCompatibility { get; set; } = new ModCompatibilityConfig();
 

--- a/Automate/Framework/Storage/ChestContainer.cs
+++ b/Automate/Framework/Storage/ChestContainer.cs
@@ -136,6 +136,21 @@ namespace Pathoschild.Stardew.Automate.Framework.Storage
             return this.GetEnumerator();
         }
 
+        /// <summary>Get count for each item.</summary>
+        /// <param name="itemCounter">Counter to increment, indexed by item ID.</param>
+        /// <param name="predicate">Returns whether an item should be counted.</param>
+        public void CountItems(IDictionary<int, int> itemCounter, Func<Item, bool> predicate=null)
+        {
+            predicate = predicate ?? (t => true);
+            foreach (Item item in this.Chest.items.Where(predicate))
+            {
+                int itemCount = 0;
+                itemCounter.TryGetValue(item.ParentSheetIndex, out itemCount);
+                itemCount += item.Stack;
+                itemCounter[item.ParentSheetIndex] = itemCount;
+            }
+        }
+
 
         /*********
         ** Private methods

--- a/Automate/Framework/StorageManager.cs
+++ b/Automate/Framework/StorageManager.cs
@@ -13,11 +13,20 @@ namespace Pathoschild.Stardew.Automate.Framework
         /*********
         ** Fields
         *********/
+        /// <summary>The storage containers that accept input or output.</summary>
+        private readonly IContainer[] Containers;
+
         /// <summary>The storage containers that accept input, in priority order.</summary>
         private readonly IContainer[] InputContainers;
 
         /// <summary>The storage containers that provide items, in priority order.</summary>
         private readonly IContainer[] OutputContainers;
+
+        /// <summary>The minimum number of each item to keep.</summary>
+        private readonly int KeepAtLeast;
+
+        /// <summary>Count of each item in this storage, index by item id.</summary>
+        private readonly IDictionary<int, int> ItemCounter;
 
 
         /*********
@@ -25,12 +34,28 @@ namespace Pathoschild.Stardew.Automate.Framework
         *********/
         /// <summary>Construct an instance.</summary>
         /// <param name="containers">The storage containers.</param>
-        public StorageManager(IEnumerable<IContainer> containers)
+        /// <param name="keepAtLeast">The minimum number of each item to keep.</param>
+        public StorageManager(IEnumerable<IContainer> containers, int keepAtLeast)
         {
-            containers = containers.ToArray();
+            this.Containers = containers.ToArray();
+            this.InputContainers = Containers.Where(p => p.StorageAllowed()).OrderByDescending(p => p.StoragePreferred()).ToArray();
+            this.OutputContainers = Containers.Where(p => p.TakingItemsAllowed()).OrderByDescending(p => p.TakingItemsPreferred()).ToArray();
+            this.KeepAtLeast = keepAtLeast;
+            this.ItemCounter = new SortedList<int, int>();
+        }
 
-            this.InputContainers = containers.Where(p => p.StorageAllowed()).OrderByDescending(p => p.StoragePreferred()).ToArray();
-            this.OutputContainers = containers.Where(p => p.TakingItemsAllowed()).OrderByDescending(p => p.TakingItemsPreferred()).ToArray();
+        /****
+        ** CountItems
+        ****/
+        /// <summary>Get count for each item.</summary>
+        /// <param name="itemCounter">Counter to increment, indexed by item ID.</param>
+        /// <param name="predicate">Returns whether an item should be counted.</param>
+        public void CountItems(IDictionary<int, int> itemCounter, Func<Item, bool> predicate=null)
+        {
+            foreach (IContainer container in this.Containers)
+            {
+                container.CountItems(itemCounter, predicate);
+            }
         }
 
         /****
@@ -39,10 +64,34 @@ namespace Pathoschild.Stardew.Automate.Framework
         /// <summary>Get all items from the given pipes.</summary>
         public IEnumerable<ITrackedStack> GetItems()
         {
+            if (KeepAtLeast > 0)
+              CountItems(i=>true);
+
             foreach (IContainer container in this.OutputContainers)
             {
                 foreach (ITrackedStack item in container)
                     yield return item;
+            }
+        }
+
+        /****
+        ** GetItemsAscendingQuality
+        ****/
+        /// <summary>Get all items from the given pipes, by ascending quality.</summary>
+        /// <param name="itemCounter">Counter to increment, indexed by item ID.</param>
+        /// <param name="predicate">Returns whether an item should be matched.</param>
+        public IEnumerable<ITrackedStack> GetItemsAscendingQuality(IDictionary<int,int> itemCounter, Func<ITrackedStack, bool> predicate=null)
+        {
+            if (KeepAtLeast > 0 && itemCounter != null)
+              CountItems(itemCounter, i => (predicate == null || predicate(new TrackedItem(i))));
+
+            for(int quality = SObject.lowQuality ; quality <= SObject.bestQuality; ++quality)
+            {
+                foreach (IContainer container in this.OutputContainers)
+                {
+                    foreach (ITrackedStack stack in container.Where(item => (predicate == null || predicate(item)) && item.Sample is SObject obj && obj.Quality == quality))
+                        yield return stack;
+                }
             }
         }
 
@@ -57,13 +106,24 @@ namespace Pathoschild.Stardew.Automate.Framework
         public bool TryGetIngredient(Func<ITrackedStack, bool> predicate, int count, out IConsumable consumable)
         {
             StackAccumulator stacks = new StackAccumulator();
-            foreach (ITrackedStack input in this.GetItems().Where(predicate))
+            IDictionary<int, int> itemCounter = new SortedList<int, int>();
+            foreach (ITrackedStack input in this.GetItemsAscendingQuality(itemCounter, predicate))
             {
-                TrackedItemCollection stack = stacks.Add(input);
-                if (stack.Count >= count)
+                int itemCount=0;
+                if (KeepAtLeast > 0 && !itemCounter.TryGetValue(input.Sample.ParentSheetIndex, out itemCount))
                 {
-                    consumable = new Consumable(stack, count);
-                    return consumable.IsMet;
+                    string error = $"Failed to retrieve item count #{input.Sample.ParentSheetIndex} ('{input.Sample.Name}')";
+                    throw new InvalidOperationException(error);
+                }
+
+                if (KeepAtLeast <= 0 || itemCount >= count + KeepAtLeast)
+                {
+                    TrackedItemCollection stack = stacks.Add(input);
+                    if (stack.Count >= count)
+                    {
+                        consumable = new Consumable(stack, count);
+                        return consumable.IsMet;
+                    }
                 }
             }
 
@@ -90,18 +150,26 @@ namespace Pathoschild.Stardew.Automate.Framework
         public bool TryGetIngredient(IRecipe[] recipes, out IConsumable consumable, out IRecipe recipe)
         {
             IDictionary<IRecipe, StackAccumulator> accumulator = recipes.ToDictionary(req => req, req => new StackAccumulator());
+            IDictionary<int, int> itemCounter = new SortedList<int, int>();
 
-            foreach (ITrackedStack input in this.GetItems())
+            foreach (ITrackedStack input in this.GetItemsAscendingQuality(itemCounter))
             {
+                int itemCount = 0;
+                if (KeepAtLeast > 0 && !itemCounter.TryGetValue(input.Sample.ParentSheetIndex, out itemCount))
+                {
+                    string error = $"Failed to retrieve item count #{input.Sample.ParentSheetIndex} ('{input.Sample.Name}')";
+                    throw new InvalidOperationException(error);
+                }
+
                 foreach (var entry in accumulator)
                 {
                     recipe = entry.Key;
                     StackAccumulator stacks = entry.Value;
 
-                    if (recipe.AcceptsInput(input))
+                    if (recipe.AcceptsInput(input) && itemCount >= recipe.InputCount + KeepAtLeast)
                     {
                         ITrackedStack stack = stacks.Add(input);
-                        if (stack.Count >= recipe.InputCount)
+                        if (KeepAtLeast <= 0 || stack.Count >= recipe.InputCount)
                         {
                             consumable = new Consumable(stack, entry.Key.InputCount);
                             return true;
@@ -206,5 +274,20 @@ namespace Pathoschild.Stardew.Automate.Framework
 
             return key;
         }
+
+        /****
+        ** CountItems
+        ****/
+        /// <summary>Get count for each item.</summary>
+        /// <param name="predicate">Returns whether an item should be counted.</param>
+        private void CountItems(Func<Item, bool> predicate)
+        {
+            this.ItemCounter.Clear();
+            foreach (IContainer container in this.Containers)
+            {
+                container.CountItems(this.ItemCounter, predicate);
+            }
+        }
+
     }
 }

--- a/Automate/IContainer.cs
+++ b/Automate/IContainer.cs
@@ -27,5 +27,10 @@ namespace Pathoschild.Stardew.Automate
         /// <param name="stack">The item stack to store.</param>
         /// <remarks>If the storage can't hold the entire stack, it should reduce the tracked stack accordingly.</remarks>
         void Store(ITrackedStack stack);
+
+        /// <summary>Get count for each item.</summary>
+        /// <param name="itemCounter">Counter to increment, indexed by item ID.</param>
+        /// <param name="predicate">Returns whether an item should be counted.</param>
+        void CountItems(IDictionary<int, int> itemCounter, Func<Item, bool> predicate=null);
     }
 }

--- a/Automate/IStorage.cs
+++ b/Automate/IStorage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using StardewValley;
 using Pathoschild.Stardew.Automate.Framework;
 
 namespace Pathoschild.Stardew.Automate
@@ -12,6 +13,14 @@ namespace Pathoschild.Stardew.Automate
         *********/
         /// <summary>Get all items from the given pipes.</summary>
         IEnumerable<ITrackedStack> GetItems();
+
+        /****
+        ** GetItemsAscendingQuality
+        ****/
+        /// <summary>Get all items from the given pipes, by ascending quality.</summary>
+        /// <param name="itemCounter">Counter to increment, indexed by item ID.</param>
+        /// <param name="predicate">Returns whether an item should be matched.</param>
+        IEnumerable<ITrackedStack> GetItemsAscendingQuality(IDictionary<int,int> itemCounter, Func<ITrackedStack, bool> predicate=null);
 
         /****
         ** TryGetIngredient
@@ -60,5 +69,13 @@ namespace Pathoschild.Stardew.Automate
         /// <summary>Add the given item stack to the pipes if there's space.</summary>
         /// <param name="item">The item stack to push.</param>
         bool TryPush(ITrackedStack item);
+
+        /****
+        ** CountItems
+        ****/
+        /// <summary>Get count for each item.</summary>
+        /// <param name="itemCounter">Counter to increment, indexed by item ID.</param>
+        /// <param name="predicate">Returns whether an item should be counted.</param>
+        void CountItems(IDictionary<int, int> itemCounter, Func<Item, bool> predicate=null);
     }
 }

--- a/Automate/ModEntry.cs
+++ b/Automate/ModEntry.cs
@@ -84,7 +84,8 @@ namespace Pathoschild.Stardew.Automate
                 data: data,
                 betterJunimosCompat: this.Config.ModCompatibility.BetterJunimos && helper.ModRegistry.IsLoaded("hawkfalcon.BetterJunimos"),
                 autoGrabberModCompat: this.Config.ModCompatibility.AutoGrabberMod && helper.ModRegistry.IsLoaded("Jotser.AutoGrabberMod"),
-                pullGemstonesFromJunimoHuts: this.Config.PullGemstonesFromJunimoHuts
+                pullGemstonesFromJunimoHuts: this.Config.PullGemstonesFromJunimoHuts,
+                keepAtLeast: this.Config.KeepAtLeast
             ));
 
             // hook events

--- a/Automate/README.md
+++ b/Automate/README.md
@@ -9,6 +9,7 @@ automatically pull raw items from the chest and push processed items into it.
   * [Factories](#factories)
   * [Connectors](#connectors)
   * [Machine priority](#machine-priority)
+  * [Saving items](#saving-items)
 * [Configure](#configure)
   * [config.json](#configjson)
   * [In-game settings](#in-game-settings)
@@ -209,6 +210,49 @@ worm bins | `WormBin`
 
 For custom machines added by other mods, see their documentation or ask their mod authors.
 
+### Saving Items
+<dl>
+<dt>overview</dt>
+<dd>
+
+By default, each machine pull all the available ingredients out of the connected chests.
+
+You can change that by setting the minimum number of each items to keep in each chest group
+in [the `config.json`](#configure). Machines always leave at least this amount in its
+associated chest group, all quality included.
+
+The lowest quality items are pulled first, meaning that those kept in storage are of the best
+available quality.
+
+</dd>
+
+<dt>example</dt>
+<dd>
+
+For example, considering this chests and kegs setup:
+```
+┌───────────────────┐┌───────────────┐┌───────┐┌───────┐     ┌───────┐
+│  chest#1          ││  chest#2      ││ keg#1 ││ keg#2 │     │ keg#X │
+│3 tomatoes         ││3 gold tomatoes││       ││       │     │       │
+│3 silver tomatoes  ││               ││       ││       │ ⋅⋅⋅ │       │
+│3 gold tomatoes    ││               ││       ││       │     │       │
+│3 irridium tomatoes││               ││       ││       │     │       │
+└───────────────────┘└───────────────┘└───────┘└───────┘     └───────┘
+```
+
+By default, all the tomatoes will got into the kegs.
+
+To keep at least 5 tomatoes, you need edit the `config.json` this way:
+```js
+"KeepAtLeast": 5
+```
+
+Instead of pulling all the tomatoes, the combined content of the two chest would then be:
+
+* 10 bottle of tomato juice
+* 3 irridium tomatoes
+* 2 gold tomatoes
+
 ## Configure
 ### config.json
 The mod creates a `config.json` file in its mod folder the first time you run it. You can open that
@@ -274,6 +318,17 @@ together. You must specify the exact _English_ names for any in-game items to us
 ```
 
 Contains `Workbench` by default.
+
+  </td>
+</tr>
+<tr>
+  <td><code>KeepAtLeast</code></td>
+  <td>
+
+The minimum number of each item to keep. Defaults to `0`.
+
+When this option is set to a positive value, machines always leave at least this amount in its
+associated chest group, all quality included; see [saving items](#saving-items).
 
   </td>
 </tr>


### PR DESCRIPTION
New configuration option: "KeepAtLeast" (integer, defaults to 0).

When this option is set to a positive value, machines will always leave at least this amount in its associated chest group, regardless of the quality.

The lowest quality items are consumed first, meaning that those kept in storage are of the best quality available.