### PR TITLE
Add optimizations to RangeValueProvider

### DIFF
--- a/ContentPatcher/Framework/Conditions/Condition.cs
+++ b/ContentPatcher/Framework/Conditions/Condition.cs
@@ -102,7 +102,10 @@ namespace ContentPatcher.Framework.Conditions
             // update values
             if (this.IsReady && token != null)
             {
-                this.CurrentValues = this.Values.SplitValuesUnique(token.NormalizeValue);
+                if (this.Values.IsMutable || !this.CurrentValues.Any())
+                {
+                    this.CurrentValues = this.Values.SplitValuesUnique(token.NormalizeValue);
+                }
                 this.IsMatch = token
                     .GetValues(this.Input)
                     .Any(value => this.CurrentValues.Contains(value));

--- a/ContentPatcher/Framework/Conditions/Condition.cs
+++ b/ContentPatcher/Framework/Conditions/Condition.cs
@@ -102,10 +102,9 @@ namespace ContentPatcher.Framework.Conditions
             // update values
             if (this.IsReady && token != null)
             {
-                if (this.Values.IsMutable || !this.CurrentValues.Any())
-                {
+                if (this.Values.IsMutable)
                     this.CurrentValues = this.Values.SplitValuesUnique(token.NormalizeValue);
-                }
+
                 this.IsMatch = token
                     .GetValues(this.Input)
                     .Any(value => this.CurrentValues.Contains(value));

--- a/ContentPatcher/Framework/Conditions/TokenString.cs
+++ b/ContentPatcher/Framework/Conditions/TokenString.cs
@@ -110,7 +110,10 @@ namespace ContentPatcher.Framework.Conditions
                     tokensUsed ??= new();
                     tokensUsed.Add(token.Name);
 
-                    isMutable = isMutable || token.IsMutable;
+                    if (!token.RequiresInput || !token.IsDeterministicForInput)
+                    {
+                        isMutable = isMutable || token.IsMutable;
+                    }
                 }
                 else
                 {

--- a/ContentPatcher/Framework/Conditions/TokenString.cs
+++ b/ContentPatcher/Framework/Conditions/TokenString.cs
@@ -110,8 +110,11 @@ namespace ContentPatcher.Framework.Conditions
                     tokensUsed ??= new();
                     tokensUsed.Add(token.Name);
 
-                    if (!token.RequiresInput || !token.IsDeterministicForInput)
+                    if (!token.IsDeterministicForInput)
                     {
+                        // If every token is deterministic, then the resulting string must be immutable. If this token
+                        // is deterministic but it receives non-deterministic input, the string will be marked mutable
+                        // when we recursively check those tokens.
                         isMutable = isMutable || token.IsMutable;
                     }
                 }

--- a/ContentPatcher/Framework/Tokens/IToken.cs
+++ b/ContentPatcher/Framework/Tokens/IToken.cs
@@ -19,6 +19,8 @@ namespace ContentPatcher.Framework.Tokens
         /// <summary>Whether this token is only valid with input arguments.</summary>
         bool RequiresInput { get; }
 
+        bool IsDeterministicForInput { get; }
+
         /// <summary>Whether to allow using this token in any value context (e.g. as a number or boolean) without validating ahead of time.</summary>
         bool BypassesContextValidation { get; }
 

--- a/ContentPatcher/Framework/Tokens/Token.cs
+++ b/ContentPatcher/Framework/Tokens/Token.cs
@@ -29,6 +29,8 @@ namespace ContentPatcher.Framework.Tokens
         /// <inheritdoc />
         public bool IsMutable => this.Values.IsMutable;
 
+        public bool IsDeterministicForInput => this.Values.IsMutable || this.Values.IsDeterministicForInput;
+
         /// <inheritdoc />
         public bool IsReady => this.Values.IsReady;
 

--- a/ContentPatcher/Framework/Tokens/Token.cs
+++ b/ContentPatcher/Framework/Tokens/Token.cs
@@ -29,7 +29,7 @@ namespace ContentPatcher.Framework.Tokens
         /// <inheritdoc />
         public bool IsMutable => this.Values.IsMutable;
 
-        public bool IsDeterministicForInput => this.Values.IsMutable || this.Values.IsDeterministicForInput;
+        public bool IsDeterministicForInput => !this.Values.IsMutable || this.Values.IsDeterministicForInput;
 
         /// <inheritdoc />
         public bool IsReady => this.Values.IsReady;

--- a/ContentPatcher/Framework/Tokens/ValueProviders/AbsoluteFilePathValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/AbsoluteFilePathValueProvider.cs
@@ -22,7 +22,7 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         /// <summary>Construct an instance.</summary>
         /// <param name="baseDirPath">The absolute path to the content pack's folder.</param>
         public AbsoluteFilePathValueProvider(string baseDirPath)
-            : base(ConditionType.AbsoluteFilePath, mayReturnMultipleValuesForRoot: false)
+            : base(ConditionType.AbsoluteFilePath, mayReturnMultipleValuesForRoot: false, isDeterministicForInput: true)
         {
             this.BaseDirPath = baseDirPath;
             this.EnableInputArguments(required: true, mayReturnMultipleValues: false, maxPositionalArgs: null);
@@ -33,7 +33,6 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         {
             bool changed = !this.IsReady;
             this.MarkReady(true);
-            this.IsDeterministicForInput = true;
             return changed;
         }
 

--- a/ContentPatcher/Framework/Tokens/ValueProviders/AbsoluteFilePathValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/AbsoluteFilePathValueProvider.cs
@@ -33,6 +33,7 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         {
             bool changed = !this.IsReady;
             this.MarkReady(true);
+            this.IsDeterministicForInput = true;
             return changed;
         }
 

--- a/ContentPatcher/Framework/Tokens/ValueProviders/BaseValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/BaseValueProvider.cs
@@ -42,6 +42,9 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         public bool IsMutable { get; protected set; } = true;
 
         /// <inheritdoc />
+        public bool IsDeterministicForInput { get; protected set; } = false;
+
+        /// <inheritdoc />
         public bool IsReady => this.State.IsReady;
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/BaseValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/BaseValueProvider.cs
@@ -225,17 +225,20 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         /// <summary>Construct an instance.</summary>
         /// <param name="name">The value provider name.</param>
         /// <param name="mayReturnMultipleValuesForRoot">Whether the root value provider may contain multiple values.</param>
-        protected BaseValueProvider(string name, bool mayReturnMultipleValuesForRoot)
+        /// <param name="isDeterministicForInput">Whether the value provider always contains the same values in every context given the same input arguments (i.e. it's immutable if its input arguments are).</param>
+        protected BaseValueProvider(string name, bool mayReturnMultipleValuesForRoot, bool isDeterministicForInput = false)
         {
             this.Name = name;
             this.MayReturnMultipleValuesForRoot = mayReturnMultipleValuesForRoot;
+            this.IsDeterministicForInput = isDeterministicForInput;
         }
 
         /// <summary>Construct an instance.</summary>
         /// <param name="type">The value provider name.</param>
         /// <param name="mayReturnMultipleValuesForRoot">Whether the root value provider may contain multiple values.</param>
-        protected BaseValueProvider(ConditionType type, bool mayReturnMultipleValuesForRoot)
-            : this(type.ToString(), mayReturnMultipleValuesForRoot) { }
+        /// <param name="isDeterministicForInput">Whether the value provider always contains the same values in every context given the same input arguments (i.e. it's immutable if its input arguments are).</param>
+        protected BaseValueProvider(ConditionType type, bool mayReturnMultipleValuesForRoot, bool isDeterministicForInput = false)
+            : this(type.ToString(), mayReturnMultipleValuesForRoot, isDeterministicForInput) { }
 
         /// <summary>Enable input arguments for this value provider.</summary>
         /// <param name="required">Whether input arguments are required when using this value provider.</param>

--- a/ContentPatcher/Framework/Tokens/ValueProviders/CountValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/CountValueProvider.cs
@@ -14,6 +14,7 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
             : base(ConditionType.Count, mayReturnMultipleValuesForRoot: false)
         {
             this.EnableInputArguments(required: false, mayReturnMultipleValues: false, maxPositionalArgs: null);
+            this.IsDeterministicForInput = true;
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/CountValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/CountValueProvider.cs
@@ -11,10 +11,9 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         *********/
         /// <summary>Construct an instance.</summary>
         public CountValueProvider()
-            : base(ConditionType.Count, mayReturnMultipleValuesForRoot: false)
+            : base(ConditionType.Count, mayReturnMultipleValuesForRoot: false, isDeterministicForInput: true)
         {
             this.EnableInputArguments(required: false, mayReturnMultipleValues: false, maxPositionalArgs: null);
-            this.IsDeterministicForInput = true;
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/FormatAssetNameValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/FormatAssetNameValueProvider.cs
@@ -17,6 +17,7 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         {
             this.EnableInputArguments(required: true, mayReturnMultipleValues: false, maxPositionalArgs: null);
             this.ValidNamedArguments = InvariantSets.FromValue("separator");
+            this.IsDeterministicForInput = true;
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/FormatAssetNameValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/FormatAssetNameValueProvider.cs
@@ -13,11 +13,10 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         *********/
         /// <summary>Construct an instance.</summary>
         public FormatAssetNameValueProvider()
-            : base(ConditionType.FormatAssetName, mayReturnMultipleValuesForRoot: false)
+            : base(ConditionType.FormatAssetName, mayReturnMultipleValuesForRoot: false, isDeterministicForInput: true)
         {
             this.EnableInputArguments(required: true, mayReturnMultipleValues: false, maxPositionalArgs: null);
             this.ValidNamedArguments = InvariantSets.FromValue("separator");
-            this.IsDeterministicForInput = true;
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/HasFileValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/HasFileValueProvider.cs
@@ -27,6 +27,8 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         {
             this.RelativePathExists = relativePathExists;
             this.EnableInputArguments(required: true, mayReturnMultipleValues: false, maxPositionalArgs: null);
+            // This is deterministic for end users, but may not be for developers expecting patch reload, or other mechanisms for the filesystem to be refreshed
+            this.IsDeterministicForInput = true;
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/HasFileValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/HasFileValueProvider.cs
@@ -23,12 +23,10 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         /// <summary>Construct an instance.</summary>
         /// <param name="relativePathExists">Get whether a relative file path exists in the content pack.</param>
         public HasFileValueProvider(Func<string, bool> relativePathExists)
-            : base(ConditionType.HasFile, mayReturnMultipleValuesForRoot: false)
+            : base(ConditionType.HasFile, mayReturnMultipleValuesForRoot: false, isDeterministicForInput: true) // limitation: isDeterministicForInput doesn't account for content pack authors using `patch reload` after adding/deleting files
         {
             this.RelativePathExists = relativePathExists;
             this.EnableInputArguments(required: true, mayReturnMultipleValues: false, maxPositionalArgs: null);
-            // This is deterministic for end users, but may not be for developers expecting patch reload, or other mechanisms for the filesystem to be refreshed
-            this.IsDeterministicForInput = true;
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/HasValueValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/HasValueValueProvider.cs
@@ -12,10 +12,9 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         *********/
         /// <summary>Construct an instance.</summary>
         public HasValueValueProvider()
-            : base(ConditionType.HasValue, mayReturnMultipleValuesForRoot: false)
+            : base(ConditionType.HasValue, mayReturnMultipleValuesForRoot: false, isDeterministicForInput: true)
         {
             this.EnableInputArguments(required: false, mayReturnMultipleValues: false, maxPositionalArgs: null);
-            this.IsDeterministicForInput = true;
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/HasValueValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/HasValueValueProvider.cs
@@ -15,6 +15,7 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
             : base(ConditionType.HasValue, mayReturnMultipleValuesForRoot: false)
         {
             this.EnableInputArguments(required: false, mayReturnMultipleValues: false, maxPositionalArgs: null);
+            this.IsDeterministicForInput = true;
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/IValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/IValueProvider.cs
@@ -20,6 +20,9 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         /// <summary>Whether the value provider requires positional input arguments, and does not provide values without it (see <see cref="AllowsPositionalInput"/>).</summary>
         bool RequiresPositionalInput { get; }
 
+        /// <summary>Whether the value provider is immutable / deterministic if the inputs are also immutable</summary>
+        bool IsDeterministicForInput { get; }
+
         /// <summary>Whether to allow using this token in any value context (e.g. as a number or boolean) without validating ahead of time.</summary>
         bool BypassesContextValidation { get; }
 

--- a/ContentPatcher/Framework/Tokens/ValueProviders/IValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/IValueProvider.cs
@@ -20,7 +20,7 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         /// <summary>Whether the value provider requires positional input arguments, and does not provide values without it (see <see cref="AllowsPositionalInput"/>).</summary>
         bool RequiresPositionalInput { get; }
 
-        /// <summary>Whether the value provider is immutable / deterministic if the inputs are also immutable</summary>
+        /// <summary>Whether the value provider always contains the same values in every context given the same input arguments (i.e. it's immutable if its input arguments are).</summary>
         bool IsDeterministicForInput { get; }
 
         /// <summary>Whether to allow using this token in any value context (e.g. as a number or boolean) without validating ahead of time.</summary>

--- a/ContentPatcher/Framework/Tokens/ValueProviders/LetterCaseValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/LetterCaseValueProvider.cs
@@ -21,14 +21,13 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         /// <summary>Construct an instance.</summary>
         /// <param name="type">The condition type. This must be one of <see cref="ConditionType.Lowercase"/> or <see cref="ConditionType.Uppercase"/>.</param>
         public LetterCaseValueProvider(ConditionType type)
-            : base(type, mayReturnMultipleValuesForRoot: false)
+            : base(type, mayReturnMultipleValuesForRoot: false, isDeterministicForInput: true)
         {
             if (type != ConditionType.Lowercase && type != ConditionType.Uppercase)
                 throw new ArgumentException($"The {nameof(type)} must be one of {ConditionType.Lowercase} or {ConditionType.Uppercase}.", nameof(type));
 
             this.Type = type;
             this.EnableInputArguments(required: false, mayReturnMultipleValues: false, maxPositionalArgs: null);
-            this.IsDeterministicForInput = true;
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/LetterCaseValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/LetterCaseValueProvider.cs
@@ -28,6 +28,7 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
 
             this.Type = type;
             this.EnableInputArguments(required: false, mayReturnMultipleValues: false, maxPositionalArgs: null);
+            this.IsDeterministicForInput = true;
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/MergeValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/MergeValueProvider.cs
@@ -11,10 +11,9 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         *********/
         /// <summary>Construct an instance.</summary>
         public MergeValueProvider()
-            : base(ConditionType.Merge, mayReturnMultipleValuesForRoot: false)
+            : base(ConditionType.Merge, mayReturnMultipleValuesForRoot: false, isDeterministicForInput: true)
         {
             this.EnableInputArguments(required: false, mayReturnMultipleValues: true, maxPositionalArgs: null);
-            this.IsDeterministicForInput = true;
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/MergeValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/MergeValueProvider.cs
@@ -14,6 +14,7 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
             : base(ConditionType.Merge, mayReturnMultipleValuesForRoot: false)
         {
             this.EnableInputArguments(required: false, mayReturnMultipleValues: true, maxPositionalArgs: null);
+            this.IsDeterministicForInput = true;
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/ModConvention/ConventionDelegates.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/ModConvention/ConventionDelegates.cs
@@ -14,6 +14,8 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders.ModConvention
         /// <remarks>Default true.</remarks>
         internal delegate bool IsMutable();
 
+        internal delegate bool IsDeterministicForInput();
+
         /// <summary>Get whether the token allows input arguments (e.g. an NPC name for a relationship token).</summary>
         /// <remarks>Default false.</remarks>
         internal delegate bool AllowsInput();

--- a/ContentPatcher/Framework/Tokens/ValueProviders/ModConvention/ConventionDelegates.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/ModConvention/ConventionDelegates.cs
@@ -14,6 +14,8 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders.ModConvention
         /// <remarks>Default true.</remarks>
         internal delegate bool IsMutable();
 
+        /// <inheritdoc cref="IValueProvider.IsDeterministicForInput"/>
+        /// <remarks>Default false.</remarks>
         internal delegate bool IsDeterministicForInput();
 
         /// <summary>Get whether the token allows input arguments (e.g. an NPC name for a relationship token).</summary>

--- a/ContentPatcher/Framework/Tokens/ValueProviders/ModConvention/ConventionValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/ModConvention/ConventionValueProvider.cs
@@ -34,6 +34,8 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders.ModConvention
         /// <inheritdoc />
         public bool IsMutable => this.Provider.IsMutable();
 
+        public bool IsDeterministicForInput => this.Provider.IsDeterministicForInput();
+
         /// <inheritdoc />
         /// <remarks>This is cached to ensure it never changes outside a context update (even if the mod token is otherwise incorrectly changing without a context update), since that would cause subtle hard-to-troubleshoot bugs where patches don't update correctly in some cases.</remarks>
         public bool IsReady { get; private set; }

--- a/ContentPatcher/Framework/Tokens/ValueProviders/ModConvention/ConventionValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/ModConvention/ConventionValueProvider.cs
@@ -34,6 +34,7 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders.ModConvention
         /// <inheritdoc />
         public bool IsMutable => this.Provider.IsMutable();
 
+        /// <inheritdoc />
         public bool IsDeterministicForInput => this.Provider.IsDeterministicForInput();
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/ModConvention/ConventionWrapper.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/ModConvention/ConventionWrapper.cs
@@ -22,6 +22,8 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders.ModConvention
         /// <summary>Get whether the values may change depending on the context.</summary>
         private ConventionDelegates.IsMutable? IsMutableImpl;
 
+        private ConventionDelegates.IsDeterministicForInput? IsDeterministicForInputImpl;
+
         /// <summary>The implementation for <see cref="AllowsInput"/>, if any.</summary>
         private ConventionDelegates.AllowsInput? AllowsInputImpl;
 
@@ -122,6 +124,7 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders.ModConvention
                 succeeded =
                     // metadata
                     TryMap<ConventionDelegates.IsMutable>(out error)
+                    && TryMap<ConventionDelegates.IsDeterministicForInput>(out error)
                     && TryMap<ConventionDelegates.AllowsInput>(out error)
                     && TryMap<ConventionDelegates.RequiresInput>(out error)
                     && TryMap<ConventionDelegates.CanHaveMultipleValues>(out error)
@@ -151,6 +154,12 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders.ModConvention
         public bool IsMutable()
         {
             return this.IsMutableImpl?.Invoke() ?? true;
+        }
+
+        /// <summary>Get whether the token is immutable if the inputs are also immutable</summary>
+        public bool IsDeterministicForInput()
+        {
+            return this.IsDeterministicForInputImpl?.Invoke() ?? false;
         }
 
         /// <summary>Get whether the value provider allows input arguments (e.g. an NPC name for a relationship token).</summary>

--- a/ContentPatcher/Framework/Tokens/ValueProviders/ModConvention/ConventionWrapper.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/ModConvention/ConventionWrapper.cs
@@ -22,6 +22,7 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders.ModConvention
         /// <summary>Get whether the values may change depending on the context.</summary>
         private ConventionDelegates.IsMutable? IsMutableImpl;
 
+        /// <summary>The implementation for <see cref="IsDeterministicForInput"/>, if any.</summary>
         private ConventionDelegates.IsDeterministicForInput? IsDeterministicForInputImpl;
 
         /// <summary>The implementation for <see cref="AllowsInput"/>, if any.</summary>
@@ -156,7 +157,7 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders.ModConvention
             return this.IsMutableImpl?.Invoke() ?? true;
         }
 
-        /// <summary>Get whether the token is immutable if the inputs are also immutable</summary>
+        /// <inheritdoc cref="ConventionDelegates.IsDeterministicForInput"/>
         public bool IsDeterministicForInput()
         {
             return this.IsDeterministicForInputImpl?.Invoke() ?? false;

--- a/ContentPatcher/Framework/Tokens/ValueProviders/PathPartValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/PathPartValueProvider.cs
@@ -16,10 +16,9 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         *********/
         /// <summary>Construct an instance.</summary>
         public PathPartValueProvider()
-            : base(ConditionType.PathPart, mayReturnMultipleValuesForRoot: false)
+            : base(ConditionType.PathPart, mayReturnMultipleValuesForRoot: false, isDeterministicForInput: true)
         {
             this.EnableInputArguments(required: true, mayReturnMultipleValues: false, maxPositionalArgs: 2);
-            this.IsDeterministicForInput = true;
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/PathPartValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/PathPartValueProvider.cs
@@ -19,6 +19,7 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
             : base(ConditionType.PathPart, mayReturnMultipleValuesForRoot: false)
         {
             this.EnableInputArguments(required: true, mayReturnMultipleValues: false, maxPositionalArgs: 2);
+            this.IsDeterministicForInput = true;
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/QueryValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/QueryValueProvider.cs
@@ -37,6 +37,7 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         {
             this.BypassesContextValidation = true;
             this.EnableInputArguments(required: true, mayReturnMultipleValues: false, maxPositionalArgs: null);
+            this.IsDeterministicForInput = true;
             this.MarkReady(true);
         }
 

--- a/ContentPatcher/Framework/Tokens/ValueProviders/QueryValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/QueryValueProvider.cs
@@ -33,11 +33,10 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         *********/
         /// <summary>Construct an instance.</summary>
         public QueryValueProvider()
-            : base(ConditionType.Query, mayReturnMultipleValuesForRoot: false)
+            : base(ConditionType.Query, mayReturnMultipleValuesForRoot: false, isDeterministicForInput: true)
         {
             this.BypassesContextValidation = true;
             this.EnableInputArguments(required: true, mayReturnMultipleValues: false, maxPositionalArgs: null);
-            this.IsDeterministicForInput = true;
             this.MarkReady(true);
         }
 

--- a/ContentPatcher/Framework/Tokens/ValueProviders/RangeValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/RangeValueProvider.cs
@@ -39,8 +39,6 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
             if (!base.TryValidateInput(input, out error))
                 return false;
 
-            this.IsMutable = input.IsMutable;
-
             if (input.IsReady)
             {
                 return

--- a/ContentPatcher/Framework/Tokens/ValueProviders/RangeValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/RangeValueProvider.cs
@@ -23,6 +23,7 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
             : base(ConditionType.Range, mayReturnMultipleValuesForRoot: true)
         {
             this.EnableInputArguments(required: true, mayReturnMultipleValues: true, maxPositionalArgs: 2);
+            this.IsDeterministicForInput = true;
             this.MarkReady(true);
         }
 
@@ -37,6 +38,8 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         {
             if (!base.TryValidateInput(input, out error))
                 return false;
+
+            this.IsMutable = input.IsMutable;
 
             if (input.IsReady)
             {

--- a/ContentPatcher/Framework/Tokens/ValueProviders/RangeValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/RangeValueProvider.cs
@@ -20,10 +20,9 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         *********/
         /// <summary>Construct an instance.</summary>
         public RangeValueProvider()
-            : base(ConditionType.Range, mayReturnMultipleValuesForRoot: true)
+            : base(ConditionType.Range, mayReturnMultipleValuesForRoot: true, isDeterministicForInput: true)
         {
             this.EnableInputArguments(required: true, mayReturnMultipleValues: true, maxPositionalArgs: 2);
-            this.IsDeterministicForInput = true;
             this.MarkReady(true);
         }
 

--- a/ContentPatcher/Framework/Tokens/ValueProviders/RenderValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/RenderValueProvider.cs
@@ -14,6 +14,7 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
             : base(ConditionType.Render, mayReturnMultipleValuesForRoot: false)
         {
             this.EnableInputArguments(required: false, mayReturnMultipleValues: false, maxPositionalArgs: null);
+            this.IsDeterministicForInput = true;
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/RenderValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/RenderValueProvider.cs
@@ -11,10 +11,9 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         *********/
         /// <summary>Construct an instance.</summary>
         public RenderValueProvider()
-            : base(ConditionType.Render, mayReturnMultipleValuesForRoot: false)
+            : base(ConditionType.Render, mayReturnMultipleValuesForRoot: false, isDeterministicForInput: true)
         {
             this.EnableInputArguments(required: false, mayReturnMultipleValues: false, maxPositionalArgs: null);
-            this.IsDeterministicForInput = true;
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/RoundValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/RoundValueProvider.cs
@@ -35,6 +35,7 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
             : base(ConditionType.Round, mayReturnMultipleValuesForRoot: false)
         {
             this.EnableInputArguments(required: true, mayReturnMultipleValues: false, maxPositionalArgs: null);
+            this.IsDeterministicForInput = true;
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/RoundValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/RoundValueProvider.cs
@@ -32,10 +32,9 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         *********/
         /// <summary>Construct an instance.</summary>
         public RoundValueProvider()
-            : base(ConditionType.Round, mayReturnMultipleValuesForRoot: false)
+            : base(ConditionType.Round, mayReturnMultipleValuesForRoot: false, isDeterministicForInput: true)
         {
             this.EnableInputArguments(required: true, mayReturnMultipleValues: false, maxPositionalArgs: null);
-            this.IsDeterministicForInput = true;
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Tokens/ValueProviders/TranslationValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/TranslationValueProvider.cs
@@ -32,6 +32,9 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
 
             this.EnableInputArguments(required: true, mayReturnMultipleValues: false, maxPositionalArgs: 1);
             this.AllowAnyNamedArguments = true;
+            
+            // This is deterministic 99% of the time, but if language is changed, this would need to be invalidated
+            this.IsDeterministicForInput = false;
             this.MarkReady(true);
         }
 

--- a/ContentPatcher/Framework/Tokens/ValueProviders/TranslationValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/TranslationValueProvider.cs
@@ -25,16 +25,13 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         /// <summary>Construct an instance.</summary>
         /// <param name="translationHelper">Gets translations from the content pack's translation folder.</param>
         public TranslationValueProvider(ITranslationHelper translationHelper)
-            : base(ConditionType.I18n, mayReturnMultipleValuesForRoot: false)
+            : base(ConditionType.I18n, mayReturnMultipleValuesForRoot: false, isDeterministicForInput: true) // This is deterministic 99% of the time, but if language is changed, this would need to be invalidated
         {
             this.TranslationHelper = translationHelper;
             this.LastLocale = translationHelper.LocaleEnum;
 
             this.EnableInputArguments(required: true, mayReturnMultipleValues: false, maxPositionalArgs: 1);
             this.AllowAnyNamedArguments = true;
-            
-            // This is deterministic 99% of the time, but if language is changed, this would need to be invalidated
-            this.IsDeterministicForInput = false;
             this.MarkReady(true);
         }
 

--- a/ContentPatcher/Framework/Tokens/ValueProviders/TranslationValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/TranslationValueProvider.cs
@@ -25,7 +25,7 @@ namespace ContentPatcher.Framework.Tokens.ValueProviders
         /// <summary>Construct an instance.</summary>
         /// <param name="translationHelper">Gets translations from the content pack's translation folder.</param>
         public TranslationValueProvider(ITranslationHelper translationHelper)
-            : base(ConditionType.I18n, mayReturnMultipleValuesForRoot: false, isDeterministicForInput: true) // This is deterministic 99% of the time, but if language is changed, this would need to be invalidated
+            : base(ConditionType.I18n, mayReturnMultipleValuesForRoot: false)
         {
             this.TranslationHelper = translationHelper;
             this.LastLocale = translationHelper.LocaleEnum;


### PR DESCRIPTION
Adds the concept "IsDeterministicForInput" which is a softer version of !IsMutable which allows TokenString to keep it marked as immutable.

In addition, improves Condition.UpdateContext to only re-split the Values if its mutable (or empty to prevent it never being populated).

I'd love feedback on this if there was a better way of getting these savings.

Logs, all with extra profiler logging in place
|Log Name|Log URL|Notes|
|---|---|---|
|Before|[SMAPI.io](https://smapi.io/log/d82b60d4904b4d0da09acf1fd8416486?Levels=debug~critical&Mods=Profiler&Filter=handling+GameLoop.TimeChanged+%28)|N/A
|IsDeterministicForInput|[SMAPI.io](https://smapi.io/log/c80991a3577c413d861086176a864382?Levels=debug%7Ecritical&Mods=Profiler&Filter=handling+GameLoop.TimeChanged+%28)|Does not contain Condition changes
|Condition Changes|[SMAPI.io](https://smapi.io/log/4409f19734884fabb405ceb97d17ad44?Levels=debug%7Ecritical&Mods=Profiler&Filter=handling+GameLoop.TimeChanged+%28)|What is seen in this PR (minus profiler)