### PR TITLE
Add a setting to show "Unowned gifts" setting defaulted to true

### DIFF
--- a/LookupAnything/Framework/Fields/CharacterGiftTastesField.cs
+++ b/LookupAnything/Framework/Fields/CharacterGiftTastesField.cs
@@ -21,8 +21,8 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
         /// <param name="onlyRevealed">Only show gift tastes the player has discovered for themselves.</param>
         /// <param name="highlightUnrevealed">Whether to highlight items which haven't been revealed in the NPC profile yet.</param>
         /// <param name="ownedItemsCache">A lookup cache for owned items, as created by <see cref="GetOwnedItemsCache"/>.</param>
-        public CharacterGiftTastesField(string label, IDictionary<GiftTaste, GiftTasteModel[]> giftTastes, GiftTaste showTaste, bool onlyRevealed, bool highlightUnrevealed, IDictionary<string, bool> ownedItemsCache)
-            : base(label, CharacterGiftTastesField.GetText(giftTastes, showTaste, onlyRevealed, highlightUnrevealed, ownedItemsCache)) { }
+        public CharacterGiftTastesField(string label, IDictionary<GiftTaste, GiftTasteModel[]> giftTastes, GiftTaste showTaste, bool onlyRevealed, bool highlightUnrevealed, bool showUnowned, IDictionary<string, bool> ownedItemsCache)
+            : base(label, CharacterGiftTastesField.GetText(giftTastes, showTaste, onlyRevealed, highlightUnrevealed, showUnowned, ownedItemsCache)) { }
 
         /// <summary>Get a lookup cache for owned items.</summary>
         /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
@@ -51,7 +51,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
         /// <param name="onlyRevealed">Only show gift tastes the player has discovered for themselves.</param>
         /// <param name="highlightUnrevealed">Whether to highlight items which haven't been revealed in the NPC profile yet.</param>
         /// <param name="ownedItemsCache">A lookup cache for owned items, as created by <see cref="GetOwnedItemsCache"/>.</param>
-        private static IEnumerable<IFormattedText> GetText(IDictionary<GiftTaste, GiftTasteModel[]> giftTastes, GiftTaste showTaste, bool onlyRevealed, bool highlightUnrevealed, IDictionary<string, bool> ownedItemsCache)
+        private static IEnumerable<IFormattedText> GetText(IDictionary<GiftTaste, GiftTasteModel[]> giftTastes, GiftTaste showTaste, bool onlyRevealed, bool highlightUnrevealed, bool showUnowned, IDictionary<string, bool> ownedItemsCache)
         {
             if (!giftTastes.ContainsKey(showTaste))
                 yield break;
@@ -76,6 +76,9 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
             int unrevealed = onlyRevealed
                 ? giftTastes[showTaste].Count(p => !p.IsRevealed)
                 : 0;
+            int unowned = showUnowned
+                ? 0
+                : items.Count(i => !i.IsInventory && !i.IsOwned);
 
             // generate text
             if (items.Any())
@@ -92,9 +95,12 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                         yield return new FormattedText(text, Color.Green, bold);
                     else if (entry.IsOwned)
                         yield return new FormattedText(text, Color.Black, bold);
-                    else
+                    else if (showUnowned)
                         yield return new FormattedText(text, Color.Gray, bold);
                 }
+
+                if (unowned > 0)
+                    yield return new FormattedText(I18n.Npc_UnownedGiftTasteAppended(count: unowned), Color.Gray);
 
                 if (unrevealed > 0)
                     yield return new FormattedText(I18n.Npc_UndiscoveredGiftTasteAppended(count: unrevealed), Color.Gray);

--- a/LookupAnything/Framework/Fields/CharacterGiftTastesField.cs
+++ b/LookupAnything/Framework/Fields/CharacterGiftTastesField.cs
@@ -18,11 +18,12 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
         /// <param name="label">A short field label.</param>
         /// <param name="giftTastes">The items by how much this NPC likes receiving them.</param>
         /// <param name="showTaste">The gift taste to show.</param>
-        /// <param name="onlyRevealed">Only show gift tastes the player has discovered for themselves.</param>
+        /// <param name="onlyRevealed">Whether to only show gift tastes the player has discovered for themselves.</param>
         /// <param name="highlightUnrevealed">Whether to highlight items which haven't been revealed in the NPC profile yet.</param>
+        /// <param name="onlyOwned">Whether to only show gift tastes for items which the player owns somewhere in the world.</param>
         /// <param name="ownedItemsCache">A lookup cache for owned items, as created by <see cref="GetOwnedItemsCache"/>.</param>
-        public CharacterGiftTastesField(string label, IDictionary<GiftTaste, GiftTasteModel[]> giftTastes, GiftTaste showTaste, bool onlyRevealed, bool highlightUnrevealed, bool showUnowned, IDictionary<string, bool> ownedItemsCache)
-            : base(label, CharacterGiftTastesField.GetText(giftTastes, showTaste, onlyRevealed, highlightUnrevealed, showUnowned, ownedItemsCache)) { }
+        public CharacterGiftTastesField(string label, IDictionary<GiftTaste, GiftTasteModel[]> giftTastes, GiftTaste showTaste, bool onlyRevealed, bool highlightUnrevealed, bool onlyOwned, IDictionary<string, bool> ownedItemsCache)
+            : base(label, CharacterGiftTastesField.GetText(giftTastes, showTaste, onlyRevealed, highlightUnrevealed, onlyOwned, ownedItemsCache)) { }
 
         /// <summary>Get a lookup cache for owned items.</summary>
         /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
@@ -48,10 +49,11 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
         /// <summary>Get the text to display.</summary>
         /// <param name="giftTastes">The items by how much this NPC likes receiving them.</param>
         /// <param name="showTaste">The gift taste to show.</param>
-        /// <param name="onlyRevealed">Only show gift tastes the player has discovered for themselves.</param>
+        /// <param name="onlyRevealed">Whether to only show gift tastes the player has discovered for themselves.</param>
         /// <param name="highlightUnrevealed">Whether to highlight items which haven't been revealed in the NPC profile yet.</param>
+        /// <param name="onlyOwned">Whether to only show gift tastes for items which the player owns somewhere in the world.</param>
         /// <param name="ownedItemsCache">A lookup cache for owned items, as created by <see cref="GetOwnedItemsCache"/>.</param>
-        private static IEnumerable<IFormattedText> GetText(IDictionary<GiftTaste, GiftTasteModel[]> giftTastes, GiftTaste showTaste, bool onlyRevealed, bool highlightUnrevealed, bool showUnowned, IDictionary<string, bool> ownedItemsCache)
+        private static IEnumerable<IFormattedText> GetText(IDictionary<GiftTaste, GiftTasteModel[]> giftTastes, GiftTaste showTaste, bool onlyRevealed, bool highlightUnrevealed, bool onlyOwned, IDictionary<string, bool> ownedItemsCache)
         {
             if (!giftTastes.ContainsKey(showTaste))
                 yield break;
@@ -63,50 +65,56 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                     from entry in giftTastes[showTaste]
                     let item = entry.Item
 
-                    let inInventory = ownedItemsCache.TryGetValue(CharacterGiftTastesField.GetOwnedItemKey(item), out bool rawVal)
-                        ? rawVal
-                        : null as bool?
-                    let isOwned = inInventory != null
+                    let ownership = ownedItemsCache.TryGetValue(CharacterGiftTastesField.GetOwnedItemKey(item), out bool rawVal) ? rawVal : null as bool? // true = in inventory, false = owned elsewhere, null = none found
+                    let isOwned = ownership is not null
+                    let inInventory = ownership is true
 
-                    where !onlyRevealed || entry.IsRevealed
-                    orderby inInventory ?? false descending, isOwned descending, item.DisplayName
-                    select new { Item = item, IsInventory = inInventory ?? false, IsOwned = isOwned, isRevealed = entry.IsRevealed }
+                    orderby inInventory descending, isOwned descending, item.DisplayName
+                    select new { Item = item, IsInventory = inInventory, IsOwned = isOwned, entry.IsRevealed }
                 )
                 .ToArray();
-            int unrevealed = onlyRevealed
-                ? giftTastes[showTaste].Count(p => !p.IsRevealed)
-                : 0;
-            int unowned = showUnowned
-                ? 0
-                : items.Count(i => !i.IsInventory && !i.IsOwned);
 
             // generate text
             if (items.Any())
             {
+                int unrevealed = 0;
+                int unowned = 0;
+
                 for (int i = 0, last = items.Length - 1; i <= last; i++)
                 {
                     var entry = items[i];
+
+                    if (onlyRevealed && !entry.IsRevealed)
+                    {
+                        unrevealed++;
+                        continue;
+                    }
+
+                    if (onlyOwned && !entry.IsOwned)
+                    {
+                        unowned++;
+                        continue;
+                    }
+
                     string text = i != last
                         ? entry.Item.DisplayName + ", "
                         : entry.Item.DisplayName;
-                    bool bold = highlightUnrevealed && !entry.isRevealed;
+                    bool bold = highlightUnrevealed && !entry.IsRevealed;
 
                     if (entry.IsInventory)
                         yield return new FormattedText(text, Color.Green, bold);
                     else if (entry.IsOwned)
                         yield return new FormattedText(text, Color.Black, bold);
-                    else if (showUnowned)
+                    else
                         yield return new FormattedText(text, Color.Gray, bold);
                 }
 
-                if (unowned > 0)
-                    yield return new FormattedText(I18n.Npc_UnownedGiftTasteAppended(count: unowned), Color.Gray);
-
                 if (unrevealed > 0)
-                    yield return new FormattedText(I18n.Npc_UndiscoveredGiftTasteAppended(count: unrevealed), Color.Gray);
+                    yield return new FormattedText(I18n.Npc_UndiscoveredGiftTaste(count: unrevealed), Color.Gray);
+
+                if (unowned > 0)
+                    yield return new FormattedText(I18n.Npc_UnownedGiftTaste(count: unowned), Color.Gray);
             }
-            else
-                yield return new FormattedText(I18n.Npc_UndiscoveredGiftTaste(count: unrevealed), Color.Gray);
         }
     }
 }

--- a/LookupAnything/Framework/GenericModConfigMenuIntegrationForLookupAnything.cs
+++ b/LookupAnything/Framework/GenericModConfigMenuIntegrationForLookupAnything.cs
@@ -63,6 +63,12 @@ namespace Pathoschild.Stardew.LookupAnything.Framework
                     get: config => config.ShowAllGiftTastes,
                     set: (config, value) => config.ShowAllGiftTastes = value
                 )
+                .AddCheckbox(
+                    name: I18n.Config_ShowUnownedGifts_Name,
+                    tooltip: I18n.Config_ShowUnownedGifts_Desc,
+                    get: config => config.ShowUnownedGifts,
+                    set: (config, value) => config.ShowUnownedGifts = value
+                )
 
                 .AddSectionTitle(I18n.Config_Title_AdvancedOptions)
                 .AddCheckbox(
@@ -88,12 +94,6 @@ namespace Pathoschild.Stardew.LookupAnything.Framework
                     tooltip: I18n.Config_TargetRedirection_Desc,
                     get: config => config.EnableTargetRedirection,
                     set: (config, value) => config.EnableTargetRedirection = value
-                )
-                .AddCheckbox(
-                    name: I18n.Config_ShowUnownedGifts_Name,
-                    tooltip: I18n.Config_ShowUnownedGifts_Desc,
-                    get: config => config.ShowUnownedGifts,
-                    set: (config, value) => config.ShowUnownedGifts = value
                 )
                 .AddNumberField(
                     name: I18n.Config_ScrollAmount_Name,

--- a/LookupAnything/Framework/GenericModConfigMenuIntegrationForLookupAnything.cs
+++ b/LookupAnything/Framework/GenericModConfigMenuIntegrationForLookupAnything.cs
@@ -89,6 +89,12 @@ namespace Pathoschild.Stardew.LookupAnything.Framework
                     get: config => config.EnableTargetRedirection,
                     set: (config, value) => config.EnableTargetRedirection = value
                 )
+                .AddCheckbox(
+                    name: I18n.Config_ShowUnownedGifts_Name,
+                    tooltip: I18n.Config_ShowUnownedGifts_Desc,
+                    get: config => config.ShowUnownedGifts,
+                    set: (config, value) => config.ShowUnownedGifts = value
+                )
                 .AddNumberField(
                     name: I18n.Config_ScrollAmount_Name,
                     tooltip: I18n.Config_ScrollAmount_Desc,

--- a/LookupAnything/Framework/Lookups/Characters/CharacterLookupProvider.cs
+++ b/LookupAnything/Framework/Lookups/Characters/CharacterLookupProvider.cs
@@ -285,7 +285,8 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Characters
                 progressionMode: config.ProgressionMode,
                 highlightUnrevealedGiftTastes: config.HighlightUnrevealedGiftTastes,
                 showAllGiftTastes: config.ShowAllGiftTastes,
-                enableTargetRedirection: config.EnableTargetRedirection
+                enableTargetRedirection: config.EnableTargetRedirection,
+                showUnowned: config.ShowUnownedGifts
             );
         }
 

--- a/LookupAnything/Framework/Lookups/Characters/CharacterLookupProvider.cs
+++ b/LookupAnything/Framework/Lookups/Characters/CharacterLookupProvider.cs
@@ -286,7 +286,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Characters
                 highlightUnrevealedGiftTastes: config.HighlightUnrevealedGiftTastes,
                 showAllGiftTastes: config.ShowAllGiftTastes,
                 enableTargetRedirection: config.EnableTargetRedirection,
-                showUnowned: config.ShowUnownedGifts
+                showUnownedGifts: config.ShowUnownedGifts
             );
         }
 

--- a/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
+++ b/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
@@ -51,6 +51,9 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Characters
         /// <summary>Whether to look up the original entity when the game spawns a temporary copy.</summary>
         private readonly bool EnableTargetRedirection;
 
+        /// <summary>Whether to show unowned gift tastes. </summary>
+        private readonly bool ShowUnownedGifts;
+
         /// <summary>Whether the NPC is Gourmand in the Fern Islands farm cave.</summary>
         private readonly bool IsGourmand;
 
@@ -76,7 +79,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Characters
         /// <param name="showAllGiftTastes">Whether to show all NPC gift tastes.</param>
         /// <param name="enableTargetRedirection">Whether to look up the original entity when the game spawns a temporary copy.</param>
         /// <remarks>Reverse engineered from <see cref="NPC"/>.</remarks>
-        public CharacterSubject(ISubjectRegistry codex, GameHelper gameHelper, NPC npc, SubjectType type, Metadata metadata, IReflectionHelper reflectionHelper, bool progressionMode, bool highlightUnrevealedGiftTastes, bool showAllGiftTastes, bool enableTargetRedirection)
+        public CharacterSubject(ISubjectRegistry codex, GameHelper gameHelper, NPC npc, SubjectType type, Metadata metadata, IReflectionHelper reflectionHelper, bool progressionMode, bool highlightUnrevealedGiftTastes, bool showAllGiftTastes, bool enableTargetRedirection, bool showUnowned)
             : base(gameHelper)
         {
             this.Codex = codex;
@@ -85,6 +88,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Characters
             this.HighlightUnrevealedGiftTastes = highlightUnrevealedGiftTastes;
             this.ShowAllGiftTastes = showAllGiftTastes;
             this.EnableTargetRedirection = enableTargetRedirection;
+            this.ShowUnownedGifts = showUnowned;
 
             // initialize
             this.Target = npc;
@@ -398,7 +402,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Characters
         /// <param name="taste">The gift taste to display.</param>
         private ICustomField GetGiftTasteField(string label, IDictionary<GiftTaste, GiftTasteModel[]> giftTastes, IDictionary<string, bool> ownedItemsCache, GiftTaste taste)
         {
-            return new CharacterGiftTastesField(label, giftTastes, taste, onlyRevealed: this.ProgressionMode, highlightUnrevealed: this.HighlightUnrevealedGiftTastes, ownedItemsCache);
+            return new CharacterGiftTastesField(label, giftTastes, taste, onlyRevealed: this.ProgressionMode, highlightUnrevealed: this.HighlightUnrevealedGiftTastes, showUnowned: this.ShowUnownedGifts, ownedItemsCache);
         }
 
         /*****

--- a/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
+++ b/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
@@ -51,7 +51,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Characters
         /// <summary>Whether to look up the original entity when the game spawns a temporary copy.</summary>
         private readonly bool EnableTargetRedirection;
 
-        /// <summary>Whether to show unowned gift tastes. </summary>
+        /// <summary>Whether to show gift tastes that the player doesn't own somewhere in the world.</summary>
         private readonly bool ShowUnownedGifts;
 
         /// <summary>Whether the NPC is Gourmand in the Fern Islands farm cave.</summary>
@@ -78,8 +78,9 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Characters
         /// <param name="highlightUnrevealedGiftTastes">Whether to highlight item gift tastes which haven't been revealed in the NPC profile.</param>
         /// <param name="showAllGiftTastes">Whether to show all NPC gift tastes.</param>
         /// <param name="enableTargetRedirection">Whether to look up the original entity when the game spawns a temporary copy.</param>
+        /// <param name="showUnownedGifts">Whether to show gift tastes that the player doesn't own somewhere in the world.</param>
         /// <remarks>Reverse engineered from <see cref="NPC"/>.</remarks>
-        public CharacterSubject(ISubjectRegistry codex, GameHelper gameHelper, NPC npc, SubjectType type, Metadata metadata, IReflectionHelper reflectionHelper, bool progressionMode, bool highlightUnrevealedGiftTastes, bool showAllGiftTastes, bool enableTargetRedirection, bool showUnowned)
+        public CharacterSubject(ISubjectRegistry codex, GameHelper gameHelper, NPC npc, SubjectType type, Metadata metadata, IReflectionHelper reflectionHelper, bool progressionMode, bool highlightUnrevealedGiftTastes, bool showAllGiftTastes, bool enableTargetRedirection, bool showUnownedGifts)
             : base(gameHelper)
         {
             this.Codex = codex;
@@ -88,7 +89,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Characters
             this.HighlightUnrevealedGiftTastes = highlightUnrevealedGiftTastes;
             this.ShowAllGiftTastes = showAllGiftTastes;
             this.EnableTargetRedirection = enableTargetRedirection;
-            this.ShowUnownedGifts = showUnowned;
+            this.ShowUnownedGifts = showUnownedGifts;
 
             // initialize
             this.Target = npc;
@@ -402,7 +403,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Characters
         /// <param name="taste">The gift taste to display.</param>
         private ICustomField GetGiftTasteField(string label, IDictionary<GiftTaste, GiftTasteModel[]> giftTastes, IDictionary<string, bool> ownedItemsCache, GiftTaste taste)
         {
-            return new CharacterGiftTastesField(label, giftTastes, taste, onlyRevealed: this.ProgressionMode, highlightUnrevealed: this.HighlightUnrevealedGiftTastes, showUnowned: this.ShowUnownedGifts, ownedItemsCache);
+            return new CharacterGiftTastesField(label, giftTastes, taste, onlyRevealed: this.ProgressionMode, highlightUnrevealed: this.HighlightUnrevealedGiftTastes, onlyOwned: !this.ShowUnownedGifts, ownedItemsCache);
         }
 
         /*****

--- a/LookupAnything/Framework/ModConfig.cs
+++ b/LookupAnything/Framework/ModConfig.cs
@@ -43,7 +43,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework
         /// <summary>Whether to show advanced data mining fields.</summary>
         public bool ShowDataMiningFields { get; set; }
 
-        /// <summary>Whether to show gift tastes that are unowned. </summary>
+        /// <summary>Whether to show gift tastes that the player doesn't own somewhere in the world.</summary>
         public bool ShowUnownedGifts { get; set; } = true;
     }
 }

--- a/LookupAnything/Framework/ModConfig.cs
+++ b/LookupAnything/Framework/ModConfig.cs
@@ -42,5 +42,8 @@ namespace Pathoschild.Stardew.LookupAnything.Framework
 
         /// <summary>Whether to show advanced data mining fields.</summary>
         public bool ShowDataMiningFields { get; set; }
+
+        /// <summary>Whether to show gift tastes that are unowned. </summary>
+        public bool ShowUnownedGifts { get; set; } = true;
     }
 }

--- a/LookupAnything/i18n/de.json
+++ b/LookupAnything/i18n/de.json
@@ -536,7 +536,7 @@
     "npc.friendship.need-bouquet": "Blumenstrauß für nächstes erforderlich",
     "npc.friendship.need-points": "nächstes in {{count}} Punkten",
     "npc.undiscovered-gift-taste": "{{count}} unaufgedeckte Gegenstände",
-    "npc.undiscovered-gift-taste-appended": " und {{count}} unaufgedeckte Gegenstände",
+    "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
 
 
     /*********
@@ -713,6 +713,8 @@
     "config.highlight-unrevealed-gift-tastes.desc": "Hervorhebung von Gegenstandsgeschenken, die im NSC-Profil noch nicht offenbart wurden. Wenn diese Option aktiviert ist, werden nicht enthüllte Geschenkvorlieben fett dargestellt und es werden auch ungeliebte/gehasste Geschenke angezeigt.",
     "config.show-all-gift-tastes.name": "Zeige alle Geschenk Vorlieben",
     "config.show-all-gift-tastes.desc": "Ob alle Geschenkvorlieben bei der Suche nach NSCs und Gegenständen angezeigt werden sollen; wenn deaktiviert, werden nur die relevantesten Vorlieben (z.B. geliebte oder beliebte Geschenke) angezeigt.",
+    "config.show-unowned-gifts.name": "Show unowned gift tastes", // TODO
+    "config.show-unowned-gifts.desc": "Whether to show gift tastes for items that the player doesn't own somewhere in the world.", // TODO
 
     // advanced options
     "config.title.advanced-options": "Erweiterte Optionen",

--- a/LookupAnything/i18n/default.json
+++ b/LookupAnything/i18n/default.json
@@ -535,6 +535,7 @@
     "npc.friendship.need-points": "next in {{count}} pts",
     "npc.undiscovered-gift-taste": "{{count}} unrevealed items",
     "npc.undiscovered-gift-taste-appended": ", and {{count}} unrevealed items",
+    "npc.unowned-gift-taste-appended": " and {{count}} unowned items",
 
 
     /*********
@@ -725,6 +726,8 @@
     "config.target-redirection.desc": "In some cases the game spawns a temporary entity to represent another one. For example, Abigail in the mines is actually a temporary NPC with the name 'AbigailMine', so looking her up there won't show Abigail's real info. With this option enabled, Lookup Anything will look up the original Abigail instead.",
     "config.scroll-amount.name": "Scroll amount",
     "config.scroll-amount.desc": "The number of pixels to shift content on each up/down scroll.",
+    "config.show-unowned-gifts.name": "Show Unowned Gifts",
+    "config.show-unowned-gifts.desc": "Whether to show gifts that the player doesn't own or have in their inventory",
 
     // controls section
     "config.title.controls": "Controls",

--- a/LookupAnything/i18n/default.json
+++ b/LookupAnything/i18n/default.json
@@ -534,8 +534,7 @@
     "npc.friendship.need-bouquet": "need bouquet for next",
     "npc.friendship.need-points": "next in {{count}} pts",
     "npc.undiscovered-gift-taste": "{{count}} unrevealed items",
-    "npc.undiscovered-gift-taste-appended": ", and {{count}} unrevealed items",
-    "npc.unowned-gift-taste-appended": " and {{count}} unowned items",
+    "npc.unowned-gift-taste": "{{count}} unowned items",
 
 
     /*********
@@ -713,6 +712,8 @@
     "config.highlight-unrevealed-gift-tastes.desc": "Whether to highlight item gift tastes which haven't been revealed in the NPC profile. When enabled, unrevealed gift tastes will be bold and lookups will also show disliked/hated gifts.",
     "config.show-all-gift-tastes.name": "Show all gift tastes",
     "config.show-all-gift-tastes.desc": "Whether to show all gift tastes for NPC and item lookups; when disabled, only the most relevant tastes (e.g. loved or liked gifts) are shown.",
+    "config.show-unowned-gifts.name": "Show unowned gift tastes",
+    "config.show-unowned-gifts.desc": "Whether to show gift tastes for items that the player doesn't own somewhere in the world.",
 
     // advanced options
     "config.title.advanced-options": "Advanced options",
@@ -726,8 +727,6 @@
     "config.target-redirection.desc": "In some cases the game spawns a temporary entity to represent another one. For example, Abigail in the mines is actually a temporary NPC with the name 'AbigailMine', so looking her up there won't show Abigail's real info. With this option enabled, Lookup Anything will look up the original Abigail instead.",
     "config.scroll-amount.name": "Scroll amount",
     "config.scroll-amount.desc": "The number of pixels to shift content on each up/down scroll.",
-    "config.show-unowned-gifts.name": "Show Unowned Gifts",
-    "config.show-unowned-gifts.desc": "Whether to show gifts that the player doesn't own or have in their inventory",
 
     // controls section
     "config.title.controls": "Controls",

--- a/LookupAnything/i18n/es.json
+++ b/LookupAnything/i18n/es.json
@@ -535,7 +535,7 @@
     "npc.friendship.need-bouquet": "Necesitas un ramo de flores para lo siguiente",
     "npc.friendship.need-points": "siguiente en {{count}} puntos",
     "npc.undiscovered-gift-taste": "{{count}} items sin revelar",
-    "npc.undiscovered-gift-taste-appended": ", y {{count}} items sin revelar",
+    "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
 
 
     /*********
@@ -714,6 +714,8 @@
     "config.highlight-unrevealed-gift-tastes.desc": "Si se desea resaltar los gustos de los regalos que no han sido revelados en el perfil del NPC. Cuando se activa, los gustos de los regalos no revelados estarán en negrita y las búsquedas también mostrarán los regalos que no gustan/odian.",
     "config.show-all-gift-tastes.name": "Mostrar todos los gustos de los regalos",
     "config.show-all-gift-tastes.desc": "Mostrar o no todos los gustos de los regalos en las búsquedas de PNJs y objetos; cuando se desactiva, sólo se muestran los gustos más relevantes (por ejemplo, los regalos amados o gustados).",
+    "config.show-unowned-gifts.name": "Show unowned gift tastes", // TODO
+    "config.show-unowned-gifts.desc": "Whether to show gift tastes for items that the player doesn't own somewhere in the world.", // TODO
 
     // advanced options
     "config.title.advanced-options": "Opciones avanzadas",

--- a/LookupAnything/i18n/fr.json
+++ b/LookupAnything/i18n/fr.json
@@ -533,7 +533,7 @@
     "npc.friendship.need-bouquet": "besoin d'un bouquet",
     "npc.friendship.need-points": "manque {{count}} pts",
     "npc.undiscovered-gift-taste": "{{count}} goût(s) non révelé(s)",
-    "npc.undiscovered-gift-taste-appended": ", et {{count}} goût(s) non révelé(s)",
+    "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
 
 
     /*********
@@ -711,6 +711,8 @@
     "config.highlight-unrevealed-gift-tastes.desc": "Si vous souhaitez mettre en évidence les goûts en matière de cadeaux qui n'ont pas été révélés dans le profil du PNJ. Lorsque cette option est activée, les goûts des cadeaux qui n'ont pas été révélés seront en gras et les recherches montreront également les cadeaux pas aimé ou détesté.",
     "config.show-all-gift-tastes.name": "Afficher tous les goûts en matière de cadeaux",
     "config.show-all-gift-tastes.desc": "Afficher ou non tous les goûts en matière de cadeaux pour les recherches de PNJ et d'objets ; si cette option est désactivée, seuls les goûts les plus pertinents (par exemple, les cadeaux aimés ou appréciés) sont affichés.",
+    "config.show-unowned-gifts.name": "Show unowned gift tastes", // TODO
+    "config.show-unowned-gifts.desc": "Whether to show gift tastes for items that the player doesn't own somewhere in the world.", // TODO
 
     // advanced options
     "config.title.advanced-options": "Options avancées",

--- a/LookupAnything/i18n/hu.json
+++ b/LookupAnything/i18n/hu.json
@@ -537,7 +537,7 @@
     "npc.friendship.need-bouquet": "a következőhöz adjál neki virágcsokrot.",
     "npc.friendship.need-points": "Következő szint {{count}} pont múlva",
     "npc.undiscovered-gift-taste": "{{count}} fel nem fedezett dolog",
-    "npc.undiscovered-gift-taste-appended": ", és {{count}} fel nem fedezett dolog",
+    "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
 
 
     /*********
@@ -723,6 +723,8 @@
     "config.highlight-unrevealed-gift-tastes.desc": "Whether to highlight item gift tastes which haven't been revealed in the NPC profile. When enabled, unrevealed gift tastes will be bold and lookups will also show disliked/hated gifts.",
     "config.show-all-gift-tastes.name": "Show all gift tastes",
     "config.show-all-gift-tastes.desc": "Whether to show all gift tastes for NPC and item lookups; when disabled, only the most relevant tastes (e.g. loved or liked gifts) are shown.",
+    "config.show-unowned-gifts.name": "Show unowned gift tastes", // TODO
+    "config.show-unowned-gifts.desc": "Whether to show gift tastes for items that the player doesn't own somewhere in the world.", // TODO
 
     // advanced options
     // TODO

--- a/LookupAnything/i18n/it.json
+++ b/LookupAnything/i18n/it.json
@@ -535,7 +535,7 @@
     "npc.friendship.need-bouquet": "ha bisogno di un bouquet per avanzare",
     "npc.friendship.need-points": "prossimo fra {{count}} pti",
     "npc.undiscovered-gift-taste": "{{count}} oggetti non rivelati",
-    "npc.undiscovered-gift-taste-appended": ", e {{count}} oggetti non rivelati",
+    "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
 
 
     /*********
@@ -713,6 +713,8 @@
     "config.highlight-unrevealed-gift-tastes.desc": "Scegli se evidenziare i gusti dei regali degli oggetti che non sono stati rivelati nel profilo del PNG. Se abilitato, i gusti dei regali non rivelati saranno in grassetto e le ricerche mostreranno anche i regali non graditi/odiati.",
     "config.show-all-gift-tastes.name": "Mostra tutti i gusti dei regali",
     "config.show-all-gift-tastes.desc": "Scegli se si desidera mostrare tutti i gusti dei regali per la ricerca di PNG e oggetti; quando è disattivato, vengono mostrati solo i gusti più rilevanti (ad esempio, i regali amati o graditi).",
+    "config.show-unowned-gifts.name": "Show unowned gift tastes", // TODO
+    "config.show-unowned-gifts.desc": "Whether to show gift tastes for items that the player doesn't own somewhere in the world.", // TODO
 
     // advanced options
     "config.title.advanced-options": "Opzioni avanzate",

--- a/LookupAnything/i18n/ja.json
+++ b/LookupAnything/i18n/ja.json
@@ -546,7 +546,7 @@
     "npc.friendship.need-bouquet": "進むには花束が必要",
     "npc.friendship.need-points": "{{count}}ポイント必要",
     "npc.undiscovered-gift-taste": "{{count}}個の贈った事のないアイテム",
-    "npc.undiscovered-gift-taste-appended": ", 他{{count}}個の贈った事のないアイテム",
+    "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
 
 
     /*********
@@ -725,6 +725,8 @@
     "config.highlight-unrevealed-gift-tastes.desc": "Whether to highlight item gift tastes which haven't been revealed in the NPC profile. When enabled, unrevealed gift tastes will be bold and lookups will also show disliked/hated gifts.",
     "config.show-all-gift-tastes.name": "Show all gift tastes",
     "config.show-all-gift-tastes.desc": "Whether to show all gift tastes for NPC and item lookups; when disabled, only the most relevant tastes (e.g. loved or liked gifts) are shown.",
+    "config.show-unowned-gifts.name": "Show unowned gift tastes", // TODO
+    "config.show-unowned-gifts.desc": "Whether to show gift tastes for items that the player doesn't own somewhere in the world.", // TODO
 
     // advanced options
     // TODO

--- a/LookupAnything/i18n/ko.json
+++ b/LookupAnything/i18n/ko.json
@@ -534,7 +534,7 @@
     "npc.friendship.need-bouquet": "다음 호감도 진행을 위해서 꽃다발 필요.",
     "npc.friendship.need-points": "호감도 UP까지 {{count}}점",
     "npc.undiscovered-gift-taste": "{{count}} 미공개 품목",
-    "npc.undiscovered-gift-taste-appended": ", 그리고 {{count}} 미공개 품목",
+    "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
 
 
     /*********
@@ -712,6 +712,8 @@
     "config.highlight-unrevealed-gift-tastes.desc": "NPC 프로필에 표시되지 않은 항목 선물 취향을 강조 표시할지 여부. 활성화하면 공개되지 않은 선물 취향이 굵게 표시되고 조회 시 싫어하거나/증오하는 선물도 표시됩니다.",
     "config.show-all-gift-tastes.name": "모든 선물 취향 표시",
     "config.show-all-gift-tastes.desc": "NPC 및 아이템 조회에 대한 모든 선물 취향을 표시할지 여부. 비활성화되면 가장 관련성이 높은 취향(예: 사랑하거나 좋아하는 선물)만 표시됩니다.",
+    "config.show-unowned-gifts.name": "Show unowned gift tastes", // TODO
+    "config.show-unowned-gifts.desc": "Whether to show gift tastes for items that the player doesn't own somewhere in the world.", // TODO
 
     // advanced options
     "config.title.advanced-options": "고급 옵션",

--- a/LookupAnything/i18n/pl.json
+++ b/LookupAnything/i18n/pl.json
@@ -536,7 +536,7 @@
     "npc.friendship.need-bouquet": "potrzeba bukietu na następne",
     "npc.friendship.need-points": "następne za {{count}} pkt",
     "npc.undiscovered-gift-taste": "{{count}} nieodkrytych przedmiotów",
-    "npc.undiscovered-gift-taste-appended": ", oraz {{count}} nieodkrytych przedmiotów",
+    "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
 
 
     /*********
@@ -714,6 +714,8 @@
     "config.highlight-unrevealed-gift-tastes.desc": "Czy wyróżniać przedmioty w upodobaniach prezentowych, które nie zostały odkryte w profilu NPC. Gdy ta opcja jest włączona, nieodkryte upodobania prezentowe będą pogrubione, a w podglądach pojawią się również nielubiane/znienawidzone prezenty.",
     "config.show-all-gift-tastes.name": "Pokaż wszystkie upodobania",
     "config.show-all-gift-tastes.desc": "Czy pokazywać wszystkie upodobania prezentowe dla podglądów NPC i przedmiotów. Gdy ta opcja jest wyłączona, pokazywane są tylko najistotniejsze upodobania (np. ukochane lub lubiane prezenty).",
+    "config.show-unowned-gifts.name": "Show unowned gift tastes", // TODO
+    "config.show-unowned-gifts.desc": "Whether to show gift tastes for items that the player doesn't own somewhere in the world.", // TODO
 
     // advanced options
     "config.title.advanced-options": "Opcje zaawansowane",

--- a/LookupAnything/i18n/pt.json
+++ b/LookupAnything/i18n/pt.json
@@ -536,7 +536,7 @@
     "npc.friendship.need-bouquet": "Precisa de um buquê pra prosseguir",
     "npc.friendship.need-points": "Precisa de {{count}} pontos para prosseguir",
     "npc.undiscovered-gift-taste": "{{count}} itens não revelados",
-    "npc.undiscovered-gift-taste-appended": ", e {{count}} items não revelados",
+    "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
 
 
     /*********
@@ -715,6 +715,8 @@
     "config.highlight-unrevealed-gift-tastes.desc": "Whether to highlight item gift tastes which haven't been revealed in the NPC profile. When enabled, unrevealed gift tastes will be bold and lookups will also show disliked/hated gifts.",
     "config.show-all-gift-tastes.name": "Show all gift tastes",
     "config.show-all-gift-tastes.desc": "Whether to show all gift tastes for NPC and item lookups; when disabled, only the most relevant tastes (e.g. loved or liked gifts) are shown.",
+    "config.show-unowned-gifts.name": "Show unowned gift tastes", // TODO
+    "config.show-unowned-gifts.desc": "Whether to show gift tastes for items that the player doesn't own somewhere in the world.", // TODO
 
     // advanced options
     // TODO

--- a/LookupAnything/i18n/ru.json
+++ b/LookupAnything/i18n/ru.json
@@ -536,7 +536,7 @@
     "npc.friendship.need-bouquet": "нужен букет для след.",
     "npc.friendship.need-points": "след. через {{count}}",
     "npc.undiscovered-gift-taste": "{{count}} нераскрытых предметов",
-    "npc.undiscovered-gift-taste-appended": ", и {{count}} нераскрытых предметов",
+    "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
 
 
     /*********
@@ -715,6 +715,8 @@
     "config.highlight-unrevealed-gift-tastes.desc": "Whether to highlight item gift tastes which haven't been revealed in the NPC profile. When enabled, unrevealed gift tastes will be bold and lookups will also show disliked/hated gifts.",
     "config.show-all-gift-tastes.name": "Show all gift tastes",
     "config.show-all-gift-tastes.desc": "Whether to show all gift tastes for NPC and item lookups; when disabled, only the most relevant tastes (e.g. loved or liked gifts) are shown.",
+    "config.show-unowned-gifts.name": "Show unowned gift tastes", // TODO
+    "config.show-unowned-gifts.desc": "Whether to show gift tastes for items that the player doesn't own somewhere in the world.", // TODO
 
     // advanced options
     // TODO

--- a/LookupAnything/i18n/th.json
+++ b/LookupAnything/i18n/th.json
@@ -536,7 +536,7 @@
     "npc.friendship.need-bouquet": "ต้องให้ช่อดอกไม้เพื่อเลื่อนขั้น",
     "npc.friendship.need-points": "เลื่อนขั้นใน {{count}} แต้ม",
     "npc.undiscovered-gift-taste": "{{count}} ชิ้นที่ยังไม่เปิดเผย",
-    "npc.undiscovered-gift-taste-appended": ", และ {{count}} ชิ้นที่ยังไม่เปิดเผย",
+    "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
 
 
     /*********
@@ -714,6 +714,8 @@
     "config.highlight-unrevealed-gift-tastes.desc": "จะเน้นรสนิยมของขวัญของไอเท็มที่ยังไม่ได้เปิดเผยในโปรไฟล์ NPC หรือไม่ เมื่อเปิดใช้งาน รสนิยมของขวัญที่ยังไม่ได้เปิดเผยจะเป็นตัวหนา และการค้นหาจะแสดงของขวัญที่ไม่ชอบ/เกลียด",
     "config.show-all-gift-tastes.name": "แสดงรสนิยมของขวัญทั้งหมด",
     "config.show-all-gift-tastes.desc": "จะแสดงรสนิยมของขวัญทั้งหมดสำหรับ NPC และการค้นหารายการหรือไม่ เมื่อปิดใช้งาน จะแสดงเฉพาะรสนิยมที่เกี่ยวข้องมากที่สุด (เช่น ของขวัญที่รักหรือชอบ)",
+    "config.show-unowned-gifts.name": "Show unowned gift tastes", // TODO
+    "config.show-unowned-gifts.desc": "Whether to show gift tastes for items that the player doesn't own somewhere in the world.", // TODO
 
     // advanced options
     "config.title.advanced-options": "ตัวเลือกขั้นสูง",

--- a/LookupAnything/i18n/tr.json
+++ b/LookupAnything/i18n/tr.json
@@ -536,7 +536,7 @@
     "npc.friendship.need-bouquet": "ilerlemek için buket gerekli",
     "npc.friendship.need-points": "{{count}} puana gelişir",
     "npc.undiscovered-gift-taste": "{{count}} gizli nesneler",
-    "npc.undiscovered-gift-taste-appended": ", ve {{count}} gizli nesneler",
+    "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
 
 
     /*********
@@ -714,6 +714,8 @@
     "config.highlight-unrevealed-gift-tastes.desc": "NPC profilinde açıklanmayan eşya hediye zevklerinin vurgulanıp vurgulanmayacağı. Etkinleştirildiğinde, açıklanmayan hediye zevkleri cesur olacak ve aramalarda ayrıca beğenilmeyen/nefret edilen hediyeler de gösterilecek.",
     "config.show-all-gift-tastes.name": "Bütün hediye zevklerini göster",
     "config.show-all-gift-tastes.desc": "NPC ve item aramaları için tüm hediye zevklerinin gösterilip gösterilmeyeceği; devre dışı bırakıldığında, yalnızca en alakalı lezzetler (örneğin sevilen veya sevilen hediyeler) gösterilir.",
+    "config.show-unowned-gifts.name": "Show unowned gift tastes", // TODO
+    "config.show-unowned-gifts.desc": "Whether to show gift tastes for items that the player doesn't own somewhere in the world.", // TODO
 
     // advanced options
     "config.title.advanced-options": "Gelişmiş Seçenekler",

--- a/LookupAnything/i18n/uk.json
+++ b/LookupAnything/i18n/uk.json
@@ -534,7 +534,7 @@
     "npc.friendship.need-bouquet": "Потрібен букет для наступн.",
     "npc.friendship.need-points": "Наступн. за {{count}}",
     "npc.undiscovered-gift-taste": "{{count}} незвіданих предметів",
-    "npc.undiscovered-gift-taste-appended": " та {{count}} незвіданих предметів",
+    "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
 
 
     /*********
@@ -712,6 +712,8 @@
     "config.highlight-unrevealed-gift-tastes.desc": "Виділення улюблених подарунків, які не були виявлені в профілі НП. Якщо ввімкнено, не виявлені улюблені подарунки будуть жирними, а пошук також показуватиме подарунки, які не сподобалися/є жахливими.",
     "config.show-all-gift-tastes.name": "Показувати усі улюблені подарунки",
     "config.show-all-gift-tastes.desc": "Показ усіх улюблених подарунків для НП та пошуку предметів; якщо вимкнено, відображаються лише найбільш релевантні подарунки (наприклад, улюблені або ті, що сподобалися).",
+    "config.show-unowned-gifts.name": "Show unowned gift tastes", // TODO
+    "config.show-unowned-gifts.desc": "Whether to show gift tastes for items that the player doesn't own somewhere in the world.", // TODO
 
     // advanced options
     "config.title.advanced-options": "Розширені опції",

--- a/LookupAnything/i18n/zh.json
+++ b/LookupAnything/i18n/zh.json
@@ -537,7 +537,7 @@
     "npc.friendship.need-bouquet": "需要花束进行到下一阶段",
     "npc.friendship.need-points": "下一等级需要{{count}}点好感度",
     "npc.undiscovered-gift-taste": "{{count}} 个没揭露的品目",
-    "npc.undiscovered-gift-taste-appended": ", 和 {{count}} 个没揭露的品目",
+    "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
 
 
     /*********
@@ -715,6 +715,8 @@
     "config.highlight-unrevealed-gift-tastes.desc": "对未揭露的npc礼物好感度，加粗显示；同时显示不喜欢、厌恶的礼物。",
     "config.show-all-gift-tastes.name": "显示所有礼物好感度",
     "config.show-all-gift-tastes.desc": "开启后，显示npc所有的礼物好感度；关闭后，只显示重要的（最爱、喜欢）。",
+    "config.show-unowned-gifts.name": "Show unowned gift tastes", // TODO
+    "config.show-unowned-gifts.desc": "Whether to show gift tastes for items that the player doesn't own somewhere in the world.", // TODO
 
     // advanced options
     "config.title.advanced-options": "高级",


### PR DESCRIPTION
This helps with packs with thousands of items all with gift tastes and making the F1 menu have higher framerate due to the sheer volume of items

![image](https://user-images.githubusercontent.com/767456/217812163-970394a5-4f98-4731-a33c-d72f648e9132.png)
