### PR TITLE
Allow fuzzier matching for types in `patch export filename type`

### DIFF
--- a/ContentPatcher/Framework/Commands/Commands/ExportCommand.cs
+++ b/ContentPatcher/Framework/Commands/Commands/ExportCommand.cs
@@ -70,7 +70,7 @@ namespace ContentPatcher.Framework.Commands.Commands
 
             // The fully qualified name for a Texture2D is kind of long.
             // Here are some shortcuts.
-            if (typeName.Contains("image", StringComparison.OrdinalIgnoreCase))
+            if (typeName.Equals("image", StringComparison.OrdinalIgnoreCase))
             {
                 typeName = "Microsoft.Xna.Framework.Graphics.Texture2D, MonoGame.Framework";
             }

--- a/ContentPatcher/Framework/Commands/Commands/ExportCommand.cs
+++ b/ContentPatcher/Framework/Commands/Commands/ExportCommand.cs
@@ -155,8 +155,9 @@ namespace ContentPatcher.Framework.Commands.Commands
                     return new[] { type };
             }
 
-            // else by full name
+            // by type name
             {
+                HashSet<Type> typesByName = new();
                 HashSet<Type> typesByFullName = new();
                 foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
                 {
@@ -169,6 +170,8 @@ namespace ContentPatcher.Framework.Commands.Commands
                         {
                             if (string.Equals(type.FullName, name, StringComparison.OrdinalIgnoreCase))
                                 typesByFullName.Add(type);
+                            if (string.Equals(type.Name, name, StringComparison.OrdinalIgnoreCase))
+                                typesByName.Add(type);
                         }
                         catch
                         {
@@ -177,7 +180,11 @@ namespace ContentPatcher.Framework.Commands.Commands
                     }
                 }
 
-                return typesByFullName.OrderBy(p => p.FullName, HumanSortComparer.DefaultIgnoreCase).ToArray();
+                HashSet<Type> matches = typesByFullName.Any()
+                    ? typesByFullName
+                    : typesByName;
+                return matches.OrderBy(p => p.FullName, HumanSortComparer.DefaultIgnoreCase).ToArray();
+
             }
         }
 

--- a/ContentPatcher/Framework/Commands/Commands/ExportCommand.cs
+++ b/ContentPatcher/Framework/Commands/Commands/ExportCommand.cs
@@ -70,7 +70,7 @@ namespace ContentPatcher.Framework.Commands.Commands
 
             // The fully qualified name for a Texture2D is kind of long.
             // Here are some shortcuts.
-            if ((new[] {"png", "texture", "texture2d", "image"}).Any((a) => a.Contains(typeName, StringComparison.OrdinalIgnoreCase)))
+            if (typeName.Contains("image", StringComparison.OrdinalIgnoreCase))
             {
                 typeName = "Microsoft.Xna.Framework.Graphics.Texture2D, MonoGame.Framework";
             }


### PR DESCRIPTION
Currently, to patch export an asset that's not loaded, the user has to specify the fully qualified type name. For system types, this isn't too bad, but for images, it's... `"Microsoft.Xna.Framework.Graphics.Texture2D, MonoGame.Framework"`, which I'm pretty sure I've never gotten right on the first try. This PR does two things:

1. Allows users to type in `image` to refer to an image asset (case-insensitive).
2. Allows fuzzier matching when referring to type names. Just the full name (without the assembly) is sufficient, as long as there's not two types with the same full name.