### PR TITLE
[Lookup Anything] Fix child birthday in future

### DIFF
--- a/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
+++ b/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
@@ -449,7 +449,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Characters
         /// <param name="child">The child instance.</param>
         private string GetChildBirthdayString(Child child)
         {
-            int daysOld = -child.daysOld.Value;
+            int daysOld = child.daysOld.Value;
 
             try
             {


### PR DESCRIPTION
When using F1 on a child, its birthday is shown as a future date, and this shown date advances by 2 for every in-game day. This PR fixes that by removing one of the double negations (the other is `.AddDays(-daysOld)` in the next few lines).

The same issue also applies to the `stable` branch as the code is identical.