### PR TITLE
[Lookup Anything] show current quests that need an item in the 'needed for' field

### DIFF
--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -480,23 +480,6 @@ namespace Pathoschild.Stardew.LookupAnything
             return recipes.ToArray();
         }
 
-        /// <summary>Get items needed to complete current quests.</summary>
-        public QuestModel[] GetQuests()
-        {
-            var quests = new List<QuestModel>();
-
-            // information found in StardewValley.Farmer.hasNewQuestActivity
-
-            // help wanted quests
-            quests.AddRange(Game1.player.questLog
-                .Select(q => new QuestModel(q)));
-
-            // special orders
-            quests.AddRange(Game1.player.team.specialOrders
-                .Select(q => new QuestModel(q)));
-
-            return quests.ToArray();
-        }
 
         /*********
         ** Private methods

--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -480,6 +480,24 @@ namespace Pathoschild.Stardew.LookupAnything
             return recipes.ToArray();
         }
 
+        /// <summary>Get items needed to complete current quests.</summary>
+        public QuestModel[] GetQuests()
+        {
+            var quests = new List<QuestModel>();
+
+            // information found in StardewValley.Farmer.hasNewQuestActivity
+
+            // help wanted quests
+            quests.AddRange(Game1.player.questLog
+                .Select(q => new QuestModel(q)));
+
+            // special orders
+            quests.AddRange(Game1.player.team.specialOrders
+                .Select(q => new QuestModel(q)));
+
+            return quests.ToArray();
+        }
+
         /*********
         ** Private methods
         *********/

--- a/LookupAnything/Framework/I18n.cs
+++ b/LookupAnything/Framework/I18n.cs
@@ -1794,7 +1794,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework
             return I18n.GetByKey("item.needed-for.craft-master", new { recipes });
         }
 
-        /// <summary>Get a translation equivalent to "quests ({{quests}})".</summary>
+        /// <summary>Get a translation equivalent to "current quests ({{quests}})".</summary>
         /// <param name="quests">The value to inject for the <c>{{quests}}</c> token.</param>
         public static string Item_NeededFor_Quests(object quests)
         {
@@ -2729,7 +2729,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework
             return I18n.GetByKey("tree.stage.partial", new { stageName, step, max });
         }
 
-        /// <summary>Get a translation equivalent to "can't grow in winter outside greenhouse".</summary>
+        /// <summary>Get a translation equivalent to "can't grow in winter outside greenhouse unless fertilized".</summary>
         public static string Tree_NextGrowth_Winter()
         {
             return I18n.GetByKey("tree.next-growth.winter");

--- a/LookupAnything/Framework/I18n.cs
+++ b/LookupAnything/Framework/I18n.cs
@@ -1794,6 +1794,13 @@ namespace Pathoschild.Stardew.LookupAnything.Framework
             return I18n.GetByKey("item.needed-for.craft-master", new { recipes });
         }
 
+        /// <summary>Get a translation equivalent to "quests ({{quests}})".</summary>
+        /// <param name="quests">The value to inject for the <c>{{quests}}</c> token.</param>
+        public static string Item_NeededFor_Quests(object quests)
+        {
+            return I18n.GetByKey("item.needed-for.quests", new { quests });
+        }
+
         /// <summary>Get a translation equivalent to "shipping box".</summary>
         public static string Item_SellsTo_ShippingBox()
         {

--- a/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
+++ b/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
@@ -673,6 +673,15 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Items
                     neededFor.Add(I18n.Item_NeededFor_CraftMaster(recipes: string.Join(", ", uncraftedNames)));
             }
 
+            // quests
+            string[] quests = this.GameHelper.GetQuests()
+                .Where(q => q != null && !string.IsNullOrWhiteSpace(q.DisplayText) && q.NeedsItems)
+                .Where(q => q.IsValidItem(obj))
+                .OrderBy(q => q.DisplayText)
+                .Select(q => q.DisplayText).ToArray();
+            if (quests.Any())
+                neededFor.Add(I18n.Item_NeededFor_Quests(quests: string.Join(", ", quests)));
+
             // yield
             if (neededFor.Any())
                 yield return new GenericField(I18n.Item_NeededFor(), string.Join(", ", neededFor));

--- a/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
+++ b/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
@@ -674,13 +674,15 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Items
             }
 
             // quests
-            string[] quests = this.GameHelper.GetQuests()
-                .Where(q => q != null && !string.IsNullOrWhiteSpace(q.DisplayText) && q.NeedsItems)
-                .Where(q => q.IsValidItem(obj))
-                .OrderBy(q => q.DisplayText)
-                .Select(q => q.DisplayText).ToArray();
-            if (quests.Any())
-                neededFor.Add(I18n.Item_NeededFor_Quests(quests: string.Join(", ", quests)));
+            {
+                string[] quests = this.GameHelper
+                    .GetQuestsWhichNeedItem(obj)
+                    .Select(p => p.DisplayText)
+                    .OrderBy(p => p)
+                    .ToArray();
+                if (quests.Any())
+                    neededFor.Add(I18n.Item_NeededFor_Quests(quests: string.Join(", ", quests)));
+            }
 
             // yield
             if (neededFor.Any())

--- a/LookupAnything/Framework/Models/QuestModel.cs
+++ b/LookupAnything/Framework/Models/QuestModel.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Pathoschild.Stardew.Common;
+using Pathoschild.Stardew.Common.Items.ItemData;
+using StardewValley;
+using StardewValley.Quests;
+using SObject = StardewValley.Object;
+
+namespace Pathoschild.Stardew.LookupAnything.Framework.Models
+{
+    /// <summary>A quest model.</summary>
+    internal class QuestModel
+    {
+        /*********
+        ** Accessors
+        *********/
+        /// <summary>The display text for the quest name.</summary>
+        public string DisplayText { get; }
+
+        /// <summary>Whether any items are needed to complete this quest..</summary>
+        public bool NeedsItems { get; }
+
+        /// <summary>The checks for whether an item is valid for this quest.</summary>
+        private readonly List<Func<Item, bool>> ItemValidChecks;
+
+        /// <summary>Construct a new quest model from a Quest.</summary>
+        /// <param name="quest">The Quest.</param>
+        public QuestModel(Quest quest)
+        {
+            this.DisplayText = quest.GetName();
+            this.ItemValidChecks = new List<Func<Item, bool>>();
+
+            // add checks for valid items
+            this.NeedsItems = true;
+            switch (quest)
+            {
+                case CraftingQuest specificQuest:
+                    this.ItemValidChecks.Add(i =>
+                        this.IsItemMatch(specificQuest.indexToCraft.Value, specificQuest.isBigCraftable.Value, i));
+                    break;
+                case ItemDeliveryQuest specificQuest:
+                    this.ItemValidChecks.Add(i =>
+                        this.IsItemMatch(specificQuest.item.Value, false, i));
+                    break;
+                case ItemHarvestQuest specificQuest:
+                    this.ItemValidChecks.Add(i =>
+                        this.IsItemMatch(specificQuest.itemIndex.Value, false, i));
+                    break;
+                case LostItemQuest specificQuest:
+                    this.ItemValidChecks.Add(i =>
+                        this.IsItemMatch(specificQuest.itemIndex.Value, false, i));
+                    break;
+                case ResourceCollectionQuest specificQuest:
+                    this.ItemValidChecks.Add(i =>
+                        this.IsItemMatch(specificQuest.resource.Value, false, i));
+                    break;
+                case SecretLostItemQuest specificQuest:
+                    this.ItemValidChecks.Add(i =>
+                        this.IsItemMatch(specificQuest.itemIndex.Value, false, i));
+                    break;
+                default:
+                    this.NeedsItems = false;
+                    break;
+            }
+        }
+
+        /// <summary>Construct a new quest model from a Special Order.</summary>
+        /// <param name="specialOrder">The Special Order.</param>
+        public QuestModel(SpecialOrder specialOrder)
+        {
+            this.DisplayText = specialOrder.GetName();
+            this.ItemValidChecks = new List<Func<Item, bool>>();
+
+            // add checks for valid items
+            this.NeedsItems = true;
+            foreach (OrderObjective objective in specialOrder.objectives)
+            {
+                switch (objective)
+                {
+                    case CollectObjective specificObjective:
+                        this.ItemValidChecks.Add(i =>
+                            this.IsValidItem(i, specificObjective.acceptableContextTagSets));
+                        break;
+                    case DeliverObjective specificObjective:
+                        this.ItemValidChecks.Add(i =>
+                            this.IsValidItem(i, specificObjective.acceptableContextTagSets));
+                        break;
+                    case DonateObjective specificObjective:
+                        this.ItemValidChecks.Add(specificObjective.IsValidItem);
+                        break;
+                    case FishObjective specificObjective:
+                        this.ItemValidChecks.Add(i =>
+                            this.IsValidItem(i, specificObjective.acceptableContextTagSets));
+                        break;
+                    case GiftObjective specificObjective:
+                        this.ItemValidChecks.Add(i =>
+                            this.IsValidItem(i, specificObjective.acceptableContextTagSets));
+                        break;
+                    case ShipObjective specificObjective:
+                        this.ItemValidChecks.Add(i =>
+                            this.IsValidItem(i, specificObjective.acceptableContextTagSets));
+                        break;
+                    default:
+                        this.NeedsItems = false;
+                        break;
+                }
+            }
+        }
+
+        /// <summary>Check whether an object is valid for this quest model.</summary>
+        /// <param name="obj">The object.</param>
+        public bool IsValidItem(SObject obj)
+        {
+            return this.ItemValidChecks.Any(f => f(obj));
+        }
+
+        /// <summary>Check whether an item is valid for this quest model.</summary>
+        /// <param name="item">The item.</param>
+        /// <param name="acceptableContextTagSets">The Special Order objective's acceptable context tag sets.</param>
+        /// <remarks>Based on <see cref="StardewValley.DonateObjective.IsValidItem"/>.</remarks>
+        private bool IsValidItem(Item item, IEnumerable<string> acceptableContextTagSets)
+        {
+            if (item == null)
+                return false;
+            foreach (string acceptableContextTagSet in acceptableContextTagSets)
+            {
+                bool flag1 = false;
+                char[] chArray1 = new char[1] {','};
+                foreach (string str1 in acceptableContextTagSet.Split(chArray1))
+                {
+                    bool flag2 = false;
+                    char[] chArray2 = new char[1] {'/'};
+                    foreach (string str2 in str1.Split(chArray2))
+                    {
+                        if (item.HasContextTag(str2.Trim()))
+                        {
+                            flag2 = true;
+                            break;
+                        }
+                    }
+
+                    if (!flag2)
+                        flag1 = true;
+                }
+
+                if (!flag1)
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>Check if itemA is the same item as itemB.</summary>
+        /// <param name="itemAIndex">The index for itemA.</param>
+        /// <param name="isItemABigCraftable">Whether itemA is a BigCraftable.</param>
+        /// <param name="itemB">The other item.</param>
+        private bool IsItemMatch(int itemAIndex, bool isItemABigCraftable, Item itemB)
+        {
+            bool isSameIndex = itemAIndex == itemB.ParentSheetIndex;
+            bool isItemBBigCraftable = itemB.GetItemType() == ItemType.BigCraftable;
+            return isSameIndex && isItemABigCraftable == isItemBBigCraftable;
+        }
+    }
+}

--- a/LookupAnything/GameHelper.cs
+++ b/LookupAnything/GameHelper.cs
@@ -377,6 +377,12 @@ namespace Pathoschild.Stardew.LookupAnything
             }
         }
 
+        /// <summary>Get items needed to complete current quests.</summary>
+        public IEnumerable<QuestModel> GetQuests()
+        {
+            return this.DataParser.GetQuests();
+        }
+
         /// <summary>Get an object by its parent sprite index.</summary>
         /// <param name="index">The parent sprite index.</param>
         /// <param name="stack">The number of items in the stack.</param>

--- a/LookupAnything/GameHelper.cs
+++ b/LookupAnything/GameHelper.cs
@@ -377,10 +377,25 @@ namespace Pathoschild.Stardew.LookupAnything
             }
         }
 
-        /// <summary>Get items needed to complete current quests.</summary>
-        public IEnumerable<QuestModel> GetQuests()
+        /// <summary>Get the current quests which need an item.</summary>
+        /// <param name="item">The item to check.</param>
+        public IEnumerable<QuestModel> GetQuestsWhichNeedItem(SObject item)
         {
-            return this.DataParser.GetQuests();
+            // get all quests
+            var quests =
+                Game1.player.questLog.Select(quest => new QuestModel(quest))
+                .Concat(Game1.player.team.specialOrders.Select(order => new QuestModel(order)));
+
+            // get matching quests
+            foreach (QuestModel quest in quests)
+            {
+                bool needsItem =
+                    !string.IsNullOrWhiteSpace(quest.DisplayText)
+                    && quest.NeedsItem(item);
+
+                if (needsItem)
+                    yield return quest;
+            }
         }
 
         /// <summary>Get an object by its parent sprite index.</summary>

--- a/LookupAnything/i18n/de.json
+++ b/LookupAnything/i18n/de.json
@@ -382,6 +382,7 @@
     "item.needed-for.full-collection": "\"Eine vollständige Sammlung\" Errungenschaft (Spende eines dem Museum)",
     "item.needed-for.gourmet-chef": "\"Gourmetkoch\" Errungenschaft (koche {{recipes}})",
     "item.needed-for.craft-master": "\"Handwerksmeister\" Errungenschaft (stelle {{recipes}} her)",
+    "item.needed-for.quests": "current quests ({{quests}})", // TODO
     "item.sells-to.shipping-box": "Versandkiste",
     "item.recipes-for-ingredient.entry": "{{name}} (braucht {{count}})",
     "item.recipes-for-machine.multiple-items": "{{name}} x{{count}}",

--- a/LookupAnything/i18n/default.json
+++ b/LookupAnything/i18n/default.json
@@ -382,7 +382,7 @@
     "item.needed-for.full-collection": "full collection achievement (donate one to museum)",
     "item.needed-for.gourmet-chef": "gourmet chef achievement (cook {{recipes}})",
     "item.needed-for.craft-master": "craft master achievement (make {{recipes}})",
-    "item.needed-for.quests": "quests ({{quests}})",
+    "item.needed-for.quests": "current quests ({{quests}})",
     "item.sells-to.shipping-box": "shipping box",
     "item.recipes-for-ingredient.entry": "{{name}} (needs {{count}})",
     "item.recipes-for-machine.multiple-items": "{{name}} x{{count}}",

--- a/LookupAnything/i18n/default.json
+++ b/LookupAnything/i18n/default.json
@@ -382,6 +382,7 @@
     "item.needed-for.full-collection": "full collection achievement (donate one to museum)",
     "item.needed-for.gourmet-chef": "gourmet chef achievement (cook {{recipes}})",
     "item.needed-for.craft-master": "craft master achievement (make {{recipes}})",
+    "item.needed-for.quests": "quests ({{quests}})",
     "item.sells-to.shipping-box": "shipping box",
     "item.recipes-for-ingredient.entry": "{{name}} (needs {{count}})",
     "item.recipes-for-machine.multiple-items": "{{name}} x{{count}}",

--- a/LookupAnything/i18n/es.json
+++ b/LookupAnything/i18n/es.json
@@ -382,6 +382,7 @@
     "item.needed-for.full-collection": "Logro de ''full collection'' (donar esto al museo)",
     "item.needed-for.gourmet-chef": "Logro de ''gourmet chef'' (cocina {{recipes}})",
     "item.needed-for.craft-master": "Logro de ''craft master'' (crea {{recipes}})",
+    "item.needed-for.quests": "current quests ({{quests}})", // TODO
     "item.sells-to.shipping-box": "Caja de envío",
     "item.recipes-for-ingredient.entry": "{{name}} (necesita {{count}})",
     "item.recipes-for-machine.multiple-items": "{{name}} x {{count}}",

--- a/LookupAnything/i18n/fr.json
+++ b/LookupAnything/i18n/fr.json
@@ -382,6 +382,7 @@
     "item.needed-for.full-collection": "succès collection complète (1 à donner au musée)",
     "item.needed-for.gourmet-chef": "succès chef gourmet (cuisiner {{recipes}})",
     "item.needed-for.craft-master": "succès maître artisant (fabriquer {{recipes}})",
+    "item.needed-for.quests": "current quests ({{quests}})", // TODO
     "item.sells-to.shipping-box": "bac d'expédition",
     "item.recipes-for-ingredient.entry": "{{name}} (nécessite {{count}})",
     "item.recipes-for-machine.multiple-items": "{{name}} x {{count}}",

--- a/LookupAnything/i18n/hu.json
+++ b/LookupAnything/i18n/hu.json
@@ -383,6 +383,7 @@
     "item.needed-for.full-collection": "teljes gyűjtemény teljesítmény (adományozz egyet a múzeumnak)",
     "item.needed-for.gourmet-chef": "ínyenc szakács teljesítmény (készíts még: {{recipes}})",
     "item.needed-for.craft-master": "kézműves mester teljesítmény (készíts még: {{recipes}})",
+    "item.needed-for.quests": "current quests ({{quests}})", // TODO
     "item.sells-to.shipping-box": "szállítmányos láda",
     "item.recipes-for-ingredient.entry": "{{name}} (szükséges: {{count}})",
     "item.recipes-for-machine.multiple-items": "{{name}} x{{count}}",

--- a/LookupAnything/i18n/it.json
+++ b/LookupAnything/i18n/it.json
@@ -381,6 +381,7 @@
     "item.needed-for.full-collection": "l'achievement 'collezione completa' (donane ancora uno al museo)",
     "item.needed-for.gourmet-chef": "l'achievement 'chef da gourmet' (cucina {{recipes}})",
     "item.needed-for.craft-master": "l'achievement 'maestro della fabbricazione' (crea {{recipes}})",
+    "item.needed-for.quests": "current quests ({{quests}})", // TODO
     "item.sells-to.shipping-box": "Cassetta delle spedizioni",
     "item.recipes-for-ingredient.entry": "{{name}} ({{count}} necessari)",
     "item.recipes-for-machine.multiple-items": "{{name}} x{{count}}",

--- a/LookupAnything/i18n/ja.json
+++ b/LookupAnything/i18n/ja.json
@@ -384,6 +384,7 @@
     "item.needed-for.full-collection": "実績:コンプリートコレクション (博物館に一つ寄付)",
     "item.needed-for.gourmet-chef": "実績:グルメマスター ({{recipes}}を調理する)",
     "item.needed-for.craft-master": "実績:クラフトマスター ({{recipes}}を作成する)",
+    "item.needed-for.quests": "current quests ({{quests}})", // TODO
     "item.sells-to.shipping-box": "出荷箱",
     "item.recipes-for-ingredient.entry": "{{name}} ({{count}}個必要)",
     "item.recipes-for-machine.multiple-items": "{{name}}が{{count}}個",

--- a/LookupAnything/i18n/ko.json
+++ b/LookupAnything/i18n/ko.json
@@ -382,6 +382,7 @@
     "item.needed-for.full-collection": "도전과제 '수집 완료' (박물관에 기증)",
     "item.needed-for.gourmet-chef": "도전과제 '미식가 요리사' ({{recipes}}을/를 요리하세요)",
     "item.needed-for.craft-master": "도전과제 '제작의 달인' ({{recipes}}을/를 제작하세요)",
+    "item.needed-for.quests": "current quests ({{quests}})", // TODO
     "item.sells-to.shipping-box": "출하 상자",
     "item.recipes-for-ingredient.entry": "{{name}} ({{count}}개 필요)",
     "item.recipes-for-machine.multiple-items": "{{name}} x{{count}}",

--- a/LookupAnything/i18n/pt.json
+++ b/LookupAnything/i18n/pt.json
@@ -382,6 +382,7 @@
     "item.needed-for.full-collection": "conquista da Coleção Completa (doe um para o museu)",
     "item.needed-for.gourmet-chef": "conquista de Chefe Gourmet (cozinhe {{recipes}})",
     "item.needed-for.craft-master": "conquista de Mestre do Artesanato (crie {{recipes}})",
+    "item.needed-for.quests": "current quests ({{quests}})", // TODO
     "item.sells-to.shipping-box": "Caixa de envio",
     "item.recipes-for-ingredient.entry": "{{name}} (precisa de {{count}})",
     "item.recipes-for-machine.multiple-items": "{{name}} x {{count}}",

--- a/LookupAnything/i18n/ru.json
+++ b/LookupAnything/i18n/ru.json
@@ -382,6 +382,7 @@
     "item.needed-for.full-collection": "достижение 'Полная коллекция' (Пожертвуйте музею)",
     "item.needed-for.gourmet-chef": "достижение 'Шеф-повар' (приготовьте рецепт: {{recipes}})",
     "item.needed-for.craft-master": "достижение 'Мастер' (создайте предмет: {{recipes}})",
+    "item.needed-for.quests": "current quests ({{quests}})", // TODO
     "item.sells-to.shipping-box": "Отгрузочный ящик",
     "item.recipes-for-ingredient.entry": "{{name}} ({{count}} шт.)",
     "item.recipes-for-machine.multiple-items": "{{name}} x{{count}}",

--- a/LookupAnything/i18n/zh.json
+++ b/LookupAnything/i18n/zh.json
@@ -383,6 +383,7 @@
     "item.needed-for.full-collection": "全套收集成就(向博物馆捐赠一个)",
     "item.needed-for.gourmet-chef": "美食大厨成就(烹饪{{recipes}})",
     "item.needed-for.craft-master": "制造大师成就(制造{{recipes}})",
+    "item.needed-for.quests": "current quests ({{quests}})", // TODO
     "item.sells-to.shipping-box": "出货箱",
     "item.recipes-for-ingredient.entry": "{{name}} (需要{{count}})",
     "item.recipes-for-machine.multiple-items": "{{name}} x{{count}}",

--- a/LookupAnything/release-notes.md
+++ b/LookupAnything/release-notes.md
@@ -2,7 +2,7 @@
 
 # Release notes
 ## Upcoming release
-* Show current quests that need an item in the "Needed For" field.
+* Add quests to item 'needed for' field (thanks to cofiem!).
 * Fixed item lookups not showing all cooking/crafting recipes in some cases.
 * Improved translations. Thanks to wally232 (updated Korean)!
 

--- a/LookupAnything/release-notes.md
+++ b/LookupAnything/release-notes.md
@@ -2,6 +2,7 @@
 
 # Release notes
 ## Upcoming release
+* Show current quests that need an item in the "Needed For" field.
 * Fixed item lookups not showing all cooking/crafting recipes in some cases.
 * Improved translations. Thanks to wally232 (updated Korean)!
 


### PR DESCRIPTION
"Items needed for quests, either story related or the Help Wanted quests, should show under the "Needed For" section."

Work in progress.
Closes #443

Example:
![needed-for-example](https://user-images.githubusercontent.com/441771/107620064-d9867680-6c9f-11eb-86d1-2c4c2103002c.jpg)
