### PR TITLE
When clicking "add to existing stacks" do it for all storages

### DIFF
--- a/ChestsAnywhere/ChestsAnywhere.csproj
+++ b/ChestsAnywhere/ChestsAnywhere.csproj
@@ -4,6 +4,7 @@
     <Version>1.20.14</Version>
     <RootNamespace>Pathoschild.Stardew.ChestsAnywhere</RootNamespace>
     <TargetFramework>net452</TargetFramework>
+    <EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ChestsAnywhere/ItemGrabMenuPatches.cs
+++ b/ChestsAnywhere/ItemGrabMenuPatches.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Harmony;
+using Pathoschild.Stardew.ChestsAnywhere.Framework;
+using StardewModdingAPI;
+using StardewValley.Menus;
+
+namespace Pathoschild.Stardew.ChestsAnywhere
+{
+    [HarmonyPatch(typeof(ItemGrabMenu), nameof(ItemGrabMenu.FillOutStacks))]
+    internal class ItemGrabMenuPatches
+    {
+        private static ChestFactory ChestFactory;
+        private static IMonitor Monitor;
+        private static Func<RangeHandler> GetRangeHandler;
+        private static bool IsProcessing = false;
+
+        internal static void Initialize(IMonitor monitor, ChestFactory chestFactory, Func<RangeHandler> getRangeHandler)
+        {
+            Monitor = monitor;
+            ChestFactory = chestFactory;
+            GetRangeHandler = getRangeHandler;
+        }
+
+        [HarmonyPostfix]
+        internal static void Postfix(ItemGrabMenu __instance)
+        {
+            if (IsProcessing)
+                return;
+
+            try
+            {
+                IsProcessing = true;
+
+                var chests = ChestFactory.GetChests(GetRangeHandler())
+                    .Select(c => c.Container)
+                    .Select(c => c.OpenMenu())
+                    .OfType<ItemGrabMenu>()
+                    .Where(m => m != __instance);
+
+
+                foreach(ItemGrabMenu chest in chests)
+                    chest.FillOutStacks();
+            }
+            catch (Exception ex)
+            {
+                Monitor.Log($"Failed in {nameof(ItemGrabMenuPatches)}.{nameof(Postfix)}:\n{ex}", LogLevel.Error);
+            }
+            finally
+            {
+                IsProcessing = false;
+            }
+        }
+    }
+}

--- a/ChestsAnywhere/ModEntry.cs
+++ b/ChestsAnywhere/ModEntry.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Harmony;
 using Microsoft.Xna.Framework;
 using Pathoschild.Stardew.ChestsAnywhere.Framework;
 using Pathoschild.Stardew.ChestsAnywhere.Framework.Containers;
@@ -62,6 +63,10 @@ namespace Pathoschild.Stardew.ChestsAnywhere
             helper.Events.GameLoop.UpdateTicking += this.OnUpdateTicking;
             helper.Events.Display.RenderedHud += this.OnRenderedHud;
             helper.Events.Input.ButtonsChanged += this.OnButtonsChanged;
+
+            ItemGrabMenuPatches.Initialize(this.Monitor, this.ChestFactory, this.GetCurrentRange);
+            var harmony = HarmonyInstance.Create(this.ModManifest.UniqueID);
+            harmony.PatchAll();
 
             // validate translations
             if (!helper.Translation.GetTranslations().Any())


### PR DESCRIPTION
Not sure if harmony is the best way for this but it's certainly the easiest.

Whenever the button is clicked for a chest we simply call the same function for all other storage that use ItemGrabMenu (I don't have a save with all the various types so I can't 100% test this but even on a fail it should just revert to the default handling).