### PR TITLE
[Lookup Anything] Fix generic `HoveredItem` field support for custom sub-pages of `GameMenu`

### DIFF
--- a/LookupAnything/Framework/Lookups/Items/ItemLookupProvider.cs
+++ b/LookupAnything/Framework/Lookups/Items/ItemLookupProvider.cs
@@ -300,7 +300,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Items
                 ****/
                 default:
                     {
-                        Item? item = this.Reflection.GetField<Item?>(menu, "HoveredItem", required: false)?.GetValue(); // ChestsAnywhere
+                        Item? item = this.Reflection.GetField<Item?>(targetMenu, "HoveredItem", required: false)?.GetValue(); // ChestsAnywhere
                         if (item != null)
                             return this.BuildSubject(item, ObjectContext.Inventory, null);
                     }


### PR DESCRIPTION
The item lookup provider's menu handler currently detects if the active menu is `GameMenu` and gets the active page from it. Except for generic menu support.

The `HoveredItem` field for generic mod menu support is accessed on `menu` rather than `targetMenu`, thus not handling GameMenu children properly. This fixes that.