### PR TITLE
Fix transparency in sprites drawn in Lookup Anything menu

### DIFF
--- a/LookupAnything/Components/LookupMenu.cs
+++ b/LookupAnything/Components/LookupMenu.cs
@@ -327,7 +327,17 @@ namespace Pathoschild.Stardew.LookupAnything.Components
                     {
                         // begin draw
                         device.ScissorRectangle = new Rectangle(x + gutter, y + gutter, (int)contentWidth, (int)contentHeight);
-                        contentBatch.Begin(SpriteSortMode.Deferred, BlendState.NonPremultiplied, SamplerState.PointClamp, null, new RasterizerState { ScissorTestEnable = true });
+                        var blendState = new BlendState()
+                        {
+                            AlphaBlendFunction = BlendFunction.Add,
+                            AlphaSourceBlend = Blend.Zero,
+                            AlphaDestinationBlend = Blend.One,
+
+                            ColorBlendFunction = BlendFunction.Add,
+                            ColorSourceBlend = Blend.SourceAlpha,
+                            ColorDestinationBlend = Blend.InverseSourceAlpha,
+                        };
+                        contentBatch.Begin(SpriteSortMode.Deferred, blendState, SamplerState.PointClamp, null, new RasterizerState { ScissorTestEnable = true });
 
                         // scroll view
                         this.CurrentScroll = Math.Max(0, this.CurrentScroll); // don't scroll past top

--- a/LookupAnything/Components/LookupMenu.cs
+++ b/LookupAnything/Components/LookupMenu.cs
@@ -54,6 +54,18 @@ namespace Pathoschild.Stardew.LookupAnything.Components
         /// <summary>The spacing around the scroll buttons.</summary>
         private readonly int ScrollButtonGutter = 15;
 
+        /// <summary>The blend state to use when rendering the content sprite batch.</summary>
+        private readonly BlendState ContentBlendState = new()
+        {
+            AlphaBlendFunction = BlendFunction.Add,
+            AlphaSourceBlend = Blend.Zero,
+            AlphaDestinationBlend = Blend.One,
+
+            ColorBlendFunction = BlendFunction.Add,
+            ColorSourceBlend = Blend.SourceAlpha,
+            ColorDestinationBlend = Blend.InverseSourceAlpha
+        };
+
         /// <summary>The maximum pixels to scroll.</summary>
         private int MaxScroll;
 
@@ -327,17 +339,7 @@ namespace Pathoschild.Stardew.LookupAnything.Components
                     {
                         // begin draw
                         device.ScissorRectangle = new Rectangle(x + gutter, y + gutter, (int)contentWidth, (int)contentHeight);
-                        var blendState = new BlendState()
-                        {
-                            AlphaBlendFunction = BlendFunction.Add,
-                            AlphaSourceBlend = Blend.Zero,
-                            AlphaDestinationBlend = Blend.One,
-
-                            ColorBlendFunction = BlendFunction.Add,
-                            ColorSourceBlend = Blend.SourceAlpha,
-                            ColorDestinationBlend = Blend.InverseSourceAlpha,
-                        };
-                        contentBatch.Begin(SpriteSortMode.Deferred, blendState, SamplerState.PointClamp, null, new RasterizerState { ScissorTestEnable = true });
+                        contentBatch.Begin(SpriteSortMode.Deferred, this.ContentBlendState, SamplerState.PointClamp, null, new RasterizerState { ScissorTestEnable = true });
 
                         // scroll view
                         this.CurrentScroll = Math.Max(0, this.CurrentScroll); // don't scroll past top
@@ -441,6 +443,8 @@ namespace Pathoschild.Stardew.LookupAnything.Components
         /// <summary>Clean up after the menu when it's disposed.</summary>
         public void Dispose()
         {
+            this.ContentBlendState.Dispose();
+
             this.CleanupImpl();
         }
 


### PR DESCRIPTION
Sprites that are being drawn in the Lookup Anything menu have a weird alpha blending function being applied to them. Dimmed sprites (for example, in a recipe that isn't unlocked) clip through the background of the menu and partially show the world behind them:

![image](https://user-images.githubusercontent.com/2214247/147042076-ba13f7a7-8877-4239-89ed-049b0528904f.png)

This PR fixes the blend state that LU uses to draw the fields in its menus. It maintains the same color blending function (`srcColor * srcAlpha) + (dstColor * (1 - srcAlpha))`) but uses the destination alpha instead now to ensure that after the sprite is drawn, the alpha channel has the same value as the background it's being drawn on previously did.

![image](https://user-images.githubusercontent.com/2214247/147042371-2b002879-66d0-4389-a09d-79ddd3b1b5af.png)
