### PR TITLE
When loading patches from an IncludePatch, have reIndex off

### DIFF
--- a/ContentPatcher/Framework/Patches/IncludePatch.cs
+++ b/ContentPatcher/Framework/Patches/IncludePatch.cs
@@ -141,7 +141,7 @@ namespace ContentPatcher.Framework.Patches
                         rawPatches: content.Changes,
                         rootIndexPath: this.IndexPath,
                         path: this.GetIncludedLogPath(this.FromAsset),
-                        reindex: true,
+                        reindex: false,
                         parentPatch: this
                     );
                     this.IsApplied = true;


### PR DESCRIPTION
In my current modpack, it was previously taking 34 seconds (plus logging overhead) to do the initial UpdateTicked event.
With this change, it goes down to 5 seconds, and 3.6 when the logging overhead is removed.

This is partially untested, particularly when LoadPatches is invoked via ReloadCommand or by ApplyNewConfig