### PR TITLE
[Lookup Anything] Add recipes for items needed to construct buildings

### DIFF
--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -464,7 +464,7 @@ namespace Pathoschild.Stardew.LookupAnything
                 let building = new BluePrint(entry.BuildingKey)
                 select new RecipeModel(
                     key: null,
-                    type: RecipeType.BuildingBlueprint,
+                    type: RecipeType.BuildingInput,
                     displayType: building.displayName,
                     ingredients: entry.Ingredients.Select(p => new RecipeIngredientModel(new[] { p.Key }, p.Value)),
                     item: ingredient => this.CreateRecipeItem(ingredient?.ParentSheetIndex, entry.Output),

--- a/LookupAnything/Framework/Data/BuildingRecipeData.cs
+++ b/LookupAnything/Framework/Data/BuildingRecipeData.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Pathoschild.Stardew.LookupAnything.Framework.Data
 {
-    /// <summary>Metadata for a building recipe.</summary>
+    /// <summary>Metadata for a recipe that can be crafted using a building.</summary>
     internal class BuildingRecipeData
     {
         /*********

--- a/LookupAnything/Framework/Fields/ItemRecipesField.cs
+++ b/LookupAnything/Framework/Fields/ItemRecipesField.cs
@@ -184,7 +184,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                     RecipeItemEntry output = this.CreateItemEntry(
                         name: recipe.SpecialOutput?.DisplayText ?? outputItem?.DisplayName,
                         item: outputItem,
-                        spriteInfo: recipe.SpecialOutput?.Sprite,
+                        sprite: recipe.SpecialOutput?.Sprite,
                         minCount: recipe.MinOutput,
                         maxCount: recipe.MaxOutput,
                         chance: recipe.OutputChance,
@@ -341,12 +341,12 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
         /// <summary>Create a recipe item model.</summary>
         /// <param name="name">The display name for the item.</param>
         /// <param name="item">The instance of the item.</param>
-        /// <param name="spriteInfo">The instance of the sprite for the item.</param>
+        /// <param name="sprite">The item sprite, or <c>null</c> to generate it automatically.</param>
         /// <param name="minCount">The minimum number of items needed or created.</param>
         /// <param name="maxCount">The maximum number of items needed or created.</param>
         /// <param name="chance">The chance of creating an output item.</param>
         /// <param name="isOutput">Whether the item is output or input.</param>
-        private RecipeItemEntry CreateItemEntry(string name, Item item = null, SpriteInfo spriteInfo = null, int minCount = 1, int maxCount = 1, decimal chance = 100, bool isOutput = false)
+        private RecipeItemEntry CreateItemEntry(string name, Item item = null, SpriteInfo sprite = null, int minCount = 1, int maxCount = 1, decimal chance = 100, bool isOutput = false)
         {
             // get display text
             string text;
@@ -369,7 +369,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
             }
 
             return new RecipeItemEntry(
-                sprite: spriteInfo ?? this.GameHelper.GetSprite(item),
+                sprite: sprite ?? this.GameHelper.GetSprite(item),
                 displayText: text
             );
         }

--- a/LookupAnything/Framework/Fields/ItemRecipesField.cs
+++ b/LookupAnything/Framework/Fields/ItemRecipesField.cs
@@ -182,8 +182,9 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                 {
                     Item outputItem = recipe.CreateItem(ingredient);
                     RecipeItemEntry output = this.CreateItemEntry(
-                        name: outputItem.DisplayName,
+                        name: recipe.SpecialOutput?.DisplayText ?? outputItem?.DisplayName,
                         item: outputItem,
+                        spriteInfo: recipe.SpecialOutput?.Sprite,
                         minCount: recipe.MinOutput,
                         maxCount: recipe.MaxOutput,
                         chance: recipe.OutputChance,
@@ -329,7 +330,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                 }
 
                 return this.CreateItemEntry(
-                    name: input.DisplayName,
+                    name: input?.DisplayName,
                     item: input,
                     minCount: ingredient.Count,
                     maxCount: ingredient.Count
@@ -340,11 +341,12 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
         /// <summary>Create a recipe item model.</summary>
         /// <param name="name">The display name for the item.</param>
         /// <param name="item">The instance of the item.</param>
+        /// <param name="spriteInfo">The instance of the sprite for the item.</param>
         /// <param name="minCount">The minimum number of items needed or created.</param>
         /// <param name="maxCount">The maximum number of items needed or created.</param>
         /// <param name="chance">The chance of creating an output item.</param>
         /// <param name="isOutput">Whether the item is output or input.</param>
-        private RecipeItemEntry CreateItemEntry(string name, Item item = null, int minCount = 1, int maxCount = 1, decimal chance = 100, bool isOutput = false)
+        private RecipeItemEntry CreateItemEntry(string name, Item item = null, SpriteInfo spriteInfo = null, int minCount = 1, int maxCount = 1, decimal chance = 100, bool isOutput = false)
         {
             // get display text
             string text;
@@ -367,7 +369,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
             }
 
             return new RecipeItemEntry(
-                sprite: this.GameHelper.GetSprite(item),
+                sprite: spriteInfo ?? this.GameHelper.GetSprite(item),
                 displayText: text
             );
         }

--- a/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
+++ b/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
@@ -653,6 +653,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Items
                     (
                         from recipe in this.GameHelper.GetRecipesForIngredient(this.DisplayItem)
                         let item = recipe.CreateItem(this.DisplayItem)
+                        where item != null
                         orderby item.DisplayName
                         select new { recipe.Type, item.DisplayName, TimesCrafted = recipe.GetTimesCrafted(Game1.player) }
                     )

--- a/LookupAnything/Framework/Models/RecipeModel.cs
+++ b/LookupAnything/Framework/Models/RecipeModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Pathoschild.Stardew.Common.Items.ItemData;
+using Pathoschild.Stardew.LookupAnything.Framework.Fields.Models;
 using StardewValley;
 using StardewValley.Objects;
 
@@ -59,6 +60,9 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Models
         /// <summary>Whether the recipe must be learned before it can be used.</summary>
         public bool MustBeLearned { get; }
 
+        /// <summary>The sprite and display text for a non-standard recipe output.</summary>
+        public  RecipeItemEntry SpecialOutput { get; }
+
 
         /*********
         ** Public methods
@@ -78,7 +82,8 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Models
         /// <param name="minOutput">The minimum number of items output by the recipe.</param>
         /// <param name="maxOutput">The maximum number of items output by the recipe.</param>
         /// <param name="outputChance">The percentage chance of this recipe being produced (or <c>null</c> if the recipe is always used).</param>
-        public RecipeModel(string key, RecipeType type, string displayType, IEnumerable<RecipeIngredientModel> ingredients, Func<Item, Item> item, bool mustBeLearned, int? machineParentSheetIndex, Func<object, bool> isForMachine, IEnumerable<RecipeIngredientModel> exceptIngredients = null, int? outputItemIndex = null, ItemType? outputItemType = null, int? minOutput = null, int? maxOutput = null, decimal? outputChance = null)
+        /// <param name="specialOutput">The sprite and display text for a non-standard recipe output (or <c>null</c> if the recipe has a standard object output).</param>
+        public RecipeModel(string key, RecipeType type, string displayType, IEnumerable<RecipeIngredientModel> ingredients, Func<Item, Item> item, bool mustBeLearned, int? machineParentSheetIndex, Func<object, bool> isForMachine, IEnumerable<RecipeIngredientModel> exceptIngredients = null, int? outputItemIndex = null, ItemType? outputItemType = null, int? minOutput = null, int? maxOutput = null, decimal? outputChance = null, RecipeItemEntry specialOutput = null)
         {
             // normalize values
             if (minOutput == null && maxOutput == null)
@@ -106,6 +111,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Models
             this.MinOutput = minOutput.Value;
             this.MaxOutput = maxOutput.Value;
             this.OutputChance = outputChance > 0 && outputChance < 100 ? outputChance.Value : 100;
+            this.SpecialOutput = specialOutput;
         }
 
         /// <summary>Construct an instance.</summary>

--- a/LookupAnything/Framework/Models/RecipeType.cs
+++ b/LookupAnything/Framework/Models/RecipeType.cs
@@ -3,22 +3,22 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Models
     /// <summary>Indicates an in-game recipe type.</summary>
     internal enum RecipeType
     {
-        /// <summary>The recipe is cooked in the kitchen.</summary>
+        /// <summary>Food cooked in the kitchen.</summary>
         Cooking,
 
-        /// <summary>The recipe is crafted through the game menu.</summary>
+        /// <summary>An object crafted through the game menu.</summary>
         Crafting,
 
-        /// <summary>The recipe represents the input for a crafting machine like a furnace.</summary>
+        /// <summary>The input/output for a crafting machine like a furnace.</summary>
         MachineInput,
 
-        /// <summary>The recipe represents the input for a crafting building like a mill.</summary>
+        /// <summary>The input/output for a crafting building like a mill.</summary>
         BuildingInput,
 
-        /// <summary>The recipe represents the materials needed to construct a building through Robin or the Wizard.</summary>
+        /// <summary>The materials needed to construct a building.</summary>
         BuildingBlueprint,
 
-        /// <summary>The recipe represents the input for tailoring clothes.</summary>
+        /// <summary>Clothing created through the tailoring UI.</summary>
         TailorInput
     }
 }

--- a/LookupAnything/Framework/Models/RecipeType.cs
+++ b/LookupAnything/Framework/Models/RecipeType.cs
@@ -12,6 +12,9 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Models
         /// <summary>The recipe represents the input for a crafting machine like a furnace.</summary>
         MachineInput,
 
+        /// <summary>The recipe represents the input for a crafting building like a mill.</summary>
+        BuildingInput,
+
         /// <summary>The recipe represents the materials needed to construct a building through Robin or the Wizard.</summary>
         BuildingBlueprint,
 


### PR DESCRIPTION
Implements "[Lookup Anything] show construction recipes in item lookups".

"When an item is needed as a building material, show the buildings which need it as a construction recipe."

Closes #442.