### PR TITLE
[Content Patcher] Allow unloading top-level patches

### DIFF
--- a/ContentPatcher/Framework/PatchLoader.cs
+++ b/ContentPatcher/Framework/PatchLoader.cs
@@ -116,6 +116,22 @@ namespace ContentPatcher.Framework
                 this.PatchManager.Reindex(patchListChanged: true);
         }
 
+        /// <summary>Unload patches loaded (directly or indirectly) by the given content pack.</summary>
+        /// <param name="pack">The content pack for which to unload descendants.</param>
+        /// <param name="reindex">Whether to reindex the patch list immediately.</param>
+        public void UnloadPatchesLoadedBy(RawContentPack pack, bool reindex)
+        {
+            var patches = new List<IPatch>(this.PatchManager.GetPatches());
+            foreach (var patch in patches)
+            {
+                if ( patch.ContentPack == pack.ManagedPack )
+                    this.PatchManager.Remove(patch, reindex: false);
+            }
+
+            if (reindex)
+                this.PatchManager.Reindex(patchListChanged: true);
+        }
+
         /// <summary>Normalize and parse the given condition values.</summary>
         /// <param name="raw">The raw condition values to normalize.</param>
         /// <param name="tokenParser">Handles low-level parsing and validation for tokens.</param>

--- a/ContentPatcher/Framework/PatchManager.cs
+++ b/ContentPatcher/Framework/PatchManager.cs
@@ -208,7 +208,7 @@ namespace ContentPatcher.Framework
                 bool isReady = patch.IsReady;
 
                 // track patches to reload
-                bool reload = (wasReady && changed) || (!wasReady && isReady);
+                bool reload = (wasReady && changed) || (!wasReady && isReady) || (isReady && !patch.IsApplied);
                 if (reload)
                 {
                     patch.IsApplied = false;

--- a/ContentPatcher/ModEntry.cs
+++ b/ContentPatcher/ModEntry.cs
@@ -84,6 +84,9 @@ namespace ContentPatcher
         /// <summary>Whether the next tick is the first one.</summary>
         private bool IsFirstTick = true;
 
+        /// <summary>The list of raw content packs.</summary>
+        private readonly List<RawContentPack> RawContentPacks = new List<RawContentPack>();
+
 
         /*********
         ** Public methods
@@ -253,7 +256,7 @@ namespace ContentPatcher
             helper.Events.Specialized.LoadStageChanged += this.OnLoadStageChanged;
 
             // set up commands
-            this.CommandHandler = new CommandHandler(this.TokenManager, this.PatchManager, this.Monitor, modID => modID == null ? this.TokenManager : this.TokenManager.GetContextFor(modID), () => this.UpdateContext());
+            this.CommandHandler = new CommandHandler(this.TokenManager, this.PatchManager, this.PatchLoader, this.Monitor, this.RawContentPacks, modID => modID == null ? this.TokenManager : this.TokenManager.GetContextFor(modID), () => this.UpdateContext());
             helper.ConsoleCommands.Add(this.CommandHandler.CommandName, $"Starts a Content Patcher command. Type '{this.CommandHandler.CommandName} help' for details.", (name, args) => this.CommandHandler.Handle(args));
 
             // can no longer queue tokens
@@ -434,6 +437,9 @@ namespace ContentPatcher
 
                     // load patches
                     this.PatchLoader.LoadPatches(current, content.Changes, path, reindex: false, parentPatch: null);
+
+                    // add to content pack list
+                    this.RawContentPacks.Add(current);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Ability to unload a whole content pack.
Added `patch reload` command, to reload an entire content pack. (Patches only, config schema and dynamic tokens unsupported.) Mainly for testing this. I can take it out if you don't want it in for whatever reason (like not supporting the other two things.)

I made my VS2017 changes a separate commit so this PR's commit could easily be cherry-picked. I don't know enough about git to get just this commit onto the branch after the fact. :P