### PR TITLE
Update Hungarian translations for Automate

### DIFF
--- a/Automate/i18n/hu.json
+++ b/Automate/i18n/hu.json
@@ -15,31 +15,31 @@
 
     // connectors
     "config.title.connectors": "Engedélyezett csatlakozók",
-    "config.connector.desc": "A {{itemName}} összekapcsolja a gépeket és a ládákat.",
+    "config.connector.desc": "A(z) {{itemName}} összekapcsolja a gépeket és a ládákat.",
     "config.custom-connectors.name": "Egyedi csatlakozók",
     "config.custom-connectors.desc": "A szomszédos gépeket összekötő elemek pontos angol neve. Több elemet is felsorolhat vesszővel elválasztva.", // Megjegyzés: A csatlakozók neveinek angolnak kell lennie, még akkor is, ha más nyelvet használsz.
 
     // Junimo hut options
     // TODO
-    "config.title.junimo-huts": "Junimo hut behavior",
-    "config.junimo-hut-gems.name": "Gems",
-    "config.junimo-hut-gems.desc": "What Junimo huts should do with gemstone items. 'Auto-detect' will ignore them.",
-    "config.junimo-hut-fertilizer.name": "Fertilizer",
-    "config.junimo-hut-fertilizer.desc": "What Junimo huts should do with fertilizer items. 'Auto-detect' will ignore them if Better Junimos is installed, else move them from the hut into connected chests.",
-    "config.junimo-hut-seeds.name": "Seeds",
-    "config.junimo-hut-seeds.desc": "What Junimo huts should do with seed items. 'Auto-detect' will ignore them if Better Junimos is installed, else move them from the hut into connected chests.",
+    "config.title.junimo-huts": "Junimo kunyhó viselkedés",
+    "config.junimo-hut-gems.name": "Drágakövek",
+    "config.junimo-hut-gems.desc": "Mit tegyenek a Junimok a drágakövekkel. Az 'Auto-detect' ignorálni fogja.",
+    "config.junimo-hut-fertilizer.name": "Trágya",
+    "config.junimo-hut-fertilizer.desc": "Mit tegyenek a Junimok a trágyákkal. Az 'Auto-detect' ignorálni fogja, ha a Better Junimos mod instalálva van, máskülönben átviszi őket a kunyhótól a csatlakoztatott ládákba.",
+    "config.junimo-hut-seeds.name": "Magvak",
+    "config.junimo-hut-seeds.desc": "Mit tegyenek a Junimok a magvakkal. Az 'Auto-detect' ignorálni fogja, ha a Better Junimos mod instalálva van, máskülönben átviszi őket a kunyhótól a csatlakoztatott ládákba.",
 
     // Junimo hut dropdown values
     // TODO
     "config.junimo-huts.auto-detect": "Auto-detect",
-    "config.junimo-huts.ignore": "Ignore them",
-    "config.junimo-huts.move-into-chests": "Move from Junimo huts into chests",
-    "config.junimo-huts.move-into-huts": "Move from chests into Junimo huts",
+    "config.junimo-huts.ignore": "Ignorálja őket",
+    "config.junimo-huts.move-into-chests": "Mozgassa a Junimo kunyhókból a ládákba",
+    "config.junimo-huts.move-into-huts": "Mozgossa a ládákból a Junimo kunyhókba",
 
     // machine overrides
     "config.title.machine-overrides": "Gépi felülbírálások",
     "config.override.ShippingBin-name": "Szállítmány",
     "config.override.MiniShippingBin-name": "Mini szállítmány",
-    "config.override.desc": "A {{machineName}} automatizálásának engedélyezése.",
+    "config.override.desc": "A(z) {{machineName}} automatizálásának engedélyezése.",
     "config.custom-overrides-note": "Az egyéni felülbíráláshoz látogasd meg a https://github.com/Pathoschild/StardewMods/tree/develop/Automate#configure oldalt a 'Config.json' fájl közvetlen szerkesztéséhez."
 }


### PR DESCRIPTION
I translated the rest of the code to hungarian, I only left "Auto-correct" untouched, because there's not really a good sounding translation to that, but if you really wanna use it, then it's "Auto-korrekció".