### PR TITLE
Add Generic Mod Config Menu integration for Tractor Mod

### DIFF
--- a/Common/Common.projitems
+++ b/Common/Common.projitems
@@ -13,7 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DataParsers\CropDataParser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DrawHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\GenericModConfigMenu\GenericModConfigMenuIntegration.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Integrations\GenericModConfigMenu\IGenericConfigModApi.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Integrations\GenericModConfigMenu\IGenericModConfigMenuApi.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\Automate\AutomateIntegration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\Automate\IAutomateApi.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\BaseIntegration.cs" />

--- a/Common/Common.projitems
+++ b/Common/Common.projitems
@@ -12,6 +12,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)CommonHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DataParsers\CropDataParser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DrawHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Integrations\GenericModConfigMenu\GenericModConfigMenuIntegration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Integrations\GenericModConfigMenu\IGenericConfigModApi.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\Automate\AutomateIntegration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\Automate\IAutomateApi.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\BaseIntegration.cs" />

--- a/Common/Integrations/GenericModConfigMenu/GenericModConfigMenuIntegration.cs
+++ b/Common/Integrations/GenericModConfigMenu/GenericModConfigMenuIntegration.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Pathoschild.Stardew.Common.Integrations;
+using StardewModdingAPI;
+
+namespace Common.Integrations.GenericModConfigMenu
+{
+    internal class GenericModMenuIntegraion : BaseIntegration
+    {
+        private readonly IGenericModMenuApi ModApi;
+        public GenericModMenuIntegraion(IModRegistry modRegistry, IMonitor monitor)
+            : base("Generic Mod Config Menu", "spacechase0.GenericModConfigMenu", "1.1.0", modRegistry, monitor)
+        {
+            if (!this.IsLoaded)
+                return;
+            // get mod API
+            this.ModApi = this.GetValidatedApi<IGenericModMenuApi>();
+            this.IsLoaded = this.ModApi != null;
+        }
+
+        public void RegisterModConfig(IManifest mod, Action revertToDefault, Action saveToFile)
+        {
+            this.AssertLoaded();
+            this.ModApi.RegisterModConfig(mod, revertToDefault, saveToFile);
+        }
+
+        public void RegisterLabel(IManifest mod, string labelName, string labelDesc)
+        {
+            this.AssertLoaded();
+            this.ModApi.RegisterLabel(mod, labelName, labelDesc);
+        }
+        public void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<bool> optionGet, Action<bool> optionSet)
+        {
+            this.AssertLoaded();
+            this.ModApi.RegisterSimpleOption(mod, optionName, optionDesc, optionGet, optionSet);
+        }
+        public void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<int> optionGet, Action<int> optionSet)
+        {
+            this.AssertLoaded();
+            this.ModApi.RegisterSimpleOption(mod, optionName, optionDesc, optionGet, optionSet);
+        }
+        public void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<float> optionGet, Action<float> optionSet)
+        {
+            this.AssertLoaded();
+            this.ModApi.RegisterSimpleOption(mod, optionName, optionDesc, optionGet, optionSet);
+        }
+        public void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<string> optionGet, Action<string> optionSet)
+        {
+            this.AssertLoaded();
+            this.ModApi.RegisterSimpleOption(mod, optionName, optionDesc, optionGet, optionSet);
+        }
+        public void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<SButton> optionGet, Action<SButton> optionSet)
+        {
+            this.AssertLoaded();
+            this.ModApi.RegisterSimpleOption(mod, optionName, optionDesc, optionGet, optionSet);
+        }
+
+        public void RegisterClampedOption(IManifest mod, string optionName, string optionDesc, Func<int> optionGet, Action<int> optionSet, int min, int max)
+        {
+            this.AssertLoaded();
+            this.ModApi.RegisterClampedOption(mod, optionName, optionDesc, optionGet, optionSet, min, max);
+        }
+        public void RegisterClampedOption(IManifest mod, string optionName, string optionDesc, Func<float> optionGet, Action<float> optionSet, float min, float max)
+        {
+            this.AssertLoaded();
+            this.ModApi.RegisterClampedOption(mod, optionName, optionDesc, optionGet, optionSet, min, max);
+        }
+        public void RegisterChoiceOption(IManifest mod, string optionName, string optionDesc, Func<string> optionGet, Action<string> optionSet, string[] choices)
+        {
+            this.AssertLoaded();
+            this.ModApi.RegisterChoiceOption(mod, optionName, optionDesc, optionGet, optionSet, choices);
+        }
+
+        public void RegisterComplexOption(IManifest mod, string optionName, string optionDesc, Func<Vector2, object, object> widgetUpdate,
+                                                        Func<SpriteBatch, Vector2, object, object> widgetDraw, Action<object> onSave)
+        {
+            this.AssertLoaded();
+            this.ModApi.RegisterComplexOption(mod, optionName, optionDesc, widgetUpdate, widgetDraw, onSave);
+        }
+    }
+}

--- a/Common/Integrations/GenericModConfigMenu/GenericModConfigMenuIntegration.cs
+++ b/Common/Integrations/GenericModConfigMenu/GenericModConfigMenuIntegration.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Pathoschild.Stardew.Common.Integrations;
@@ -8,16 +6,16 @@ using StardewModdingAPI;
 
 namespace Common.Integrations.GenericModConfigMenu
 {
-    internal class GenericModMenuIntegraion : BaseIntegration
+    internal class GenericModConfigMenuIntegration : BaseIntegration
     {
-        private readonly IGenericModMenuApi ModApi;
-        public GenericModMenuIntegraion(IModRegistry modRegistry, IMonitor monitor)
+        private readonly IGenericModConfigMenuApi ModApi;
+        public GenericModConfigMenuIntegration(IModRegistry modRegistry, IMonitor monitor)
             : base("Generic Mod Config Menu", "spacechase0.GenericModConfigMenu", "1.1.0", modRegistry, monitor)
         {
             if (!this.IsLoaded)
                 return;
             // get mod API
-            this.ModApi = this.GetValidatedApi<IGenericModMenuApi>();
+            this.ModApi = this.GetValidatedApi<IGenericModConfigMenuApi>();
             this.IsLoaded = this.ModApi != null;
         }
 

--- a/Common/Integrations/GenericModConfigMenu/IGenericConfigModApi.cs
+++ b/Common/Integrations/GenericModConfigMenu/IGenericConfigModApi.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
+
+namespace Common.Integrations.GenericModConfigMenu
+{
+    public interface IGenericModMenuApi
+    {
+        void RegisterModConfig(IManifest mod, Action revertToDefault, Action saveToFile);
+
+        void RegisterLabel(IManifest mod, string labelName, string labelDesc);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<bool> optionGet, Action<bool> optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<int> optionGet, Action<int> optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<float> optionGet, Action<float> optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<string> optionGet, Action<string> optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<SButton> optionGet, Action<SButton> optionSet);
+
+        void RegisterClampedOption(IManifest mod, string optionName, string optionDesc, Func<int> optionGet, Action<int> optionSet, int min, int max);
+        void RegisterClampedOption(IManifest mod, string optionName, string optionDesc, Func<float> optionGet, Action<float> optionSet, float min, float max);
+
+        void RegisterChoiceOption(IManifest mod, string optionName, string optionDesc, Func<string> optionGet, Action<string> optionSet, string[] choices);
+
+        void RegisterComplexOption(IManifest mod, string optionName, string optionDesc,
+                                   Func<Vector2, object, object> widgetUpdate,
+                                   Func<SpriteBatch, Vector2, object, object> widgetDraw,
+                                   Action<object> onSave);
+    }
+}

--- a/Common/Integrations/GenericModConfigMenu/IGenericModConfigMenuApi.cs
+++ b/Common/Integrations/GenericModConfigMenu/IGenericModConfigMenuApi.cs
@@ -1,26 +1,15 @@
 using System;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
 
 namespace Common.Integrations.GenericModConfigMenu
 {
+    /// <summary>The API provided by the Generic Mod Config Menu mod.</summary>
     public interface IGenericModConfigMenuApi
     {
         void RegisterModConfig(IManifest mod, Action revertToDefault, Action saveToFile);
-
         void RegisterLabel(IManifest mod, string labelName, string labelDesc);
         void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<bool> optionGet, Action<bool> optionSet);
-        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<int> optionGet, Action<int> optionSet);
-        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<float> optionGet, Action<float> optionSet);
-        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<string> optionGet, Action<string> optionSet);
         void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<SButton> optionGet, Action<SButton> optionSet);
-
         void RegisterClampedOption(IManifest mod, string optionName, string optionDesc, Func<int> optionGet, Action<int> optionSet, int min, int max);
-        void RegisterClampedOption(IManifest mod, string optionName, string optionDesc, Func<float> optionGet, Action<float> optionSet, float min, float max);
-
-        void RegisterChoiceOption(IManifest mod, string optionName, string optionDesc, Func<string> optionGet, Action<string> optionSet, string[] choices);
-
-        void RegisterComplexOption(IManifest mod, string optionName, string optionDesc, Func<Vector2, object, object> widgetUpdate, Func<SpriteBatch, Vector2, object, object> widgetDraw, Action<object> onSave);
     }
 }

--- a/Common/Integrations/GenericModConfigMenu/IGenericModConfigMenuApi.cs
+++ b/Common/Integrations/GenericModConfigMenu/IGenericModConfigMenuApi.cs
@@ -1,13 +1,11 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
 
 namespace Common.Integrations.GenericModConfigMenu
 {
-    public interface IGenericModMenuApi
+    public interface IGenericModConfigMenuApi
     {
         void RegisterModConfig(IManifest mod, Action revertToDefault, Action saveToFile);
 
@@ -23,9 +21,6 @@ namespace Common.Integrations.GenericModConfigMenu
 
         void RegisterChoiceOption(IManifest mod, string optionName, string optionDesc, Func<string> optionGet, Action<string> optionSet, string[] choices);
 
-        void RegisterComplexOption(IManifest mod, string optionName, string optionDesc,
-                                   Func<Vector2, object, object> widgetUpdate,
-                                   Func<SpriteBatch, Vector2, object, object> widgetDraw,
-                                   Action<object> onSave);
+        void RegisterComplexOption(IManifest mod, string optionName, string optionDesc, Func<Vector2, object, object> widgetUpdate, Func<SpriteBatch, Vector2, object, object> widgetDraw, Action<object> onSave);
     }
 }

--- a/Pathoschild.Stardew.sln
+++ b/Pathoschild.Stardew.sln
@@ -63,10 +63,12 @@ Global
 		Common\Common.projitems*{7c05ff17-e7aa-485a-a0e9-bab0248cf653}*SharedItemsImports = 5
 		Common\Common.projitems*{7cd586e4-e766-494a-a06f-abac3e0e6c90}*SharedItemsImports = 5
 		Common\Common.projitems*{81b42938-5567-469b-8b92-56e006df588d}*SharedItemsImports = 5
+		Common\Common.projitems*{8fe9bd36-31eb-4a47-9c98-c216ff361664}*SharedItemsImports = 5
 		Common\Common.projitems*{9eecb232-2178-4101-9397-cfb885bc25f2}*SharedItemsImports = 5
 		Common\Common.projitems*{b9e9edfc-e98a-4370-994f-40a9f39a0284}*SharedItemsImports = 13
 		Common\Common.projitems*{ddf905ed-320b-48af-91a5-2a5563f256fa}*SharedItemsImports = 5
 		Common\Common.projitems*{ef4f1a38-6601-4441-b7b1-e9c26b312192}*SharedItemsImports = 5
+		Common\Common.projitems*{ef6d963f-fbc1-444a-b481-b8ca9c034fbc}*SharedItemsImports = 5
 		Common\Common.projitems*{f2c606b1-51d2-48f3-9cf7-2f8cd46daff9}*SharedItemsImports = 5
 		Common\Common.projitems*{fca458cf-d872-47b7-9048-403c56a20905}*SharedItemsImports = 5
 	EndGlobalSection

--- a/TractorMod/Framework/GenericModConfigMenuIntegrationForTractor.cs
+++ b/TractorMod/Framework/GenericModConfigMenuIntegrationForTractor.cs
@@ -11,54 +11,49 @@ namespace Pathoschild.Stardew.TractorMod.Framework
         /*********
         ** Fields
         *********/
+        /// <summary>The Generic Mod Config Menu integration.</summary>
+        private readonly GenericModConfigMenuIntegration<ModConfig> ConfigMenu;
+
         /// <summary>Get the current config model.</summary>
         private readonly Func<ModConfig> GetConfig;
-
-        /// <summary>Reset the config model to the default values.</summary>
-        private readonly Action Reset;
-
-        /// <summary>Save and apply the current config model.</summary>
-        private readonly Action SaveAndApply;
 
 
         /*********
         ** Public methods
         *********/
         /// <summary>Construct an instance.</summary>
-        /// <param name="getConfig">Get the current config model.</param>
-        /// <param name="reset">Reset the config model to the default values.</param>
-        /// <param name="saveAndApply">Save and apply the current config model.</param>
-        public GenericModConfigMenuIntegrationForTractor(Func<ModConfig> getConfig, Action reset, Action saveAndApply)
-        {
-            this.GetConfig = getConfig;
-            this.Reset = reset;
-            this.SaveAndApply = saveAndApply;
-        }
-
-        /// <summary>Register the config menu if available.</summary>
         /// <param name="modRegistry">An API for fetching metadata about loaded mods.</param>
         /// <param name="monitor">Encapsulates monitoring and logging.</param>
         /// <param name="manifest">The mod manifest.</param>
-        public void Register(IModRegistry modRegistry, IMonitor monitor, IManifest manifest)
+        /// <param name="getConfig">Get the current config model.</param>
+        /// <param name="reset">Reset the config model to the default values.</param>
+        /// <param name="saveAndApply">Save and apply the current config model.</param>
+        public GenericModConfigMenuIntegrationForTractor(IModRegistry modRegistry, IMonitor monitor, IManifest manifest, Func<ModConfig> getConfig, Action reset, Action saveAndApply)
         {
-            GenericModConfigMenuIntegration configMenu = new GenericModConfigMenuIntegration(modRegistry, monitor);
-            if (!configMenu.IsLoaded)
+            this.ConfigMenu = new GenericModConfigMenuIntegration<ModConfig>(modRegistry, monitor, manifest, getConfig, reset, saveAndApply);
+            this.GetConfig = getConfig;
+        }
+
+        /// <summary>Register the config menu if available.</summary>
+        public void Register()
+        {
+            var menu = this.ConfigMenu;
+            if (!menu.IsLoaded)
                 return;
 
-            configMenu.RegisterModConfig(manifest, this.Reset, this.SaveAndApply);
-            configMenu.RegisterLabel(manifest, "Basic Config Options", "Config Options");
+            menu
+                .RegisterConfig()
+                .AddLabel("Basic Config Options", "Config Options")
+                .AddLabel("", "");
 
-            configMenu.RegisterLabel(manifest, "", "");
             Regex r = new Regex(@"(?<=[A-Z])(?=[A-Z][a-z])|(?<=[^A-Z])(?=[A-Z])|(?<=[A-Za-z])(?=[^A-Za-z])");
 
-            var config = this.GetConfig;
-            foreach (var property in config().GetType().GetProperties())
+            foreach (var property in this.GetConfig().GetType().GetProperties())
             {
                 string label = r.Replace(property.Name, " ");
                 if (property.PropertyType == typeof(bool))
-                {
-                    configMenu.RegisterSimpleOption(manifest, label, "", () => (bool)property.GetValue(config(), null), (bool val) => property.SetValue(config(), val, null));
-                }
+                    menu.AddCheckbox(label, "", config => (bool)property.GetValue(config, null), (config, val) => property.SetValue(config, val, null));
+
                 else if (property.PropertyType == typeof(int))
                 {
                     //Don't do anything with the price
@@ -71,23 +66,23 @@ namespace Pathoschild.Stardew.TractorMod.Framework
                         if (property.Name == defaultProperty.Name)
                         {
                             int defaultValue = (int)defaultProperty.GetValue(defaultValues);
-                            configMenu.RegisterClampedOption(manifest, label, "", () => (int)property.GetValue(config(), null), (int val) => property.SetValue(config(), val, null), defaultValue, Math.Abs(defaultValue * 15));
+                            menu.AddNumberField(label, "", config => (int)property.GetValue(config, null), (config, val) => property.SetValue(config, val, null), defaultValue, Math.Abs(defaultValue * 15));
                         }
                     }
 
                 }
             }
 
-            configMenu.RegisterLabel(manifest, "Tool Config Options", "Config Options");
-            foreach (var field in config().StandardAttachments.GetType().GetFields())
+            menu.AddLabel("Tool Config Options", "Config Options");
+            foreach (var field in this.GetConfig().StandardAttachments.GetType().GetFields())
             {
                 string label = r.Replace(field.Name, " ");
-                configMenu.RegisterLabel(manifest, label, "Config Options");
-                object subValue = field.GetValue(config().StandardAttachments);
+                menu.AddLabel(label, "Config Options");
+                object subValue = field.GetValue(this.GetConfig().StandardAttachments);
                 foreach (var property in field.FieldType.GetProperties())
                 {
                     label = r.Replace(property.Name, " ");
-                    configMenu.RegisterSimpleOption(manifest, label, "", () => (bool)property.GetValue(subValue), (bool val) => property.SetValue(subValue, val, null));
+                    menu.AddCheckbox(label, "", config => (bool)property.GetValue(subValue), (config, val) => property.SetValue(subValue, val, null));
                 }
             }
         }

--- a/TractorMod/Framework/GenericModConfigMenuIntegrationForTractor.cs
+++ b/TractorMod/Framework/GenericModConfigMenuIntegrationForTractor.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Text.RegularExpressions;
+using Common.Integrations.GenericModConfigMenu;
+using StardewModdingAPI;
+
+namespace Pathoschild.Stardew.TractorMod.Framework
+{
+    /// <summary>Registers the mod configuration with Generic Mod Config Menu.</summary>
+    internal class GenericModConfigMenuIntegrationForTractor
+    {
+        /*********
+        ** Fields
+        *********/
+        /// <summary>Get the current config model.</summary>
+        private readonly Func<ModConfig> GetConfig;
+
+        /// <summary>Reset the config model to the default values.</summary>
+        private readonly Action Reset;
+
+        /// <summary>Save and apply the current config model.</summary>
+        private readonly Action SaveAndApply;
+
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="getConfig">Get the current config model.</param>
+        /// <param name="reset">Reset the config model to the default values.</param>
+        /// <param name="saveAndApply">Save and apply the current config model.</param>
+        public GenericModConfigMenuIntegrationForTractor(Func<ModConfig> getConfig, Action reset, Action saveAndApply)
+        {
+            this.GetConfig = getConfig;
+            this.Reset = reset;
+            this.SaveAndApply = saveAndApply;
+        }
+
+        /// <summary>Register the config menu if available.</summary>
+        /// <param name="modRegistry">An API for fetching metadata about loaded mods.</param>
+        /// <param name="monitor">Encapsulates monitoring and logging.</param>
+        /// <param name="manifest">The mod manifest.</param>
+        public void Register(IModRegistry modRegistry, IMonitor monitor, IManifest manifest)
+        {
+            GenericModConfigMenuIntegration configMenu = new GenericModConfigMenuIntegration(modRegistry, monitor);
+            if (!configMenu.IsLoaded)
+                return;
+
+            configMenu.RegisterModConfig(manifest, this.Reset, this.SaveAndApply);
+            configMenu.RegisterLabel(manifest, "Basic Config Options", "Config Options");
+
+            configMenu.RegisterLabel(manifest, "", "");
+            Regex r = new Regex(@"(?<=[A-Z])(?=[A-Z][a-z])|(?<=[^A-Z])(?=[A-Z])|(?<=[A-Za-z])(?=[^A-Za-z])");
+
+            var config = this.GetConfig;
+            foreach (var property in config().GetType().GetProperties())
+            {
+                string label = r.Replace(property.Name, " ");
+                if (property.PropertyType == typeof(bool))
+                {
+                    configMenu.RegisterSimpleOption(manifest, label, "", () => (bool)property.GetValue(config(), null), (bool val) => property.SetValue(config(), val, null));
+                }
+                else if (property.PropertyType == typeof(int))
+                {
+                    //Don't do anything with the price
+                    if (property.Name.Contains("Price"))
+                        continue;
+
+                    var defaultValues = new ModConfig();
+                    foreach (var defaultProperty in defaultValues.GetType().GetProperties())
+                    {
+                        if (property.Name == defaultProperty.Name)
+                        {
+                            int defaultValue = (int)defaultProperty.GetValue(defaultValues);
+                            configMenu.RegisterClampedOption(manifest, label, "", () => (int)property.GetValue(config(), null), (int val) => property.SetValue(config(), val, null), defaultValue, Math.Abs(defaultValue * 15));
+                        }
+                    }
+
+                }
+            }
+
+            configMenu.RegisterLabel(manifest, "Tool Config Options", "Config Options");
+            foreach (var field in config().StandardAttachments.GetType().GetFields())
+            {
+                string label = r.Replace(field.Name, " ");
+                configMenu.RegisterLabel(manifest, label, "Config Options");
+                object subValue = field.GetValue(config().StandardAttachments);
+                foreach (var property in field.FieldType.GetProperties())
+                {
+                    label = r.Replace(property.Name, " ");
+                    configMenu.RegisterSimpleOption(manifest, label, "", () => (bool)property.GetValue(subValue), (bool val) => property.SetValue(subValue, val, null));
+                }
+            }
+        }
+    }
+}

--- a/TractorMod/ModEntry.cs
+++ b/TractorMod/ModEntry.cs
@@ -178,9 +178,12 @@ namespace Pathoschild.Stardew.TractorMod
                     this.Config = new ModConfig();
                     this.Helper.WriteConfig(this.Config);
                 },
-                saveAndApply: () => this.Helper.WriteConfig(this.Config)
+                saveAndApply: () => this.Helper.WriteConfig(this.Config),
+                modRegistry: this.Helper.ModRegistry,
+                monitor: this.Monitor,
+                manifest: this.ModManifest
             );
-            configMenu.Register(this.Helper.ModRegistry, this.Monitor, this.ModManifest);
+            configMenu.Register();
         }
 
         /// <summary>The event called after a save slot is loaded.</summary>

--- a/TractorMod/ModEntry.cs
+++ b/TractorMod/ModEntry.cs
@@ -171,24 +171,21 @@ namespace Pathoschild.Stardew.TractorMod
                 farmExpansion.AddFarmBluePrint(this.GetBlueprint());
                 farmExpansion.AddExpansionBluePrint(this.GetBlueprint());
             }
-            GenericModMenuIntegraion genericModConfigMenu = new GenericModMenuIntegraion(this.Helper.ModRegistry, this.Monitor);
-            if (genericModConfigMenu.IsLoaded)
-            {
-                this.CreateMenu(genericModConfigMenu);
-            }
+            var configMenu = new GenericModConfigMenuIntegration(this.Helper.ModRegistry, this.Monitor);
+            if (configMenu.IsLoaded)
+                this.CreateMenu(configMenu);
         }
 
         /// <summary>
         /// Creates the home screen config menu
         /// </summary>
-        /// <param name="genericModConfigMenu">Integration for the Generic Mod Config Menu API</param>
-        public void CreateMenu(GenericModMenuIntegraion genericModConfigMenu)
+        /// <param name="configMenu">Integration for the Generic Mod Config Menu API</param>
+        public void CreateMenu(GenericModConfigMenuIntegration configMenu)
         {
+            configMenu.RegisterModConfig(this.ModManifest, () => this.Config = new ModConfig(), () => this.Helper.WriteConfig(this.Config));
+            configMenu.RegisterLabel(this.ModManifest, "Basic Config Options", "Config Options");
 
-            genericModConfigMenu.RegisterModConfig(this.ModManifest, () => this.Config = new ModConfig(), () => this.Helper.WriteConfig(this.Config));
-            genericModConfigMenu.RegisterLabel(this.ModManifest, "Basic Config Options", "Config Options");
-
-            genericModConfigMenu.RegisterLabel(this.ModManifest, "", "");
+            configMenu.RegisterLabel(this.ModManifest, "", "");
             Regex r = new Regex(@"(?<=[A-Z])(?=[A-Z][a-z])|(?<=[^A-Z])(?=[A-Z])|(?<=[A-Za-z])(?=[^A-Za-z])");
 
             foreach (var property in this.Config.GetType().GetProperties())
@@ -196,7 +193,7 @@ namespace Pathoschild.Stardew.TractorMod
                 string label = r.Replace(property.Name, " ");
                 if (property.PropertyType == typeof(bool))
                 {
-                    genericModConfigMenu.RegisterSimpleOption(this.ModManifest, label, "", () => (bool)property.GetValue(this.Config, null), (bool val) => property.SetValue(this.Config, val, null));
+                    configMenu.RegisterSimpleOption(this.ModManifest, label, "", () => (bool)property.GetValue(this.Config, null), (bool val) => property.SetValue(this.Config, val, null));
                 }
                 else if (property.PropertyType == typeof(int))
                 {
@@ -210,23 +207,23 @@ namespace Pathoschild.Stardew.TractorMod
                         if (property.Name == defaultProperty.Name)
                         {
                             int defaultValue = (int)defaultProperty.GetValue(defaultValues);
-                            genericModConfigMenu.RegisterClampedOption(this.ModManifest, label, "", () => (int)property.GetValue(this.Config, null), (int val) => property.SetValue(this.Config, val, null), defaultValue, Math.Abs(defaultValue * 15));
+                            configMenu.RegisterClampedOption(this.ModManifest, label, "", () => (int)property.GetValue(this.Config, null), (int val) => property.SetValue(this.Config, val, null), defaultValue, Math.Abs(defaultValue * 15));
                         }
                     }
 
                 }
             }
 
-            genericModConfigMenu.RegisterLabel(this.ModManifest, "Tool Config Options", "Config Options");
+            configMenu.RegisterLabel(this.ModManifest, "Tool Config Options", "Config Options");
             foreach (var field in this.Config.StandardAttachments.GetType().GetFields())
             {
                 string label = r.Replace(field.Name, " ");
-                genericModConfigMenu.RegisterLabel(this.ModManifest, label, "Config Options");
+                configMenu.RegisterLabel(this.ModManifest, label, "Config Options");
                 object subValue = field.GetValue(this.Config.StandardAttachments);
                 foreach (var property in field.FieldType.GetProperties())
                 {
                     label = r.Replace(property.Name, " ");
-                    genericModConfigMenu.RegisterSimpleOption(this.ModManifest, label, "", () => (bool)property.GetValue(subValue), (bool val) => property.SetValue(subValue, val, null));
+                    configMenu.RegisterSimpleOption(this.ModManifest, label, "", () => (bool)property.GetValue(subValue), (bool val) => property.SetValue(subValue, val, null));
                 }
             }
         }

--- a/TractorMod/ModEntry.cs
+++ b/TractorMod/ModEntry.cs
@@ -173,7 +173,11 @@ namespace Pathoschild.Stardew.TractorMod
             // add Generic Mod Config Menu integration
             var configMenu = new GenericModConfigMenuIntegrationForTractor(
                 getConfig: () => this.Config,
-                reset: () => this.Helper.WriteConfig(this.Config),
+                reset: () =>
+                {
+                    this.Config = new ModConfig();
+                    this.Helper.WriteConfig(this.Config);
+                },
                 saveAndApply: () => this.Helper.WriteConfig(this.Config)
             );
             configMenu.Register(this.Helper.ModRegistry, this.Monitor, this.ModManifest);

--- a/TractorMod/release-notes.md
+++ b/TractorMod/release-notes.md
@@ -1,6 +1,6 @@
 # Release notes
 ## Upcoming release
-
+* Added support for Generic Mod Config Menu (thanks to collaboration with NexusFlight!).
 * Added compatibility with boulders and stumps added by Farm Type Manager.
 
 ## 4.10.1


### PR DESCRIPTION
After our quick discussion on the other pull request
I used Generic Mod Config Menu to create a title screen config menu for Tractor Mod
The integers(Distance,Tractor Speed, Magnetic Radius) are limited from their default value up to * 15
This allowed the code I wrote to stay generic enough that i can be applied to all of them and Distance does not go over 15 (To stay within the performance bounds you talk about in the readme.)
I once again left out price and build materials, as if you are going to cheat that you may as well turn on summon without garage.
 
![image](https://user-images.githubusercontent.com/25351253/83287942-7a98d400-a1da-11ea-8315-5489d99784cf.png)
