### PR TITLE
Rewrite lexer to avoid regex

### DIFF
--- a/ContentPatcher/Framework/Lexing/LexTokens/LexBit.cs
+++ b/ContentPatcher/Framework/Lexing/LexTokens/LexBit.cs
@@ -1,28 +1,7 @@
+using System.Diagnostics;
+
 namespace ContentPatcher.Framework.Lexing.LexTokens
 {
     /// <summary>A low-level character pattern within a string/</summary>
-    internal class LexBit
-    {
-        /*********
-        ** Accessors
-        *********/
-        /// <summary>The lexical character pattern type.</summary>
-        public LexBitType Type { get; }
-
-        /// <summary>The raw matched text.</summary>
-        public string Text { get; }
-
-
-        /*********
-        ** Public methods
-        *********/
-        /// <summary>Construct an instance.</summary>
-        /// <param name="type">The lexical character pattern type.</param>
-        /// <param name="text">The raw matched text.</param>
-        public LexBit(LexBitType type, string text)
-        {
-            this.Type = type;
-            this.Text = text;
-        }
-    }
+    internal readonly record struct LexBit(LexBitType Type, string Text);
 }

--- a/ContentPatcher/Framework/Lexing/Lexer.cs
+++ b/ContentPatcher/Framework/Lexing/Lexer.cs
@@ -36,14 +36,17 @@ namespace ContentPatcher.Framework.Lexing
             if (rawText is null)
                 yield break;
 
+            // Empty string - the rest of the function
+            // avoids yielding out empty strings
+            // so this must be handled special.
             if (rawText.Length == 0)
             {
                 yield return new LexBit(LexBitType.Literal, string.Empty);
                 yield break;
             }
 
+            // parse
             int length = rawText.Length;
-
             int lastMatch = 0;
             int start = 0;
             int index;

--- a/ContentPatcher/Framework/Lexing/Lexer.cs
+++ b/ContentPatcher/Framework/Lexing/Lexer.cs
@@ -14,9 +14,7 @@ namespace ContentPatcher.Framework.Lexing
         /*********
         ** Fields
         *********/
-        /// <summary>A regular expression which matches lexical patterns that split lexical patterns. For example, ':' is a <see cref="LexBitType.PositionalInputArgSeparator"/> pattern that splits a token name and its input arguments. The split pattern is itself a lexical pattern.</summary>
-        // private static readonly Regex LexicalSplitPattern = new(@"({{|}}|:|\|)", RegexOptions.Compiled);
-
+        /// <summary>The four characters to split by for lexical splitting. For example, ':' is a <see cref="LexBitType.PositionalInputArgSeparator"/> pattern that splits a token name and its input arguments.</summary>
         private static readonly char[] SplitPattern = new[] { '{', '}', '|', ':' };
 
 
@@ -44,26 +42,28 @@ namespace ContentPatcher.Framework.Lexing
                 yield break;
             }
 
+            int length = rawText.Length;
+
             int lastMatch = 0;
             int start = 0;
             int index;
-            while (true)
+
+            do
             {
                 index = rawText.IndexOfAny(SplitPattern, start);
                 if (index == -1)
                 {
-                    if (lastMatch < rawText.Length)
+                    if (lastMatch < length)
                         yield return new LexBit(LexBitType.Literal, rawText[lastMatch..]);
                     yield break;
                 }
                 else
                 {
-
-                    switch (rawText[index])
+                    char match = rawText[index];
+                    switch (match)
                     {
                         case '{':
                         case '}':
-                            char match = rawText[index];
                             if (index < rawText.Length - 1 && match == rawText[index + 1])
                             {
                                 if (lastMatch != index)
@@ -97,31 +97,10 @@ namespace ContentPatcher.Framework.Lexing
                             lastMatch = start;
                             break;
                         default:
-                            throw new InvalidOperationException("Not supposed to get here at all, lol");
+                            throw new InvalidOperationException("How did we get here?");
                     }
                 }
-            }
-
-            /*
-            // parse
-            string[] parts = Lexer.LexicalSplitPattern.Split(rawText);
-            foreach (string part in parts)
-            {
-                if (part == string.Empty)
-                    continue; // split artifact
-
-                LexBitType type = part switch
-                {
-                    "{{" => LexBitType.StartToken,
-                    "}}" => LexBitType.EndToken,
-                    InternalConstants.PositionalInputArgSeparator => LexBitType.PositionalInputArgSeparator,
-                    InternalConstants.NamedInputArgSeparator => LexBitType.NamedInputArgSeparator,
-                    _ => LexBitType.Literal
-                };
-
-                yield return new LexBit(type, part);
-            }
-            */
+            } while (lastMatch < length);
         }
 
         /// <summary>Parse a sequence of lexical character patterns into higher-level lexical tokens.</summary>


### PR DESCRIPTION
Hi Pathos!

This PR just moves the lexer off using regex to manually splitting the string using IndexOfAny. I haven't fully benchmarked it, but from watching Profiler on a decently sized mod group, the UpdateTicked just after GameLaunched goes from ~6.5 s to about 5.5s. So not something to write home about, but decently worthwhile, I think? 