### PR TITLE
Only reindex if a patch has changed its TargetAsset

### DIFF
--- a/ContentPatcher/Framework/PatchManager.cs
+++ b/ContentPatcher/Framework/PatchManager.cs
@@ -254,7 +254,6 @@ namespace ContentPatcher.Framework
                         reloadAssetNames.Add(patch.TargetAsset);
                 }
 
-                hasTargetChanges = hasTargetChanges || wasTargetAsset != null && patch.TargetAsset == null;
                 hasTargetChanges = hasTargetChanges || (wasTargetAsset != null && patch.TargetAsset == null);
                 hasTargetChanges = hasTargetChanges || (wasTargetAsset == null && patch.TargetAsset != null);
                 hasTargetChanges = hasTargetChanges || (wasTargetAsset != null && patch.TargetAsset != null && !wasTargetAsset.IsEquivalentTo(patch.TargetAsset));

--- a/ContentPatcher/Framework/PatchManager.cs
+++ b/ContentPatcher/Framework/PatchManager.cs
@@ -254,9 +254,8 @@ namespace ContentPatcher.Framework
                         reloadAssetNames.Add(patch.TargetAsset);
                 }
 
-                hasTargetChanges = hasTargetChanges || (wasTargetAsset != null && patch.TargetAsset == null);
-                hasTargetChanges = hasTargetChanges || (wasTargetAsset == null && patch.TargetAsset != null);
-                hasTargetChanges = hasTargetChanges || (wasTargetAsset != null && patch.TargetAsset != null && !wasTargetAsset.IsEquivalentTo(patch.TargetAsset));
+                // Short circuit if its already true, otherwise test if they are not equal, and on the event old is null, check if new is not null (different)
+                hasTargetChanges = hasTargetChanges || (!wasTargetAsset?.Equals(patch.TargetAsset) ?? patch.TargetAsset != null);
                 // log change
                 verbosePatchesReloaded?.Add(new PatchAuditChange(patch, wasReady, wasFromAsset, wasTargetAsset, reloadAsset));
                 if (this.Monitor.IsVerbose)

--- a/ContentPatcher/Framework/PatchManager.cs
+++ b/ContentPatcher/Framework/PatchManager.cs
@@ -170,6 +170,8 @@ namespace ContentPatcher.Framework
             // update patches
             IAssetName? prevAssetName = null;
             HashSet<IPatch> newPatches = new(new ObjectReferenceComparer<IPatch>());
+
+            bool hasTargetChanges = false;
             while (patchQueue.Any())
             {
                 IPatch patch = patchQueue.Dequeue();
@@ -252,6 +254,10 @@ namespace ContentPatcher.Framework
                         reloadAssetNames.Add(patch.TargetAsset);
                 }
 
+                hasTargetChanges = hasTargetChanges || wasTargetAsset != null && patch.TargetAsset == null;
+                hasTargetChanges = hasTargetChanges || (wasTargetAsset != null && patch.TargetAsset == null);
+                hasTargetChanges = hasTargetChanges || (wasTargetAsset == null && patch.TargetAsset != null);
+                hasTargetChanges = hasTargetChanges || (wasTargetAsset != null && patch.TargetAsset != null && !wasTargetAsset.IsEquivalentTo(patch.TargetAsset));
                 // log change
                 verbosePatchesReloaded?.Add(new PatchAuditChange(patch, wasReady, wasFromAsset, wasTargetAsset, reloadAsset));
                 if (this.Monitor.IsVerbose)
@@ -267,8 +273,11 @@ namespace ContentPatcher.Framework
                 }
             }
 
-            // reset indexes
-            this.Reindex(patchListChanged: false);
+            if (hasTargetChanges)
+            {
+                // reset indexes
+                this.Reindex(patchListChanged: false);
+            }
 
             // log changes
             if (verbosePatchesReloaded?.Count > 0)


### PR DESCRIPTION
Before: https://smapi.io/log/65fe9f31ea714be4bf26b1a613c6bae4?Levels=trace%7Edebug%7Einfo%7Ewarn%7Eerror%7Ealert%7Ecritical&Filter=reIndex%3A
After:  https://smapi.io/log/6045009a80474d418f1067b4e783c526?Filter=reIndex&Levels=trace%7Edebug%7Einfo%7Ewarn%7Eerror%7Ealert%7Ecritical

Whenever there was a TimeChanged event that took > 10ms, This ReIndex method was consistently taking 6-10ms to process, when most of the time, no patches changed targets, this attempts to reduce the amount of times patches get reindexed by target.