### PR TITLE
Suppress keybinds for use with binding to Controller Buttons

### DIFF
--- a/HorseFluteAnywhere/ModEntry.cs
+++ b/HorseFluteAnywhere/ModEntry.cs
@@ -94,8 +94,13 @@ namespace Pathoschild.Stardew.HorseFluteAnywhere
         /// <param name="e">The event data.</param>
         private void OnButtonsChanged(object sender, ButtonsChangedEventArgs e)
         {
-            if (this.SummonKey.JustPressed() && this.CanPlayFlute(Game1.player))
-                this.HorseFlute.Value.performUseAction(Game1.currentLocation);
+            if (this.SummonKey.JustPressed() && Context.IsPlayerFree) {
+                this.Helper.Input.SuppressActiveKeybinds(this.SummonKey);
+                if (this.CanPlayFlute(Game1.player))
+                {
+                    this.HorseFlute.Value.performUseAction(Game1.currentLocation);
+                }
+            }
         }
 
         /// <summary>The event called after the location list changes.</summary>
@@ -238,12 +243,7 @@ namespace Pathoschild.Stardew.HorseFluteAnywhere
         /// <param name="player">The player to check.</param>
         private bool CanPlayFlute(Farmer player)
         {
-            return
-                Context.IsPlayerFree
-                && (
-                    !this.Config.RequireHorseFlute
-                    || player.Items.Any(p => Utility.IsNormalObjectAtParentSheetIndex(p, ModEntry.HorseFluteId))
-                );
+            return !this.Config.RequireHorseFlute || player.Items.Any(p => Utility.IsNormalObjectAtParentSheetIndex(p, ModEntry.HorseFluteId));
         }
 
         /// <summary>Get whether a player is riding a (non-tractor) horse.</summary>

--- a/HorseFluteAnywhere/ModEntry.cs
+++ b/HorseFluteAnywhere/ModEntry.cs
@@ -94,12 +94,10 @@ namespace Pathoschild.Stardew.HorseFluteAnywhere
         /// <param name="e">The event data.</param>
         private void OnButtonsChanged(object sender, ButtonsChangedEventArgs e)
         {
-            if (this.SummonKey.JustPressed() && Context.IsPlayerFree) {
+            if (this.SummonKey.JustPressed() && this.CanPlayFlute(Game1.player))
+            {
                 this.Helper.Input.SuppressActiveKeybinds(this.SummonKey);
-                if (this.CanPlayFlute(Game1.player))
-                {
-                    this.HorseFlute.Value.performUseAction(Game1.currentLocation);
-                }
+                this.HorseFlute.Value.performUseAction(Game1.currentLocation);
             }
         }
 
@@ -243,7 +241,12 @@ namespace Pathoschild.Stardew.HorseFluteAnywhere
         /// <param name="player">The player to check.</param>
         private bool CanPlayFlute(Farmer player)
         {
-            return !this.Config.RequireHorseFlute || player.Items.Any(p => Utility.IsNormalObjectAtParentSheetIndex(p, ModEntry.HorseFluteId));
+            return
+                Context.IsPlayerFree
+                && (
+                    !this.Config.RequireHorseFlute
+                    || player.Items.Any(p => Utility.IsNormalObjectAtParentSheetIndex(p, ModEntry.HorseFluteId))
+                );
         }
 
         /// <summary>Get whether a player is riding a (non-tractor) horse.</summary>

--- a/LookupAnything/ModEntry.cs
+++ b/LookupAnything/ModEntry.cs
@@ -144,13 +144,13 @@ namespace Pathoschild.Stardew.LookupAnything
                 // pressed
                 if (keys.ToggleSearch.JustPressed())
                 {
-                    this.TryToggleSearch();
                     this.Helper.Input.SuppressActiveKeybinds(keys.ToggleSearch);
+                    this.TryToggleSearch();
                 }
                 else if (keys.ToggleLookup.JustPressed())
                 {
-                    this.ToggleLookup();
                     this.Helper.Input.SuppressActiveKeybinds(keys.ToggleLookup);
+                    this.ToggleLookup();
                 }
                 else if (keys.ScrollUp.JustPressed())
                     (Game1.activeClickableMenu as LookupMenu)?.ScrollUp();

--- a/LookupAnything/ModEntry.cs
+++ b/LookupAnything/ModEntry.cs
@@ -143,9 +143,15 @@ namespace Pathoschild.Stardew.LookupAnything
 
                 // pressed
                 if (keys.ToggleSearch.JustPressed())
+                {
                     this.TryToggleSearch();
+                    this.Helper.Input.SuppressActiveKeybinds(keys.ToggleSearch);
+                }
                 else if (keys.ToggleLookup.JustPressed())
+                {
                     this.ToggleLookup();
+                    this.Helper.Input.SuppressActiveKeybinds(keys.ToggleLookup);
+                }
                 else if (keys.ScrollUp.JustPressed())
                     (Game1.activeClickableMenu as LookupMenu)?.ScrollUp();
                 else if (keys.ScrollDown.JustPressed())


### PR DESCRIPTION
Added Suppress Keybind for:
- Lookup Anything Hotkeys
- Horse Flute Hotkey

This allows setting these Hotkeys to a DPad direction or the RightStick without making the character move or opening the chat window