### PR TITLE
Add migrations for some content assets changed in Stardew Valley 1.6

### DIFF
--- a/ContentPatcher/Framework/Migrations/AggregateMigration.cs
+++ b/ContentPatcher/Framework/Migrations/AggregateMigration.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -29,8 +28,11 @@ namespace ContentPatcher.Framework.Migrations
         /*********
         ** Accessors
         *********/
-        /// <summary>The version to which this migration applies.</summary>
+        /// <inheritdoc />
         public ISemanticVersion Version { get; }
+
+        /// <inheritdoc />
+        public string[] MigrationWarnings { get; }
 
 
         /*********
@@ -45,6 +47,7 @@ namespace ContentPatcher.Framework.Migrations
             this.ValidVersions = new HashSet<string>(migrations.Select(p => p.Version.ToString()));
             this.LatestVersion = migrations.Last().Version.ToString();
             this.Migrations = migrations.Where(m => m.Version.IsNewerThan(version)).ToArray();
+            this.MigrationWarnings = this.Migrations.SelectMany(p => p.MigrationWarnings).Distinct().ToArray();
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/Framework/Migrations/BaseMigration.cs
+++ b/ContentPatcher/Framework/Migrations/BaseMigration.cs
@@ -25,6 +25,9 @@ namespace ContentPatcher.Framework.Migrations
         /// <inheritdoc />
         public ISemanticVersion Version { get; }
 
+        /// <inheritdoc />
+        public string[] MigrationWarnings { get; protected set; } = Array.Empty<string>();
+
 
         /*********
         ** Public methods

--- a/ContentPatcher/Framework/Migrations/BaseRuntimeMigration.cs
+++ b/ContentPatcher/Framework/Migrations/BaseRuntimeMigration.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics.CodeAnalysis;
+using ContentPatcher.Framework.Patches;
+using StardewModdingAPI;
+
+namespace ContentPatcher.Framework.Migrations
+{
+    /// <summary>The base implementation for a format version migrator which overrides patches at runtime.</summary>
+    internal abstract class BaseRuntimeMigration : BaseMigration, IRuntimeMigration
+    {
+        /*********
+        ** Public methods
+        *********/
+        /// <inheritdoc />
+        public virtual IAssetName? RedirectTarget(IAssetName assetName, IPatch patch)
+        {
+            return null;
+        }
+
+        /// <inheritdoc />
+        public virtual bool TryApplyLoadPatch<T>(LoadPatch patch, IAssetName assetName, [NotNullWhen(true)] ref T? asset, out string? error)
+            where T : notnull
+        {
+            error = null;
+            return false;
+        }
+
+        /// <inheritdoc />
+        public virtual bool TryApplyEditPatch<T>(IPatch patch, IAssetData asset, out string? error)
+            where T : notnull
+        {
+            error = null;
+            return false;
+        }
+
+
+        /*********
+        ** Protected methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="version">The version to which this migration applies.</param>
+        protected BaseRuntimeMigration(ISemanticVersion version)
+            : base(version) { }
+    }
+}

--- a/ContentPatcher/Framework/Migrations/FakeAssetData.cs
+++ b/ContentPatcher/Framework/Migrations/FakeAssetData.cs
@@ -1,0 +1,79 @@
+using System;
+using StardewModdingAPI;
+
+namespace ContentPatcher.Framework.Migrations
+{
+    /// <summary>An implementation of <see cref="IAssetData"/> used to apply edits to temporary data during runtime content migrations.</summary>
+    internal class FakeAssetData : IAssetData
+    {
+        /*********
+        ** Accessors
+        *********/
+        /// <inheritdoc />
+        public string? Locale { get; }
+
+        /// <inheritdoc />
+        public IAssetName Name { get; }
+
+        /// <inheritdoc />
+        public IAssetName NameWithoutLocale { get; }
+
+        /// <inheritdoc />
+        public Type DataType { get; }
+
+        /// <inheritdoc />
+        public object Data { get; }
+
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="realData">The real asset being edited.</param>
+        /// <param name="assetName">The asset name that should be shown to the edit patch.</param>
+        /// <param name="data">The asset data that should be affected by the edit patch.</param>
+        public FakeAssetData(IAssetData realData, IAssetName assetName, object data)
+        {
+            this.Locale = realData.Locale;
+            this.Name = assetName;
+            this.NameWithoutLocale = assetName.GetBaseAssetName();
+            this.DataType = data.GetType();
+            this.Data = data;
+        }
+
+        /// <remarks>This implementation does nothing, since Content Patcher's edit patches don't use it.</remarks>
+        /// <inheritdoc />
+        public void ReplaceWith(object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <remarks>This isn't implemented since edit patches don't use it.</remarks>
+        /// <inheritdoc />
+        public IAssetDataForDictionary<TKey, TValue> AsDictionary<TKey, TValue>()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <remarks>This isn't implemented since edit patches don't use it.</remarks>
+        /// <inheritdoc />
+        public IAssetDataForImage AsImage()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <remarks>This isn't implemented since edit patches don't use it.</remarks>
+        /// <inheritdoc />
+        public IAssetDataForMap AsMap()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <remarks>This isn't implemented since edit patches don't use it.</remarks>
+        /// <inheritdoc />
+        public TData GetData<TData>()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/ContentPatcher/Framework/Migrations/IMigration.cs
+++ b/ContentPatcher/Framework/Migrations/IMigration.cs
@@ -16,6 +16,9 @@ namespace ContentPatcher.Framework.Migrations
         /// <summary>The format version to which this migration applies.</summary>
         ISemanticVersion Version { get; }
 
+        /// <summary>If set, content packs for which this migration applies will be listed in an <c>INFO</c> log with these messages.</summary>
+        public string[] MigrationWarnings { get; }
+
 
         /*********
         ** Public methods

--- a/ContentPatcher/Framework/Migrations/IRuntimeMigration.cs
+++ b/ContentPatcher/Framework/Migrations/IRuntimeMigration.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics.CodeAnalysis;
+using ContentPatcher.Framework.Patches;
+using StardewModdingAPI;
+
+namespace ContentPatcher.Framework.Migrations
+{
+    /// <summary>Overrides patches at runtime to migrate them to a given format version.</summary>
+    internal interface IRuntimeMigration : IMigration
+    {
+        /// <summary>Get the actual asset name to edit, if different from the one resolved from the patch data.</summary>
+        /// <param name="assetName">The resolved asset name being loaded or edited. If earlier migrations already redirected the target, this is the new asset name.</param>
+        /// <param name="patch">The load or edit patch being applied.</param>
+        /// <returns>Returns the new asset name to load or edit instead, or <c>null</c> to keep the current one as-is.</returns>
+        IAssetName? RedirectTarget(IAssetName assetName, IPatch patch);
+
+        /// <summary>Apply a load patch to the asset at runtime, overriding the normal apply log.</summary>
+        /// <typeparam name="T">The asset type being loaded.</typeparam>
+        /// <param name="patch">The load patch to apply, with any contextual values (e.g. token strings) already updated.</param>
+        /// <param name="assetName">The resolved asset name being loaded.</param>
+        /// <param name="asset">The asset data to load. This is normally <c>null</c> before this method is called, but if multiple migrations apply to the same patch, then this will be the result of the previous migrations.</param>
+        /// <param name="error">An error message which indicates why migration failed.</param>
+        /// <returns>Returns whether the load was overridden, so that the patch isn't applied normally after calling this method.</returns>
+        bool TryApplyLoadPatch<T>(LoadPatch patch, IAssetName assetName, [NotNullWhen(true)] ref T? asset, out string? error)
+            where T : notnull;
+
+        /// <summary>Apply an edit patch to the asset at runtime, overriding the normal apply log.</summary>
+        /// <typeparam name="T">The asset type being loaded.</typeparam>
+        /// <param name="patch">The edit patch to apply, with any contextual values (e.g. token strings) already updated.</param>
+        /// <param name="asset">The loaded asset data, with any previous patches in the list already applied. If multiple migrations apply to the same patch, then the earlier migrations are already applied to this parameter at this point.</param>
+        /// <param name="error">An error message which indicates why migration failed.</param>
+        /// <returns>Returns whether the edit was overridden, so that the patch isn't applied normally after calling this method.</returns>
+        bool TryApplyEditPatch<T>(IPatch patch, IAssetData asset, out string? error)
+            where T : notnull;
+    }
+}

--- a/ContentPatcher/Framework/Migrations/Migration_2_0.ForBigCraftablesInformation.cs
+++ b/ContentPatcher/Framework/Migrations/Migration_2_0.ForBigCraftablesInformation.cs
@@ -1,0 +1,166 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using ContentPatcher.Framework.Patches;
+using StardewModdingAPI;
+using StardewModdingAPI.Framework.Content;
+using StardewValley;
+using StardewValley.GameData.BigCraftables;
+using SObject = StardewValley.Object;
+using StardewTokenParser = StardewValley.TokenizableStrings.TokenParser;
+
+namespace ContentPatcher.Framework.Migrations
+{
+    internal partial class Migration_2_0 : BaseRuntimeMigration
+    {
+        /// <summary>The migration logic to apply pre-1.6 <c>Data/BigCraftableInformation</c> patches to <c>Data/BigCraftables</c>.</summary>
+        public class BigCraftableInformationMigrator : IEditAssetMigrator
+        {
+            /*********
+            ** Fields
+            *********/
+            /// <summary>The pre-1.6 asset name.</summary>
+            private const string OldAssetName = "Data/BigCraftablesInformation";
+
+            /// <summary>The 1.6 asset name.</summary>
+            private const string NewAssetName = "Data/BigCraftables";
+
+
+            /*********
+            ** Public methods
+            *********/
+            /// <inheritdoc />
+            public bool AppliesTo(IAssetName assetName)
+            {
+                return assetName?.IsEquivalentTo(BigCraftableInformationMigrator.OldAssetName, useBaseName: true) is true;
+            }
+
+            /// <inheritdoc />
+            public IAssetName? RedirectTarget(IAssetName assetName, IPatch patch)
+            {
+                return new AssetName(BigCraftableInformationMigrator.NewAssetName, null, null);
+            }
+
+            /// <inheritdoc />
+            public bool TryApplyLoadPatch<T>(LoadPatch patch, IAssetName assetName, [NotNullWhen(true)] ref T? asset, out string? error)
+            {
+                Dictionary<string, string> tempData = patch.Load<Dictionary<string, string>>(this.GetOldAssetName(assetName));
+                Dictionary<string, BigCraftableData> newData = new();
+                this.MergeIntoNewFormat(newData, tempData, null);
+                asset = (T)(object)newData;
+
+                error = null;
+                return true;
+            }
+
+            /// <inheritdoc />
+            public bool TryApplyEditPatch<T>(EditDataPatch patch, IAssetData asset, out string? error)
+            {
+                var data = asset.GetData<Dictionary<string, BigCraftableData>>();
+                Dictionary<string, string> tempData = this.GetOldFormat(data);
+                Dictionary<string, string> tempDataBackup = new(tempData);
+                patch.Edit<Dictionary<string, string>>(new FakeAssetData(asset, this.GetOldAssetName(asset.Name), tempData));
+                this.MergeIntoNewFormat(data, tempData, tempDataBackup);
+
+                error = null;
+                return true;
+            }
+
+
+            /*********
+            ** Private methods
+            *********/
+            /// <summary>Get the old asset to edit.</summary>
+            /// <param name="newName">The new asset name whose locale to use.</param>
+            private IAssetName GetOldAssetName(IAssetName newName)
+            {
+                return new AssetName(BigCraftableInformationMigrator.OldAssetName, newName.LocaleCode, newName.LanguageCode);
+            }
+
+            /// <summary>Get the pre-1.6 equivalent for the new asset data.</summary>
+            /// <param name="from">The data to convert.</param>
+            private Dictionary<string, string> GetOldFormat(IDictionary<string, BigCraftableData> from)
+            {
+                var data = new Dictionary<string, string>();
+
+                string[] fields = new string[10];
+                foreach ((string objectId, BigCraftableData entry) in from)
+                {
+                    fields[0] = entry.Name;
+                    fields[1] = entry.Price.ToString();
+                    fields[2] = SObject.inedible.ToString(); // edibility (removed in 1.6)
+                    fields[3] = "Crafting -9";               // type + category (removed in 1.6)
+                    fields[4] = StardewTokenParser.ParseText(entry.Description);
+                    fields[5] = entry.CanBePlacedOutdoors.ToString().ToLowerInvariant();
+                    fields[6] = entry.CanBePlacedIndoors.ToString().ToLowerInvariant();
+                    fields[7] = entry.Fragility.ToString();
+                    fields[8] = entry.IsLamp.ToString().ToLowerInvariant();
+                    fields[9] = StardewTokenParser.ParseText(entry.DisplayName);
+
+                    data[objectId] = string.Join('/', fields);
+                }
+
+                return data;
+            }
+
+            /// <summary>Merge pre-1.6 data into the new asset.</summary>
+            /// <param name="asset">The asset data to update.</param>
+            /// <param name="from">The pre-1.6 data to merge into the asset.</param>
+            /// <param name="fromBackup">A copy of <paramref name="from"/> before edits were applied.</param>
+            private void MergeIntoNewFormat(IDictionary<string, BigCraftableData> asset, IDictionary<string, string> from, IDictionary<string, string>? fromBackup)
+            {
+                // remove deleted entries
+                foreach (string key in asset.Keys)
+                {
+                    if (!from.ContainsKey(key))
+                        asset.Remove(key);
+                }
+
+                // apply entries
+                foreach ((string objectId, string fromEntry) in from)
+                {
+                    // get/add target record
+                    bool isNew = false;
+                    if (!asset.TryGetValue(objectId, out BigCraftableData? entry))
+                    {
+                        isNew = true;
+                        entry = new BigCraftableData();
+                    }
+
+                    // get backup
+                    string[]? backupFields = null;
+                    if (fromBackup is not null)
+                    {
+                        if (fromBackup.TryGetValue(objectId, out string? prevRow) && prevRow == fromEntry)
+                            continue; // no changes
+                        backupFields = prevRow?.Split('/');
+                    }
+
+                    // merge fields into new asset
+                    {
+                        string[] fields = fromEntry.Split('/');
+
+                        entry.Name = ArgUtility.Get(fields, 0, entry.Name, allowBlank: false);
+                        entry.Price = ArgUtility.GetInt(fields, 1, entry.Price);
+
+                        string description = ArgUtility.Get(fields, 4);
+                        if (!string.IsNullOrWhiteSpace(description) && description != ArgUtility.Get(backupFields, 4) && description != StardewTokenParser.ParseText(entry.Description))
+                            entry.Description = description;
+
+                        entry.CanBePlacedOutdoors = ArgUtility.GetBool(fields, 5, entry.CanBePlacedOutdoors);
+                        entry.CanBePlacedIndoors = ArgUtility.GetBool(fields, 6, entry.CanBePlacedIndoors);
+                        entry.Fragility = ArgUtility.GetInt(fields, 7, entry.Fragility);
+                        entry.IsLamp = ArgUtility.GetBool(fields, 8, entry.IsLamp);
+
+                        string displayName = ArgUtility.Get(fields, 9);
+                        if (!string.IsNullOrWhiteSpace(displayName) && displayName != ArgUtility.Get(backupFields, 9) && displayName != StardewTokenParser.ParseText(entry.DisplayName))
+                            entry.DisplayName = displayName;
+                    }
+
+                    // set value
+                    if (isNew)
+                        asset[objectId] = entry;
+                }
+            }
+        }
+    }
+}

--- a/ContentPatcher/Framework/Migrations/Migration_2_0.ForCrops.cs
+++ b/ContentPatcher/Framework/Migrations/Migration_2_0.ForCrops.cs
@@ -1,0 +1,319 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using ContentPatcher.Framework.Patches;
+using Microsoft.Xna.Framework;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.GameData.Crops;
+
+namespace ContentPatcher.Framework.Migrations
+{
+    internal partial class Migration_2_0 : BaseRuntimeMigration
+    {
+        /// <summary>The migration logic to apply pre-1.6 <c>Data/Crops</c> patches to the new format.</summary>
+        public class CropsMigrator : IEditAssetMigrator
+        {
+            /*********
+            ** Fields
+            *********/
+            /// <summary>The pre-1.6 asset name.</summary>
+            private const string AssetName = "Data/Crops";
+
+
+            /*********
+            ** Public methods
+            *********/
+            /// <inheritdoc />
+            public bool AppliesTo(IAssetName assetName)
+            {
+                return assetName?.IsEquivalentTo(CropsMigrator.AssetName, useBaseName: true) is true;
+            }
+
+            /// <inheritdoc />
+            public IAssetName? RedirectTarget(IAssetName assetName, IPatch patch)
+            {
+                return null; // same asset name
+            }
+
+            /// <inheritdoc />
+            public bool TryApplyLoadPatch<T>(LoadPatch patch, IAssetName assetName, [NotNullWhen(true)] ref T? asset, out string? error)
+            {
+                Dictionary<string, string> tempData = patch.Load<Dictionary<string, string>>(assetName);
+                Dictionary<string, CropData> newData = new();
+                this.MergeIntoNewFormat(newData, tempData, null);
+                asset = (T)(object)newData;
+
+                error = null;
+                return true;
+            }
+
+            /// <inheritdoc />
+            public bool TryApplyEditPatch<T>(EditDataPatch patch, IAssetData asset, out string? error)
+            {
+                var data = asset.GetData<Dictionary<string, CropData>>();
+                Dictionary<string, string> tempData = this.GetOldFormat(data);
+                Dictionary<string, string> tempDataBackup = new(tempData);
+                patch.Edit<Dictionary<string, string>>(new FakeAssetData(asset, asset.Name, tempData));
+                this.MergeIntoNewFormat(data, tempData, tempDataBackup);
+
+                error = null;
+                return true;
+            }
+
+
+            /*********
+            ** Private methods
+            *********/
+            /// <summary>Get the pre-1.6 equivalent for the new asset data.</summary>
+            /// <param name="from">The data to convert.</param>
+            private Dictionary<string, string> GetOldFormat(IDictionary<string, CropData> from)
+            {
+                var data = new Dictionary<string, string>();
+
+                string[] fields = new string[9];
+                foreach ((string objectId, CropData entry) in from)
+                {
+                    fields[0] = string.Join(' ', entry.DaysInPhase);
+                    fields[1] = this.GetOldSeasonsField(entry);
+                    fields[2] = entry.SpriteIndex.ToString();
+                    fields[3] = entry.HarvestItemId;
+                    fields[4] = entry.RegrowDays.ToString();
+                    fields[5] = ((int)entry.HarvestMethod).ToString();
+                    fields[6] = this.GetOldExtraHarvestField(entry);
+                    fields[7] = entry.IsRaised.ToString().ToLowerInvariant();
+                    fields[8] = this.GetOldTintColorsField(entry);
+
+                    data[objectId] = string.Join('/', fields);
+                }
+
+                return data;
+            }
+
+            /// <summary>Merge pre-1.6 data into the new asset.</summary>
+            /// <param name="asset">The asset data to update.</param>
+            /// <param name="from">The pre-1.6 data to merge into the asset.</param>
+            /// <param name="fromBackup">A copy of <paramref name="from"/> before edits were applied.</param>
+            private void MergeIntoNewFormat(IDictionary<string, CropData> asset, IDictionary<string, string> from, IDictionary<string, string>? fromBackup)
+            {
+                // remove deleted entries
+                foreach (string key in asset.Keys)
+                {
+                    if (!from.ContainsKey(key))
+                        asset.Remove(key);
+                }
+
+                // apply entries
+                foreach ((string objectId, string fromEntry) in from)
+                {
+                    // get/add target record
+                    bool isNew = false;
+                    if (!asset.TryGetValue(objectId, out CropData? entry))
+                    {
+                        isNew = true;
+                        entry = new CropData();
+                    }
+
+                    // get backup
+                    string[]? backupFields = null;
+                    if (fromBackup is not null)
+                    {
+                        if (fromBackup.TryGetValue(objectId, out string? prevRow) && prevRow == fromEntry)
+                            continue; // no changes
+                        backupFields = prevRow?.Split('/');
+                    }
+
+                    // merge fields into new asset
+                    {
+                        string[] fields = fromEntry.Split('/');
+
+                        string rawDaysInPhase = ArgUtility.Get(fields, 0);
+                        if (rawDaysInPhase != ArgUtility.Get(backupFields, 0))
+                            this.MergDaysInPhaseIntoNewFormat(entry, rawDaysInPhase);
+
+                        string rawSeasons = ArgUtility.Get(fields, 1);
+                        if (rawSeasons != ArgUtility.Get(backupFields, 1))
+                            this.MergeSeasonsIntoNewFormat(entry, rawSeasons);
+
+                        entry.SpriteIndex = ArgUtility.GetInt(fields, 2, entry.SpriteIndex);
+                        entry.HarvestItemId = ArgUtility.Get(fields, 3, entry.HarvestItemId, allowBlank: false);
+                        entry.RegrowDays = ArgUtility.GetInt(fields, 4, entry.RegrowDays);
+                        entry.HarvestMethod = ArgUtility.GetEnum(fields, 5, entry.HarvestMethod);
+
+                        string rawExtraHarvestField = ArgUtility.Get(fields, 6);
+                        if (rawExtraHarvestField != null && rawExtraHarvestField != ArgUtility.Get(backupFields, 6))
+                            this.MergeExtraHarvestIntoNewFormat(entry, rawExtraHarvestField);
+
+                        entry.IsRaised = ArgUtility.GetBool(fields, 7, entry.IsRaised);
+
+                        string rawColors = ArgUtility.Get(fields, 8);
+                        if (rawColors != null && rawColors != ArgUtility.Get(backupFields, 8))
+                            this.MergeOldTintColorsFieldIntoNewFormat(entry, rawColors);
+                    }
+
+                    // set value
+                    if (isNew)
+                        asset[objectId] = entry;
+                }
+            }
+
+            /// <summary>Get the pre-1.6 'seasons' field from the new asset.</summary>
+            /// <param name="entry">The crop data to convert.</param>
+            private string GetOldSeasonsField(CropData entry)
+            {
+                return entry.Seasons is not null
+                    ? string.Join(' ', entry.Seasons.Select(p => p.ToString().ToLower()))
+                    : string.Empty;
+            }
+
+            /// <summary>Merge a pre-1.6 'extra harvest' field into the new asset.</summary>
+            /// <param name="entry">The data entry to update.</param>
+            /// <param name="field">The pre-1.6 field value to merge into the asset.</param>
+            private void MergeSeasonsIntoNewFormat(CropData entry, string field)
+            {
+                entry.Seasons?.Clear();
+                entry.Seasons ??= new();
+
+                foreach (string rawSeason in field.Split(' '))
+                {
+                    if (Utility.TryParseEnum(rawSeason, out Season season))
+                        entry.Seasons.Add(season);
+                }
+            }
+
+            /// <summary>Merge a pre-1.6 'days in phase' field into the new asset.</summary>
+            /// <param name="entry">The data entry to update.</param>
+            /// <param name="field">The pre-1.6 field value to merge into the asset.</param>
+            private void MergDaysInPhaseIntoNewFormat(CropData entry, string field)
+            {
+                entry.DaysInPhase?.Clear();
+                entry.DaysInPhase ??= new();
+
+                foreach (string rawDay in field.Split(' '))
+                {
+                    int.TryParse(rawDay, out int day);
+                    entry.DaysInPhase.Add(day);
+                }
+            }
+
+            /// <summary>Get the pre-1.6 'extra harvest' field from the new asset.</summary>
+            /// <summary>Get the extra harvest info converted to the 1.5.6 format.</summary>
+            /// <param name="entry">The crop data to convert.</param>
+            private string GetOldExtraHarvestField(CropData entry)
+            {
+                return entry.HarvestMaxStack > entry.HarvestMinStack || entry.HarvestMaxIncreasePerFarmingLevel > 0 || entry.ExtraHarvestChance > 0
+                    ? $"true {entry.HarvestMinStack} {entry.HarvestMaxStack} {entry.HarvestMaxIncreasePerFarmingLevel.ToString().TrimStart('0')} {entry.ExtraHarvestChance.ToString().TrimStart('0')}"
+                    : "false";
+            }
+
+            /// <summary>Merge a pre-1.6 'extra harvest' field into the new asset.</summary>
+            /// <param name="entry">The data entry to update.</param>
+            /// <param name="field">The pre-1.6 field value to merge into the asset.</param>
+            private void MergeExtraHarvestIntoNewFormat(CropData entry, string field)
+            {
+                string[] fields = field.Split(' ');
+                if (!ArgUtility.TryGetBool(fields, 0, out bool applies, out _))
+                    return;
+
+                if (applies)
+                {
+                    if (
+                        ArgUtility.TryGetInt(fields, 1, out int minStack, out _)
+                        && ArgUtility.TryGetInt(fields, 2, out int maxStack, out _)
+                        && ArgUtility.TryGetInt(fields, 3, out int maxIncreasePerFarmingLevel, out _)
+                        && ArgUtility.TryGetFloat(fields, 4, out float extraChance, out _)
+                    )
+                    {
+                        entry.HarvestMinStack = minStack;
+                        entry.HarvestMaxStack = maxStack;
+                        entry.HarvestMaxIncreasePerFarmingLevel = maxIncreasePerFarmingLevel;
+                        entry.ExtraHarvestChance = extraChance;
+                    }
+                }
+                if (!applies)
+                {
+                    entry.HarvestMaxStack = 1;
+                    entry.HarvestMaxIncreasePerFarmingLevel = 0;
+                    entry.ExtraHarvestChance = 0;
+                }
+            }
+
+            /// <summary>Get the pre-1.6 'tint colors' field from the new asset.</summary>
+            /// <param name="entry">The crop data to convert.</param>
+            private string GetOldTintColorsField(CropData entry)
+            {
+                if (entry.TintColors?.Count is not > 0)
+                    return "false";
+
+                StringBuilder result = new("true");
+
+                foreach (string rawColor in entry.TintColors)
+                {
+                    Color? color = Utility.StringToColor(rawColor);
+                    if (color is null)
+                        continue;
+
+                    result
+                        .Append(' ')
+                        .Append(color.Value.R)
+                        .Append(' ')
+                        .Append(color.Value.G)
+                        .Append(' ')
+                        .Append(color.Value.B);
+                }
+
+                return result.ToString();
+            }
+
+            /// <summary>Merge a pre-1.6 'tint colors' field into the new asset.</summary>
+            /// <param name="entry">The data entry to update.</param>
+            /// <param name="field">The pre-1.6 field value to merge into the asset.</param>
+            private void MergeOldTintColorsFieldIntoNewFormat(CropData entry, string field)
+            {
+                string[] fields = field.Split(' ');
+                if (!ArgUtility.TryGetBool(fields, 0, out bool applies, out _))
+                    return;
+
+                if (applies)
+                {
+                    // extract colors
+                    HashSet<string> newColors = new();
+                    for (int i = 1; i < fields.Length - 3; i += 3)
+                        newColors.Add($"{fields[i]} {fields[i + 1]} {fields[i + 2]}");
+
+                    // remove or update existing entries
+                    if (entry.TintColors?.Count > 0)
+                    {
+                        for (int i = 0; i < entry.TintColors.Count; i++)
+                        {
+                            Color? color = Utility.StringToColor(entry.TintColors[i]);
+                            string? oldColorCode = color.HasValue
+                                ? $"{color.Value.R} {color.Value.G} {color.Value.B}"
+                                : null;
+
+                            // remove if not in new colors
+                            if (oldColorCode is null || !newColors.Remove(oldColorCode))
+                            {
+                                entry.TintColors.RemoveAt(i);
+                                i--;
+                                continue;
+                            }
+                        }
+                    }
+
+                    // add any remaining colors
+                    if (newColors.Count > 0)
+                    {
+                        entry.TintColors ??= new();
+                        entry.TintColors.AddRange(newColors);
+                    }
+                }
+                else
+                {
+                    entry.TintColors?.Clear();
+                }
+            }
+        }
+    }
+}

--- a/ContentPatcher/Framework/Migrations/Migration_2_0.ForLocations.cs
+++ b/ContentPatcher/Framework/Migrations/Migration_2_0.ForLocations.cs
@@ -1,0 +1,983 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using ContentPatcher.Framework.Patches;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.GameData.Locations;
+
+namespace ContentPatcher.Framework.Migrations
+{
+    //
+    // Data/Locations is far more dynamic in 1.6, and there's no conceivable way to convert the new spawn options to
+    // the 1.5.6 format without losing nearly everything that defines them.
+    //
+    // Fortunately we don't actually need to, since we're only interested in what the edit patch changes. So this
+    // migration applies a few heuristics:
+    //   - Skip any rows/fields in the old format that didn't change.
+    //   - When a patch removes a spawn, all new spawn which would be converted to that format are removed.
+    //   - When a patch changes a spawn's chance or seasons, the existing entry is updated if possible. That's tricky
+    //     since there isn't always a 1:1 match between 1.5.6 (one list per season) and 1.6 (single list of conditional
+    //     spawns), but it's important for mod compatibility since other mods may target the same entries by ID in 1.6.
+    //   - Otherwise it's added to the asset with equivalent options.
+    //
+
+    internal partial class Migration_2_0 : BaseRuntimeMigration
+    {
+        /// <summary>The migration logic to apply pre-1.6 <c>Data/Locations</c> patches to the new format.</summary>
+        public class LocationsMigrator : IEditAssetMigrator
+        {
+            /*********
+            ** Fields
+            *********/
+            /****
+            ** Constants
+            ****/
+            /// <summary>The asset name.</summary>
+            private const string AssetName = "Data/Locations";
+
+            /// <summary>The valid season values.</summary>
+            private readonly Season[] ValidSeasons = new[] { Season.Spring, Season.Summer, Season.Fall, Season.Winter };
+
+            /// <summary>Get the unqualified object ID, if it's a valid object ID.</summary>
+            private readonly Func<string, string?> ParseObjectId;
+
+            /// <summary>The backing cache for <see cref="ParseEffectiveSeasons"/>.</summary>
+            private readonly Dictionary<string, IReadOnlySet<Season>?> ParseSeasonsCache = new();
+
+            /// <summary>The 'create on load' data for each location loaded from the asset directly without applying mod edits.</summary>
+            private Dictionary<string, CreateLocationData>? OriginalCreateLocationData;
+
+
+            /*********
+            ** Public methods
+            *********/
+            /// <summary>Construct an instance.</summary>
+            /// <param name="parseObjectId">Get the unqualified object ID, if it's a valid object ID.</param>
+            public LocationsMigrator(Func<string, string?> parseObjectId)
+            {
+                this.ParseObjectId = parseObjectId;
+            }
+
+            /// <inheritdoc />
+            public bool AppliesTo(IAssetName assetName)
+            {
+                return assetName?.IsEquivalentTo(LocationsMigrator.AssetName, useBaseName: true) is true;
+            }
+
+            /// <inheritdoc />
+            public IAssetName? RedirectTarget(IAssetName assetName, IPatch patch)
+            {
+                return null; // same asset name
+            }
+
+            /// <inheritdoc />
+            public bool TryApplyLoadPatch<T>(LoadPatch patch, IAssetName assetName, [NotNullWhen(true)] ref T? asset, out string? error)
+            {
+                Dictionary<string, string> tempData = patch.Load<Dictionary<string, string>>(assetName);
+                Dictionary<string, LocationData> newData = new();
+                this.MergeIntoNewFormat(newData, tempData, null, null, patch.ContentPack.Manifest.UniqueID);
+                asset = (T)(object)newData;
+
+                error = null;
+                return true;
+            }
+
+            /// <inheritdoc />
+            public bool TryApplyEditPatch<T>(EditDataPatch patch, IAssetData asset, out string? error)
+            {
+                var assetData = asset.GetData<Dictionary<string, LocationData>>();
+                Dictionary<string, string> tempData = this.GetOldFormat(assetData, out HashSet<string> skippedDueToNoData);
+                Dictionary<string, string> tempDataBackup = new(tempData);
+
+                patch.Edit<Dictionary<string, string>>(new FakeAssetData(asset, asset.Name, tempData));
+                this.MergeIntoNewFormat(assetData, tempData, tempDataBackup, skippedDueToNoData, patch.ContentPack.Manifest.UniqueID);
+
+                error = null;
+                return true;
+            }
+
+
+            /*********
+            ** Private methods
+            *********/
+            /// <summary>Get the pre-1.6 equivalent for the new asset data.</summary>
+            /// <param name="from">The data to convert.</param>
+            /// <param name="skippedDueToNoData">The location names which were skipped because they had no spawn data. These shouldn't be deleted if they're missing.</param>
+            private Dictionary<string, string> GetOldFormat(IDictionary<string, LocationData> from, out HashSet<string> skippedDueToNoData)
+            {
+                Dictionary<string, string> data = new();
+                skippedDueToNoData = new();
+
+                string[] fields = new string[9];
+                foreach (var pair in from)
+                {
+                    string locationName = pair.Key;
+                    LocationData entry = pair.Value;
+
+                    // map location names
+                    if (locationName == "Farm_Standard")
+                        locationName = "Farm";
+                    else if (this.IsReservedLocationName(locationName))
+                        continue;
+
+                    // load data
+                    this.GetForageChancesFromAsset(entry.Forage, out Dictionary<string, double> springForage, out Dictionary<string, double> summerForage, out Dictionary<string, double> fallForage, out Dictionary<string, double> winterForage);
+                    this.GetFishFromNewList(entry.Fish, out HashSet<FishSpawnValue> springFish, out HashSet<FishSpawnValue> summerFish, out HashSet<FishSpawnValue> fallFish, out HashSet<FishSpawnValue> winterFish);
+                    this.GetArtifactChancesFromAsset(entry.ArtifactSpots, out Dictionary<string, double> artifacts);
+
+                    // skip if no data
+                    if (
+                        springForage.Count == 0 && summerForage.Count == 0 && fallForage.Count == 0 && winterForage.Count == 0
+                        && springFish.Count == 0 && summerFish.Count == 0 && fallFish.Count == 0 && winterFish.Count == 0
+                        && artifacts.Count == 0
+                    )
+                    {
+                        skippedDueToNoData.Add(locationName);
+                        continue;
+                    }
+
+                    // apply
+                    fields[0] = this.ConvertToOldArtifactOrForageString(springForage);
+                    fields[1] = this.ConvertToOldArtifactOrForageString(summerForage);
+                    fields[2] = this.ConvertToOldArtifactOrForageString(fallForage);
+                    fields[3] = this.ConvertToOldArtifactOrForageString(winterForage);
+                    fields[4] = this.ConvertToOldFishString(locationName, springFish);
+                    fields[5] = this.ConvertToOldFishString(locationName, summerFish);
+                    fields[6] = this.ConvertToOldFishString(locationName, fallFish);
+                    fields[7] = this.ConvertToOldFishString(locationName, winterFish);
+                    fields[8] = this.ConvertToOldArtifactOrForageString(artifacts);
+
+                    data[locationName] = string.Join('/', fields);
+                }
+
+                return data;
+            }
+
+            /// <summary>Merge pre-1.6 data into the new asset.</summary>
+            /// <param name="asset">The asset data to update.</param>
+            /// <param name="temp">The pre-1.6 data to merge into the asset.</param>
+            /// <param name="tempBackup">A copy of <paramref name="temp"/> before edits were applied.</param>
+            /// <param name="skippedDueToNoData">The location names which were skipped because they had no spawn data. These shouldn't be deleted if they're missing.</param>
+            /// <param name="modId">The unique ID for the mod, used in auto-generated entry IDs.</param>
+            private void MergeIntoNewFormat(IDictionary<string, LocationData> asset, Dictionary<string, string> temp, Dictionary<string, string>? tempBackup, IReadOnlySet<string>? skippedDueToNoData, string modId)
+            {
+                // remove deleted entries
+                foreach (string key in asset.Keys)
+                {
+                    if (this.IsReservedLocationName(key))
+                        continue;
+
+                    if (!temp.ContainsKey(key) && skippedDueToNoData?.Contains(key) is not true)
+                        asset.Remove(key);
+                }
+
+                // apply entries
+                foreach ((string oldKey, string fromEntry) in temp)
+                {
+                    // map location names
+                    string locationName = oldKey;
+                    if (locationName is "Farm")
+                        locationName = "Farm_Standard";
+                    else if (this.IsReservedLocationName(locationName))
+                        continue;
+
+                    // get/add target record
+                    bool isNew = false;
+                    if (!asset.TryGetValue(locationName, out LocationData? targetLocationEntry))
+                    {
+                        isNew = true;
+                        targetLocationEntry = new LocationData
+                        {
+                            CreateOnLoad = this.GetDefaultCreateOnLoad(locationName)
+                        };
+                    }
+
+                    // get backup
+                    if (tempBackup is not null)
+                    {
+                        if (tempBackup.TryGetValue(oldKey, out string? prevRow) && prevRow == fromEntry)
+                            continue; // no changes
+                    }
+
+                    // merge fields into new asset
+                    string[] fromFields = fromEntry.Split('/');
+                    if (locationName is not "Farm_Standard") // farm forage/fish were hardcoded in 1.5.6
+                    {
+                        this.MergeForageIntoNewFormat(locationName, fromFields, targetLocationEntry, modId);
+                        this.MergeFishIntoNewFormat(locationName, fromFields, targetLocationEntry, modId);
+                    }
+                    this.MergeArtifactsIntoNewFormat(fromFields, targetLocationEntry, modId);
+
+                    // set value
+                    if (isNew)
+                        asset[locationName] = targetLocationEntry;
+                }
+            }
+
+            /// <summary>Whether a location name is reserved for 1.6 content and can't be edited by a 1.5.6 patch.</summary>
+            /// <param name="locationName">The location name to check.</param>
+            private bool IsReservedLocationName(string locationName)
+            {
+                return locationName is "Default" || locationName?.StartsWith("Farm_") is true;
+            }
+
+            /// <summary>Get the default 'create on load' data for a location.</summary>
+            /// <param name="locationName">The location name.</param>
+            private CreateLocationData GetDefaultCreateOnLoad(string locationName)
+            {
+                // use vanilla CreateOnLoad if applicable
+                if (!locationName.StartsWith("Custom_"))
+                {
+                    if (this.OriginalCreateLocationData is null)
+                    {
+                        using var content = new LocalizedContentManager(Game1.content.ServiceProvider, Game1.content.RootDirectory);
+                        this.OriginalCreateLocationData = DataLoader.Locations(content).ToDictionary(p => p.Key, p => p.Value.CreateOnLoad);
+                    }
+                    if (this.OriginalCreateLocationData.TryGetValue(locationName, out CreateLocationData? data))
+                    {
+                        return new CreateLocationData
+                        {
+                            MapPath = data.MapPath,
+                            Type = data.Type,
+                            AlwaysActive = data.AlwaysActive
+                        };
+                    }
+                }
+
+                // else use conventional pre-1.6 value
+                return new()
+                {
+                    MapPath = $"Maps\\{locationName}"
+                };
+            }
+
+            /// <summary>Merge pre-1.6 forage data into the new asset.</summary>
+            /// <param name="locationName">The internal location name being edited.</param>
+            /// <param name="fromFields">The pre-1.6 data to merge into the asset.</param>
+            /// <param name="targetLocationEntry">The location entry being added or edited.</param>
+            /// <param name="modId">The unique ID for the mod, used in auto-generated entry IDs.</param>
+            private void MergeForageIntoNewFormat(string locationName, string[] fromFields, LocationData targetLocationEntry, string modId)
+            {
+                // parseparse forage fields
+                Dictionary<string, double> fromSpringForage = this.GetChancesFromOldArtifactOrForageList(ArgUtility.Get(fromFields, 0));
+                Dictionary<string, double> fromSummerForage = this.GetChancesFromOldArtifactOrForageList(ArgUtility.Get(fromFields, 1));
+                Dictionary<string, double> fromFallForage = this.GetChancesFromOldArtifactOrForageList(ArgUtility.Get(fromFields, 2));
+                Dictionary<string, double> fromWinterForage = this.GetChancesFromOldArtifactOrForageList(ArgUtility.Get(fromFields, 3));
+                Dictionary<string, double> GetListForSeason(Season season)
+                {
+                    return season switch
+                    {
+                        Season.Spring => fromSpringForage,
+                        Season.Summer => fromSummerForage,
+                        Season.Fall => fromFallForage,
+                        _ => fromWinterForage
+                    };
+                }
+                void RemoveFromSeasons(string objectId, IEnumerable<Season> seasons)
+                {
+                    foreach (Season season in seasons)
+                        GetListForSeason(season).Remove(objectId);
+                }
+
+                // step 1: remove or update existing entries
+                if (targetLocationEntry.Forage?.Count > 0)
+                {
+                    for (int i = 0; i < targetLocationEntry.Forage.Count; i++)
+                    {
+                        var entry = targetLocationEntry.Forage[i];
+
+                        // parse entry
+                        string? objectId = this.ParseObjectId(entry.ItemId);
+                        IReadOnlySet<Season>? actualSeasons = this.ParseEffectiveSeasons(entry.Season, entry.Condition);
+                        if (objectId is null || actualSeasons is null)
+                            continue;
+
+                        // get updated chance for each season the entry targets
+                        Dictionary<Season, double> seasonChances = new();
+                        double? oneChance = null;
+                        bool allSameChance = true;
+                        foreach (Season season in actualSeasons)
+                        {
+                            double chance = GetListForSeason(season).GetValueOrDefault(objectId);
+                            if (chance > 0)
+                            {
+                                oneChance ??= chance;
+                                allSameChance = allSameChance && oneChance == chance;
+                                seasonChances[season] = chance;
+                            }
+                        }
+
+                        // remove seasons that no longer apply
+                        if (!actualSeasons.SetEquals(seasonChances.Keys))
+                        {
+                            HashSet<Season> seasons = new(actualSeasons);
+                            seasons.IntersectWith(seasonChances.Keys);
+
+                            RemoveFromSeasons(objectId, seasons);
+
+                            this.SetSeasons(locationName, targetLocationEntry.Forage, entry, seasons, out bool wasRemoved);
+                            if (wasRemoved)
+                            {
+                                i--;
+                                continue;
+                            }
+
+                            actualSeasons = seasons;
+                        }
+
+                        // update chance if all seasons have the same chance
+                        if (allSameChance)
+                        {
+                            entry.Chance = oneChance!.Value;
+                            RemoveFromSeasons(objectId, actualSeasons);
+                        }
+                    }
+                }
+
+                // step 2: add any remaining as new entries
+                void SaveForSeason(Season season, Dictionary<string, double> fromForage)
+                {
+                    if (fromForage.Count > 0)
+                    {
+                        targetLocationEntry.Forage ??= new();
+
+                        foreach ((string objectId, double chance) in fromForage)
+                        {
+                            string qualifiedItemId = ItemRegistry.type_object + objectId;
+
+                            targetLocationEntry.Forage.Add(
+                                new SpawnForageData
+                                {
+                                    Id = $"{modId}_{season}_{qualifiedItemId}",
+                                    ItemId = qualifiedItemId,
+                                    Chance = chance,
+                                    Season = season
+                                }
+                            );
+                        }
+                    }
+                }
+
+                SaveForSeason(Season.Spring, fromSpringForage);
+                SaveForSeason(Season.Summer, fromSummerForage);
+                SaveForSeason(Season.Fall, fromFallForage);
+                SaveForSeason(Season.Winter, fromWinterForage);
+            }
+
+            /// <summary>Merge pre-1.6 fish data into the new asset.</summary>
+            /// <param name="locationName">The internal location name being edited.</param>
+            /// <param name="fromFields">The pre-1.6 data to merge into the asset.</param>
+            /// <param name="targetLocationEntry">The location entry being added or edited.</param>
+            /// <param name="modId">The unique ID for the mod, used in auto-generated entry IDs.</param>
+            private void MergeFishIntoNewFormat(string locationName, string[] fromFields, LocationData targetLocationEntry, string modId)
+            {
+                // parse forage fields
+                HashSet<FishSpawnValue> fromSpringFish = this.GetValuesFromOldFishList(locationName, ArgUtility.Get(fromFields, 4));
+                HashSet<FishSpawnValue> fromSummerFish = this.GetValuesFromOldFishList(locationName, ArgUtility.Get(fromFields, 5));
+                HashSet<FishSpawnValue> fromFallFish = this.GetValuesFromOldFishList(locationName, ArgUtility.Get(fromFields, 6));
+                HashSet<FishSpawnValue> fromWinterFish = this.GetValuesFromOldFishList(locationName, ArgUtility.Get(fromFields, 7));
+                HashSet<FishSpawnValue> GetListForSeason(Season season)
+                {
+                    return season switch
+                    {
+                        Season.Spring => fromSpringFish,
+                        Season.Summer => fromSummerFish,
+                        Season.Fall => fromFallFish,
+                        _ => fromWinterFish
+                    };
+                }
+                void RemoveFromSeasons(FishSpawnValue key, IEnumerable<Season> seasons)
+                {
+                    foreach (Season season in seasons)
+                        GetListForSeason(season).Remove(key);
+                }
+
+                // step 1: remove or update existing entries
+                if (targetLocationEntry.Fish?.Count > 0)
+                {
+                    for (int i = 0; i < targetLocationEntry.Fish.Count; i++)
+                    {
+                        var entry = targetLocationEntry.Fish[i];
+
+                        // parse entry
+                        string? objectId = this.ParseObjectId(entry.ItemId);
+                        IReadOnlySet<Season>? actualSeasons = this.ParseEffectiveSeasons(entry.Season, entry.Condition);
+                        if (objectId is null || actualSeasons is null)
+                            continue;
+                        FishSpawnValue key = new FishSpawnValue(objectId, entry.FishAreaId);
+
+                        // get updated chance for each season the entry targets
+                        HashSet<Season> newSeasons = new();
+                        foreach (Season season in actualSeasons)
+                        {
+                            if (GetListForSeason(season).Contains(key))
+                                newSeasons.Add(season);
+                        }
+
+                        // remove seasons that no longer apply
+                        if (!actualSeasons.SetEquals(newSeasons))
+                        {
+                            this.SetSeasons(locationName, targetLocationEntry.Fish, entry, newSeasons, out bool wasRemoved);
+                            if (wasRemoved)
+                            {
+                                i--;
+                                continue;
+                            }
+
+                            actualSeasons = newSeasons;
+                        }
+
+                        // track that it's already in the list
+                        RemoveFromSeasons(key, actualSeasons);
+                    }
+                }
+
+                // step 2: add any remaining as new entries
+                void SaveForSeason(Season season, HashSet<FishSpawnValue> fromFish)
+                {
+                    if (fromFish.Count > 0)
+                    {
+                        targetLocationEntry.Fish ??= new();
+
+                        foreach ((string objectId, string? fishAreaId) in fromFish)
+                        {
+                            string qualifiedItemId = ItemRegistry.type_object + objectId;
+
+                            targetLocationEntry.Fish.Add(
+                                new SpawnFishData
+                                {
+                                    Id = $"{modId}_{season}_{qualifiedItemId}{(fishAreaId != null ? "_" + fishAreaId : "")}",
+                                    ItemId = qualifiedItemId,
+                                    FishAreaId = fishAreaId,
+                                    Season = season
+                                }
+                            );
+                        }
+                    }
+                }
+
+                SaveForSeason(Season.Spring, fromSpringFish);
+                SaveForSeason(Season.Summer, fromSummerFish);
+                SaveForSeason(Season.Fall, fromFallFish);
+                SaveForSeason(Season.Winter, fromWinterFish);
+            }
+
+            /// <summary>Merge pre-1.6 artifact data into the new asset.</summary>
+            /// <param name="fromFields">The pre-1.6 data to merge into the asset.</param>
+            /// <param name="targetLocationEntry">The location entry being added or edited.</param>
+            /// <param name="modId">The unique ID for the mod, used in auto-generated entry IDs.</param>
+            private void MergeArtifactsIntoNewFormat(string[] fromFields, LocationData targetLocationEntry, string modId)
+            {
+                // parse artifact field
+                Dictionary<string, double> fromArtifacts = this.GetChancesFromOldArtifactOrForageList(ArgUtility.Get(fromFields, 8));
+
+                // step 1: remove or update existing entries
+                if (targetLocationEntry.ArtifactSpots?.Count > 0)
+                {
+                    for (int i = 0; i < targetLocationEntry.ArtifactSpots.Count; i++)
+                    {
+                        var entry = targetLocationEntry.ArtifactSpots[i];
+
+                        // parse entry
+                        string? objectId = this.ParseObjectId(entry.ItemId);
+                        IReadOnlySet<Season>? actualSeasons = this.ParseEffectiveSeasons(null, entry.Condition);
+                        if (objectId is null || actualSeasons is null)
+                            continue;
+
+                        // skip: can't convert seasonal artifact spots between 1.5.6 and 1.6
+                        if (actualSeasons.Count != 4)
+                            continue;
+
+                        // remove if deleted
+                        if (!fromArtifacts.TryGetValue(objectId, out double chance))
+                        {
+                            targetLocationEntry.ArtifactSpots.RemoveAt(i);
+                            i--;
+                            continue;
+                        }
+
+                        // update chance
+                        entry.Chance = chance;
+                        fromArtifacts.Remove(objectId);
+                    }
+                }
+
+                // step 2: add any remaining as new entries
+                if (fromArtifacts.Count > 0)
+                {
+                    targetLocationEntry.ArtifactSpots ??= new();
+
+                    foreach ((string objectId, double chance) in fromArtifacts)
+                    {
+                        string qualifiedItemId = ItemRegistry.type_object + objectId;
+
+                        targetLocationEntry.ArtifactSpots.Add(
+                            new ArtifactSpotDropData
+                            {
+                                Id = $"{modId}_{qualifiedItemId}",
+                                ItemId = qualifiedItemId,
+                                Chance = chance
+                            }
+                        );
+                    }
+                }
+            }
+
+            /// <summary>Set the seasons for a forage entry, or remove it if it no longer spawns in any season.</summary>
+            /// <param name="locationName">The internal location name.</param>
+            /// <param name="list">The forage list in the target asset.</param>
+            /// <param name="entry">The entry to edit in the target asset.</param>
+            /// <param name="seasons">The seasons for which it should spawn.</param>
+            /// <param name="wasRemoved">Whether the forage entry was removed from the <paramref name="list"/>.</param>
+            private void SetSeasons(string locationName, List<SpawnForageData> list, SpawnForageData entry, HashSet<Season> seasons, out bool wasRemoved)
+            {
+                wasRemoved = false;
+
+                switch (seasons.Count)
+                {
+                    case 0:
+                        list.Remove(entry);
+                        wasRemoved = true;
+                        break;
+
+                    case 1:
+                        entry.Season = seasons.First();
+                        entry.Condition = null;
+                        break;
+
+                    default:
+                        entry.Season = null;
+                        entry.Condition = entry.Condition?.Trim().StartsWith(nameof(GameStateQuery.DefaultResolvers.SEASON), StringComparison.OrdinalIgnoreCase) is true
+                            ? $"{nameof(GameStateQuery.DefaultResolvers.SEASON)} {string.Join(' ', seasons)}"
+                            : $"{nameof(GameStateQuery.DefaultResolvers.LOCATION_SEASON)} {locationName} {string.Join(' ', seasons)}";
+                        break;
+                }
+            }
+
+            /// <summary>Set the seasons for a fish entry, or remove it if it no longer spawns in any season.</summary>
+            /// <param name="locationName">The internal location name.</param>
+            /// <param name="list">The fish list in the target asset.</param>
+            /// <param name="entry">The entry to edit in the target asset.</param>
+            /// <param name="seasons">The seasons for which it should spawn.</param>
+            /// <param name="wasRemoved">Whether the fish entry was removed from the <paramref name="list"/>.</param>
+            private void SetSeasons(string locationName, List<SpawnFishData> list, SpawnFishData entry, HashSet<Season> seasons, out bool wasRemoved)
+            {
+                wasRemoved = false;
+
+                switch (seasons.Count)
+                {
+                    case 0:
+                        list.Remove(entry);
+                        wasRemoved = true;
+                        break;
+
+                    case 1:
+                        entry.Season = seasons.First();
+                        entry.Condition = null;
+                        break;
+
+                    default:
+                        entry.Season = null;
+                        entry.Condition = entry.Condition?.Trim().StartsWith(nameof(GameStateQuery.DefaultResolvers.SEASON), StringComparison.OrdinalIgnoreCase) is true
+                            ? $"{nameof(GameStateQuery.DefaultResolvers.SEASON)} {string.Join(' ', seasons)}"
+                            : $"{nameof(GameStateQuery.DefaultResolvers.LOCATION_SEASON)} {locationName} {string.Join(' ', seasons)}";
+                        break;
+                }
+            }
+
+            /// <summary>Get the item IDs that spawn based on a space-delimited list of 'ID chance' pairs.</summary>
+            /// <param name="rawData">The raw forage list string.</param>
+            private Dictionary<string, double> GetChancesFromOldArtifactOrForageList(string rawData)
+            {
+                Dictionary<string, double> forage = new();
+
+                string[] fields = rawData.Split(' ');
+                for (int i = 0; i < fields.Length - 1; i += 2)
+                {
+                    string objectId = fields[i];
+                    if (double.TryParse(fields[i + 1], out double chance))
+                        forage[objectId] = chance;
+                }
+
+                return forage;
+            }
+
+            /// <summary>Get the fish IDs that spawn based on a space-delimited list of 'ID zone chance' tuples.</summary>
+            /// <param name="locationName">The internal location name.</param>
+            /// <param name="rawData">The raw forage list string.</param>
+            private HashSet<FishSpawnValue> GetValuesFromOldFishList(string locationName, string rawData)
+            {
+                HashSet<FishSpawnValue> fish = new();
+
+                string[] fields = rawData.Split(' ');
+                for (int i = 0; i < fields.Length - 1; i += 2)
+                {
+                    string objectId = fields[i];
+                    string? fishArea = this.UpgradeFishAreaId(locationName, fields[i + 1]);
+
+                    fish.Add(new FishSpawnValue(objectId, fishArea));
+                }
+
+                return fish;
+            }
+
+            /// <summary>Get the forage that spawn based on the new data.</summary>
+            /// <param name="data">The new location forage data.</param>
+            /// <param name="springForage">The equivalent pre-1.6 data for spring.</param>
+            /// <param name="summerForage">The equivalent pre-1.6 data for summer.</param>
+            /// <param name="fallForage">The equivalent pre-1.6 data for fall.</param>
+            /// <param name="winterForage">The equivalent pre-1.6 data for winter.</param>
+            private void GetForageChancesFromAsset(List<SpawnForageData> data, out Dictionary<string, double> springForage, out Dictionary<string, double> summerForage, out Dictionary<string, double> fallForage, out Dictionary<string, double> winterForage)
+            {
+                // init lookups
+                springForage = new();
+                summerForage = new();
+                fallForage = new();
+                winterForage = new();
+
+                // read data
+                foreach (SpawnForageData entry in data)
+                {
+                    // parse raw data
+                    string? objectId = this.ParseObjectId(entry.ItemId);
+                    IReadOnlySet<Season>? seasons = this.ParseEffectiveSeasons(entry.Season, entry.Condition);
+                    if (objectId is null || seasons is null)
+                        continue;
+
+                    // apply
+                    foreach (Season season in this.ValidSeasons)
+                    {
+                        if (!seasons.Contains(season))
+                            continue;
+
+                        var dict = season switch
+                        {
+                            Season.Spring => springForage,
+                            Season.Summer => summerForage,
+                            Season.Fall => fallForage,
+                            _ => winterForage
+                        };
+
+                        dict[objectId] = entry.Chance;
+                    }
+                }
+            }
+
+            /// <summary>Get the artifacts that spawn based on the new data.</summary>
+            /// <param name="data">The new location artifact data.</param>
+            /// <param name="artifacts">The equivalent pre-1.6 data.</param>
+            private void GetArtifactChancesFromAsset(List<ArtifactSpotDropData> data, out Dictionary<string, double> artifacts)
+            {
+                // init lookup
+                artifacts = new();
+
+                // read data
+                foreach (ArtifactSpotDropData entry in data)
+                {
+                    // parse raw data
+                    string? objectId = this.ParseObjectId(entry.ItemId);
+                    IReadOnlySet<Season>? seasons = this.ParseEffectiveSeasons(null, entry.Condition);
+                    if (objectId is null || seasons is null)
+                        continue;
+
+                    // skip: can't convert seasonal artifact spots to 1.5.6
+                    if (seasons.Count != 4)
+                        continue;
+
+                    // apply
+                    artifacts[objectId] = entry.Chance;
+                }
+            }
+
+            /// <summary>Get the fish that spawn based on the new data.</summary>
+            /// <param name="data">The new location fish data.</param>
+            /// <param name="springFish">The equivalent pre-1.6 data for spring.</param>
+            /// <param name="summerFish">The equivalent pre-1.6 data for summer.</param>
+            /// <param name="fallFish">The equivalent pre-1.6 data for fall.</param>
+            /// <param name="winterFish">The equivalent pre-1.6 data for winter.</param>
+            private void GetFishFromNewList(List<SpawnFishData> data, out HashSet<FishSpawnValue> springFish, out HashSet<FishSpawnValue> summerFish, out HashSet<FishSpawnValue> fallFish, out HashSet<FishSpawnValue> winterFish)
+            {
+                // init lookups
+                springFish = new();
+                summerFish = new();
+                fallFish = new();
+                winterFish = new();
+
+                // read data
+                foreach (SpawnFishData entry in data)
+                {
+                    if (entry.Chance < 1)
+                        continue; // can't convert fish chances to 1.5.6
+
+                    // parse raw data
+                    string? objectId = this.ParseObjectId(entry.ItemId);
+                    IReadOnlySet<Season>? seasons = this.ParseEffectiveSeasons(null, entry.Condition);
+                    if (objectId is null || seasons is null)
+                        continue;
+
+                    // apply
+                    foreach (Season season in this.ValidSeasons)
+                    {
+                        if (!seasons.Contains(season))
+                            continue;
+
+                        var dict = season switch
+                        {
+                            Season.Spring => springFish,
+                            Season.Summer => summerFish,
+                            Season.Fall => fallFish,
+                            _ => winterFish
+                        };
+
+                        dict.Add(new FishSpawnValue(objectId, entry.FishAreaId));
+                    }
+                }
+            }
+
+            /// <summary>Convert a dictionary of artifact or forage spawn values to the old format.</summary>
+            /// <param name="forage">The forage data to convert.</param>
+            private string ConvertToOldArtifactOrForageString(Dictionary<string, double> forage)
+            {
+                if (forage.Count == 0)
+                    return "-1";
+
+                StringBuilder result = new();
+                foreach ((string objectId, double chance) in forage)
+                {
+                    result
+                        .Append(objectId)
+                        .Append(' ')
+                        .Append(chance)
+                        .Append(' ');
+                }
+
+                return result.ToString(0, result.Length - 1);
+            }
+
+            /// <summary>Convert a dictionary of fish spawn values to the old format.</summary>
+            /// <param name="locationName">The internal location name.</param>
+            /// <param name="fish">The fish data to convert.</param>
+            private string ConvertToOldFishString(string locationName, HashSet<FishSpawnValue> fish)
+            {
+                if (fish.Count == 0)
+                    return "-1";
+
+                StringBuilder result = new();
+                foreach ((string objectId, string? fishZoneId) in fish)
+                {
+                    result
+                        .Append(objectId)
+                        .Append(' ')
+                        .Append(this.DowngradeFishAreaId(locationName, fishZoneId))
+                        .Append(' ');
+                }
+
+                return result.ToString(0, result.Length - 1);
+            }
+
+            private string DowngradeFishAreaId(string locationName, string? id)
+            {
+                if (id is null)
+                    return "-1";
+
+                switch (locationName)
+                {
+                    case "Forest":
+                        return id switch
+                        {
+                            "Lake" => "1",
+                            "River" => "0",
+                            _ => id
+                        };
+
+                    case "IslandWest":
+                        return id switch
+                        {
+                            "Freshwater" => "2",
+                            "Ocean" => "1",
+                            _ => id
+                        };
+
+                    default:
+                        return id;
+                }
+            }
+
+            private string? UpgradeFishAreaId(string locationName, string id)
+            {
+                if (id is "-1")
+                    return null;
+
+                switch (locationName)
+                {
+                    case "Forest":
+                        return id switch
+                        {
+                            "0" => "River",
+                            "1" => "Lake",
+                            _ => id
+                        };
+
+                    case "IslandWest":
+                        return id switch
+                        {
+                            "1" => "Ocean",
+                            "2" => "Freshwater",
+                            _ => id
+                        };
+
+                    default:
+                        return id;
+                }
+            }
+
+            /// <summary>Parse the seasons for which a spawn entry applies, if it's valid and not too dynamic to convert to 1.5.6.</summary>
+            /// <param name="season">The specific season for which the entry applies.</param>
+            /// <param name="condition">The game state query which indicates whether the entry applies.</param>
+            /// <returns>Returns the parsed seasons, or <c>null</c> if invalid or not convertible to 1.5.6.</returns>
+            private IReadOnlySet<Season>? ParseEffectiveSeasons(Season? season, string condition)
+            {
+                string cacheKey = $"{season}|{condition}";
+
+                // skip cached
+                {
+                    if (this.ParseSeasonsCache.TryGetValue(cacheKey, out IReadOnlySet<Season>? cached))
+                        return cached;
+                }
+
+                // parse raw seasons
+                if (!this.TryParseRawSeasonsFromNewData(season, condition, out HashSet<Season> seasons, out HashSet<Season> notSeasons))
+                {
+                    this.ParseSeasonsCache[cacheKey] = null;
+                    return null;
+                }
+
+                // cancel out seasons that are both included and excluded
+                if (notSeasons.Count > 0 && notSeasons.Count > 0)
+                {
+                    foreach (Season curSeason in this.ValidSeasons)
+                    {
+                        bool apply = seasons.Contains(curSeason);
+                        bool exclude = notSeasons.Contains(curSeason);
+
+                        if (apply && exclude)
+                        {
+                            seasons.Remove(curSeason);
+                            notSeasons.Remove(curSeason);
+                        }
+                    }
+
+                    // if all seasons were cancelled out, the entry can never spawn
+                    if (seasons.Count == 0 && notSeasons.Count == 0)
+                    {
+                        this.ParseSeasonsCache[cacheKey] = null;
+                        return null;
+                    }
+                }
+
+                // If both seasons and not-seasons still have values, they're non-overlapping. In that case not-seasons
+                // is redundant since it would only exclude seasons that are already not excluded via seasons.
+                if (seasons.Count > 0 && notSeasons.Count > 0)
+                    notSeasons.Clear();
+
+                // invert not seasons
+                if (notSeasons.Count > 0)
+                {
+                    foreach (Season curSeason in this.ValidSeasons)
+                    {
+                        if (!notSeasons.Contains(curSeason))
+                            seasons.Add(curSeason);
+                    }
+                }
+
+                // get result
+                if (seasons.Count > 0)
+                {
+                    this.ParseSeasonsCache[cacheKey] = seasons;
+                    return seasons;
+                }
+                else
+                {
+                    this.ParseSeasonsCache[cacheKey] = null;
+                    return null;
+                }
+            }
+
+            /// <summary>Extract the seasons for which a spawn entry applies, if it's valid and not too dynamic to convert to 1.5.6.</summary>
+            /// <param name="season">The specific season for which the entry applies.</param>
+            /// <param name="condition">The game state query which indicates whether the entry applies.</param>
+            /// <param name="parsedSeasons">The set to which to add the seasons it spawns in.</param>
+            /// <param name="parsedNotSeasons">The set to which to add the seasons it cannot spawn in.</param>
+            private bool TryParseRawSeasonsFromNewData(Season? season, string condition, out HashSet<Season> parsedSeasons, out HashSet<Season> parsedNotSeasons)
+            {
+                // init sets
+                parsedSeasons = new();
+                parsedNotSeasons = new();
+
+                // single season
+                bool isSingleSeason = false;
+                if (season.HasValue)
+                {
+                    parsedSeasons.Add(season.Value);
+                    isSingleSeason = true;
+                }
+
+                // shortcut if no conditions
+                if (GameStateQuery.IsImmutablyTrue(condition))
+                {
+                    if (!isSingleSeason)
+                    {
+                        parsedSeasons.Add(Season.Spring);
+                        parsedSeasons.Add(Season.Summer);
+                        parsedSeasons.Add(Season.Fall);
+                        parsedSeasons.Add(Season.Winter);
+                    }
+
+                    return parsedSeasons.Count > 0;
+                }
+
+                // extract from game state query
+                foreach (GameStateQuery.ParsedGameStateQuery query in GameStateQuery.Parse(condition))
+                {
+                    // skip broken
+                    if (query.Error is not null)
+                        return false;
+
+                    // get index where list of seasons starts
+                    string[] args = query.Query;
+                    string name = args[0];
+                    int seasonIndex;
+                    if (string.Equals(name, nameof(GameStateQuery.DefaultResolvers.LOCATION_SEASON)))
+                        seasonIndex = 2;
+                    else if (string.Equals(name, nameof(GameStateQuery.DefaultResolvers.SEASON)))
+                        seasonIndex = -1;
+                    else
+                        return false; // non-season query, too dynamic to convert
+
+                    // apply
+                    bool negate = query.Negated;
+                    for (int i = seasonIndex; i < args.Length; i++)
+                    {
+                        if (!Utility.TryParseEnum(args[i], out Season curSeason))
+                            return false;
+
+                        if (negate)
+                            parsedNotSeasons.Add(curSeason);
+                        else
+                            parsedSeasons.Add(curSeason);
+                    }
+                }
+
+                return parsedSeasons.Count > 0 || parsedNotSeasons.Count > 0;
+            }
+        }
+
+        /// <summary>The unique key pair for old fish spawn data.</summary>
+        /// <param name="ObjectId">The unqualified object ID to spawn.</param>
+        /// <param name="FishZoneId">The fish zone ID it spawns in.</param>
+        public record FishSpawnValue(string ObjectId, string? FishZoneId);
+    }
+}

--- a/ContentPatcher/Framework/Migrations/Migration_2_0.ForNpcDispositions.cs
+++ b/ContentPatcher/Framework/Migrations/Migration_2_0.ForNpcDispositions.cs
@@ -1,0 +1,355 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using ContentPatcher.Framework.Patches;
+using Microsoft.Xna.Framework;
+using StardewModdingAPI;
+using StardewModdingAPI.Framework.Content;
+using StardewValley;
+using StardewValley.GameData.Characters;
+using StardewTokenParser = StardewValley.TokenizableStrings.TokenParser;
+
+namespace ContentPatcher.Framework.Migrations
+{
+    internal partial class Migration_2_0 : BaseRuntimeMigration
+    {
+        /// <summary>The migration logic to apply pre-1.6 <c>Data/NPCDispositions</c> patches to <c>Data/Characters</c>.</summary>
+        public class NpcDispositionsMigrator : IEditAssetMigrator
+        {
+            /*********
+            ** Fields
+            *********/
+            /// <summary>The pre-1.6 asset name.</summary>
+            private const string OldAssetName = "Data/NPCDispositions";
+
+            /// <summary>The 1.6 asset name.</summary>
+            private const string NewAssetName = "Data/Characters";
+
+
+            /*********
+            ** Public methods
+            *********/
+            /// <inheritdoc />
+            public bool AppliesTo(IAssetName assetName)
+            {
+                return assetName?.IsEquivalentTo(NpcDispositionsMigrator.OldAssetName, useBaseName: true) is true;
+            }
+
+            /// <inheritdoc />
+            public IAssetName? RedirectTarget(IAssetName assetName, IPatch patch)
+            {
+                return new AssetName(NpcDispositionsMigrator.NewAssetName, null, null);
+            }
+
+            /// <inheritdoc />
+            public bool TryApplyLoadPatch<T>(LoadPatch patch, IAssetName assetName, [NotNullWhen(true)] ref T? asset, out string? error)
+            {
+                Dictionary<string, string> tempData = patch.Load<Dictionary<string, string>>(this.GetOldAssetName(assetName));
+                Dictionary<string, CharacterData> newData = new();
+                this.MergeIntoNewFormat(newData, tempData, null);
+                asset = (T)(object)newData;
+
+                error = null;
+                return true;
+            }
+
+            /// <inheritdoc />
+            public bool TryApplyEditPatch<T>(EditDataPatch patch, IAssetData asset, out string? error)
+            {
+                var data = asset.GetData<Dictionary<string, CharacterData>>();
+                Dictionary<string, string> tempData = this.GetOldFormat(data);
+                Dictionary<string, string> tempDataBackup = new(tempData);
+                patch.Edit<Dictionary<string, string>>(new FakeAssetData(asset, this.GetOldAssetName(asset.Name), tempData));
+                this.MergeIntoNewFormat(data, tempData, tempDataBackup);
+
+                error = null;
+                return true;
+            }
+
+
+            /*********
+            ** Private methods
+            *********/
+            /// <summary>Get the old asset to edit.</summary>
+            /// <param name="newName">The new asset name whose locale to use.</param>
+            private IAssetName GetOldAssetName(IAssetName newName)
+            {
+                return new AssetName(NpcDispositionsMigrator.OldAssetName, newName.LocaleCode, newName.LanguageCode);
+            }
+
+            /// <summary>Get the pre-1.6 equivalent for the new asset data.</summary>
+            /// <param name="from">The data to convert.</param>
+            private Dictionary<string, string> GetOldFormat(IDictionary<string, CharacterData> from)
+            {
+                var data = new Dictionary<string, string>();
+
+                string[] fields = new string[12];
+                foreach ((string npcName, CharacterData entry) in from)
+                {
+                    fields[0] = entry.Age.ToString().ToLowerInvariant();
+                    fields[1] = entry.Manner.ToString().ToLowerInvariant();
+                    fields[2] = entry.SocialAnxiety.ToString().ToLowerInvariant();
+                    fields[3] = entry.Optimism.ToString().ToLowerInvariant();
+                    fields[4] = entry.Gender.ToString().ToLowerInvariant();
+                    fields[5] = this.GetOldDateableField(npcName, entry.CanBeRomanced);
+                    fields[6] = entry.LoveInterest ?? "null";
+                    fields[7] = entry.HomeRegion;
+                    fields[8] = this.GetOldBirthdayField(entry.BirthSeason, entry.BirthDay);
+                    fields[9] = this.GetOldFriendsAndFamilyField(entry.FriendsAndFamily);
+                    fields[10] = $"default_home_position 0 0"; // the home is dynamic in 1.6, so we just need to check if the content pack changes it
+                    fields[11] = StardewTokenParser.ParseText(entry.DisplayName);
+
+                    data[npcName] = string.Join('/', fields);
+                }
+
+                return data;
+            }
+
+            /// <summary>Merge pre-1.6 data into the new asset.</summary>
+            /// <param name="asset">The asset data to update.</param>
+            /// <param name="from">The pre-1.6 data to merge into the asset.</param>
+            /// <param name="fromBackup">A copy of <paramref name="from"/> before edits were applied.</param>
+            private void MergeIntoNewFormat(IDictionary<string, CharacterData> asset, IDictionary<string, string> from, IDictionary<string, string>? fromBackup)
+            {
+                // remove deleted entries
+                foreach (string key in asset.Keys)
+                {
+                    if (!from.ContainsKey(key))
+                        asset.Remove(key);
+                }
+
+                // apply entries
+                foreach ((string npcName, string fromEntry) in from)
+                {
+                    // get/add target record
+                    bool isNew = false;
+                    if (!asset.TryGetValue(npcName, out CharacterData? entry))
+                    {
+                        isNew = true;
+                        entry = new CharacterData();
+                    }
+
+                    // get backup
+                    string[]? backupFields = null;
+                    if (fromBackup is not null)
+                    {
+                        if (fromBackup.TryGetValue(npcName, out string? prevRow) && prevRow == fromEntry)
+                            continue; // no changes
+                        backupFields = prevRow?.Split('/');
+                    }
+
+                    // merge fields into new asset
+                    {
+                        string[] fields = fromEntry.Split('/');
+
+                        entry.Age = ArgUtility.GetEnum(fields, 0, entry.Age);
+                        entry.Manner = ArgUtility.GetEnum(fields, 1, entry.Manner);
+                        entry.SocialAnxiety = ArgUtility.GetEnum(fields, 2, entry.SocialAnxiety);
+                        entry.Optimism = ArgUtility.GetEnum(fields, 3, entry.Optimism);
+                        entry.Gender = ArgUtility.GetEnum(fields, 4, entry.Gender);
+
+                        this.MergeDateableFieldIntoNewFormat(entry, ArgUtility.Get(fields, 5));
+
+                        entry.LoveInterest = ArgUtility.Get(fields, 6, entry.LoveInterest);
+                        if (entry.LoveInterest == "null")
+                            entry.LoveInterest = null;
+
+                        entry.HomeRegion = ArgUtility.Get(fields, 7, entry.HomeRegion);
+
+                        string rawBirthday = ArgUtility.Get(fields, 8);
+                        if (rawBirthday != ArgUtility.Get(backupFields, 8))
+                            this.MergeBirthdayIntoNewFormat(entry, rawBirthday);
+
+                        string rawFriendsAndFamily = ArgUtility.Get(fields, 9);
+                        if (rawFriendsAndFamily != ArgUtility.Get(backupFields, 9))
+                            this.MergeFriendsAndFamilyIntoNewFormat(entry, rawFriendsAndFamily);
+
+                        string rawHome = ArgUtility.Get(fields, 10);
+                        if (rawHome != ArgUtility.Get(backupFields, 10))
+                            this.MergeHomeIntoNewFormat(entry, rawHome);
+
+                        string displayName = ArgUtility.Get(fields, 11);
+                        if (!string.IsNullOrWhiteSpace(displayName) && displayName != ArgUtility.Get(backupFields, 11) && displayName != StardewTokenParser.ParseText(entry.DisplayName))
+                            entry.DisplayName = displayName;
+                    }
+
+                    // set value
+                    if (isNew)
+                        asset[npcName] = entry;
+                }
+            }
+
+            /// <summary>Get the pre-1.6 dateable field from the new asset.</summary>
+            /// <param name="npcName">The internal NPC name.</param>
+            /// <param name="canRomance">Whether the NPC can be romanced.</param>
+            private string GetOldDateableField(string npcName, bool canRomance)
+            {
+                if (canRomance)
+                    return "datable";
+
+                return npcName == "Krobus"
+                    ? "secret"
+                    : "not-datable";
+            }
+
+            /// <summary>Merge a pre-1.6 'dateable' field into the new asset.</summary>
+            /// <param name="entry">The NPC data to update.</param>
+            /// <param name="dateable">The 'dateable' field value.</param>
+            private void MergeDateableFieldIntoNewFormat(CharacterData entry, string dateable)
+            {
+                // can romance
+                switch (dateable)
+                {
+                    case "datable":
+                        entry.CanBeRomanced = true;
+                        break;
+
+                    default:
+                        entry.CanBeRomanced = false;
+                        break;
+                }
+            }
+
+            /// <summary>Get the pre-1.6 birthday field from the new asset.</summary>
+            /// <param name="season">The birthday season, or <c>null</c> if the NPC has no birthday.</param>
+            /// <param name="season">The birthday day.</param>
+            private string GetOldBirthdayField(Season? season, int day)
+            {
+                return season is not null
+                    ? $"{season.Value.ToString().ToLowerInvariant()} {day}"
+                    : "null";
+            }
+
+            /// <summary>Merge a pre-1.6 'birthday' field into the new asset.</summary>
+            /// <param name="entry">The NPC data to update.</param>
+            /// <param name="birthday">The 'birthday' field value.</param>
+            private void MergeBirthdayIntoNewFormat(CharacterData entry, string birthday)
+            {
+                string[] fields = ArgUtility.SplitBySpace(birthday, 2);
+
+                if (fields[0] == "null" || string.IsNullOrWhiteSpace(fields[0]))
+                    entry.BirthSeason = null;
+                else if (Utility.TryParseEnum(fields[0], out Season season))
+                    entry.BirthSeason = season;
+
+                entry.BirthDay = ArgUtility.GetInt(fields, 1, entry.BirthDay);
+            }
+
+            /// <summary>Get the pre-1.6 'friends and family' field from the new asset.</summary>
+            /// <param name="data">The 1.6 field value.</param>
+            private string GetOldFriendsAndFamilyField(Dictionary<string, string> data)
+            {
+                if (data?.Count is not > 0)
+                    return string.Empty;
+
+                StringBuilder result = new();
+                foreach (var pair in data)
+                {
+                    string npcName = pair.Key;
+                    string? nickname = StardewTokenParser.ParseText(pair.Value)?.Replace("'", "``");
+
+                    result
+                        .Append(npcName)
+                        .Append(" '")
+                        .Append(nickname)
+                        .Append("' ");
+                }
+
+                return result.ToString(0, result.Length - 1);
+            }
+
+            /// <summary>Merge a pre-1.6 'friends and family' field into the new asset.</summary>
+            /// <param name="entry">The NPC data to update.</param>
+            /// <param name="rawFriendsAndFamily">The 'friends and family' field value.</param>
+            /// <remarks>This is partly derived from the 1.5.6 <c>NPC.loadCurrentDialogue()</c> code, but with added support for spaces inside the quotes (which is allowed in 1.6) and edge cases like a trailing name.</remarks>
+            private void MergeFriendsAndFamilyIntoNewFormat(CharacterData entry, string rawFriendsAndFamily)
+            {
+                // parse field
+                Dictionary<string, string> newValues = new();
+                {
+                    int startFrom = 0;
+                    while (startFrom < rawFriendsAndFamily.Length - 1)
+                    {
+                        int startNicknameIndex = rawFriendsAndFamily.IndexOf('\'', startFrom);
+                        if (startNicknameIndex == -1)
+                            break; // 1.5.6 would ignore a trailing name without a nickname
+
+                        int endNicknameIndex = rawFriendsAndFamily.IndexOf('\'', startNicknameIndex + 1);
+                        if (endNicknameIndex == -1)
+                            endNicknameIndex = rawFriendsAndFamily.Length;
+
+                        string name = rawFriendsAndFamily.Substring(startFrom, startNicknameIndex - startFrom);
+                        string nickname = rawFriendsAndFamily.Substring(startNicknameIndex + 1, endNicknameIndex - 1 - startNicknameIndex).Replace("``", "'").Replace('_', ' '); // unescape single quotes (from 1.6 data) and spaces (in pre-1.6 format)
+
+                        newValues[name] = nickname;
+                        startFrom = endNicknameIndex + 1;
+                    }
+                }
+
+                // remove or update existing entries
+                if (entry.FriendsAndFamily?.Count > 0)
+                {
+                    foreach ((string npcName, string oldNickname) in entry.FriendsAndFamily)
+                    {
+                        // remove if deleted
+                        if (!newValues.TryGetValue(npcName, out string? newNickname))
+                        {
+                            entry.FriendsAndFamily.Remove(npcName);
+                            continue;
+                        }
+
+                        // else update
+                        if (newNickname != oldNickname && newNickname != StardewTokenParser.ParseText(oldNickname))
+                            entry.FriendsAndFamily[npcName] = newNickname;
+
+                        newValues.Remove(npcName);
+                    }
+                }
+
+                // add any remaining entries
+                if (newValues.Count > 0)
+                {
+                    entry.FriendsAndFamily ??= new();
+
+                    foreach ((string npcName, string nickname) in newValues)
+                        entry.FriendsAndFamily[npcName] = nickname;
+                }
+            }
+
+            /// <summary>Merge a pre-1.6 'home' field into the new asset.</summary>
+            /// <param name="entry">The NPC data to update.</param>
+            /// <param name="rawHome">The 'home' field value.</param>
+            private void MergeHomeIntoNewFormat(CharacterData entry, string rawHome)
+            {
+                string[] fields = ArgUtility.SplitBySpace(rawHome, 3);
+
+                string locationName = fields[0];
+                if (!ArgUtility.TryGetPoint(fields, 1, out Point tile, out _))
+                    tile = Point.Zero;
+
+                // update existing entry
+                if (entry.Home?.Count > 0)
+                {
+                    foreach (var home in entry.Home)
+                    {
+                        if (home.Location == locationName && GameStateQuery.IsImmutablyTrue(home.Condition))
+                        {
+                            home.Tile = tile;
+                            return;
+                        }
+                    }
+                }
+
+                // else reset to match
+                entry.Home ??= new List<CharacterHomeData>();
+                entry.Home.Clear();
+                entry.Home.Add(new CharacterHomeData
+                {
+                    Id = "Default",
+                    Location = locationName,
+                    Tile = tile
+                });
+            }
+        }
+    }
+}

--- a/ContentPatcher/Framework/Migrations/Migration_2_0.ForObjectInformation.cs
+++ b/ContentPatcher/Framework/Migrations/Migration_2_0.ForObjectInformation.cs
@@ -1,0 +1,373 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using ContentPatcher.Framework.Patches;
+using StardewModdingAPI;
+using StardewModdingAPI.Framework.Content;
+using StardewValley;
+using StardewValley.Buffs;
+using StardewValley.GameData.Buffs;
+using StardewValley.GameData.Objects;
+using StardewTokenParser = StardewValley.TokenizableStrings.TokenParser;
+
+namespace ContentPatcher.Framework.Migrations
+{
+    internal partial class Migration_2_0 : BaseRuntimeMigration
+    {
+        /// <summary>The migration logic to apply pre-1.6 <c>Data/ObjectInformation</c> patches to <c>Data/Objects</c>.</summary>
+        public class ObjectInformationMigrator : IEditAssetMigrator
+        {
+            /*********
+            ** Fields
+            *********/
+            /// <summary>The pre-1.6 asset name.</summary>
+            private const string OldAssetName = "Data/ObjectInformation";
+
+            /// <summary>The 1.6 asset name.</summary>
+            private const string NewAssetName = "Data/Objects";
+
+            /// <summary>Get the unqualified object ID, if it's a valid object ID.</summary>
+            private readonly Func<string, string?> ParseObjectId;
+
+
+            /*********
+            ** Public methods
+            *********/
+            /// <summary>Construct an instance.</summary>
+            /// <param name="parseObjectId">Get the unqualified object ID, if it's a valid object ID.</param>
+            public ObjectInformationMigrator(Func<string, string?> parseObjectId)
+            {
+                this.ParseObjectId = parseObjectId;
+            }
+
+            /// <inheritdoc />
+            public bool AppliesTo(IAssetName assetName)
+            {
+                return assetName?.IsEquivalentTo(ObjectInformationMigrator.OldAssetName, useBaseName: true) is true;
+            }
+
+            /// <inheritdoc />
+            public IAssetName? RedirectTarget(IAssetName assetName, IPatch patch)
+            {
+                return new AssetName(ObjectInformationMigrator.NewAssetName, null, null);
+            }
+
+            /// <inheritdoc />
+            public bool TryApplyLoadPatch<T>(LoadPatch patch, IAssetName assetName, [NotNullWhen(true)] ref T? asset, out string? error)
+            {
+                Dictionary<string, string> tempData = patch.Load<Dictionary<string, string>>(this.GetOldAssetName(assetName));
+                Dictionary<string, ObjectData> newData = new();
+                this.MergeIntoNewFormat(newData, tempData, null, patch.ContentPack.Manifest.UniqueID);
+                asset = (T)(object)newData;
+
+                error = null;
+                return true;
+            }
+
+            /// <inheritdoc />
+            public bool TryApplyEditPatch<T>(EditDataPatch patch, IAssetData asset, out string? error)
+            {
+                var data = asset.GetData<Dictionary<string, ObjectData>>();
+                Dictionary<string, string> tempData = this.GetOldFormat(data);
+                Dictionary<string, string> tempDataBackup = new(tempData);
+                patch.Edit<Dictionary<string, string>>(new FakeAssetData(asset, this.GetOldAssetName(asset.Name), tempData));
+                this.MergeIntoNewFormat(data, tempData, tempDataBackup, patch.ContentPack.Manifest.UniqueID);
+
+                error = null;
+                return true;
+            }
+
+
+            /*********
+            ** Private methods
+            *********/
+            /// <summary>Get the old asset to edit.</summary>
+            /// <param name="newName">The new asset name whose locale to use.</param>
+            private IAssetName GetOldAssetName(IAssetName newName)
+            {
+                return new AssetName(ObjectInformationMigrator.OldAssetName, newName.LocaleCode, newName.LanguageCode);
+            }
+
+            /// <summary>Get the pre-1.6 equivalent for the new asset data.</summary>
+            /// <param name="from">The data to convert.</param>
+            private Dictionary<string, string> GetOldFormat(IDictionary<string, ObjectData> from)
+            {
+                var data = new Dictionary<string, string>();
+
+                string[] fields = new string[9];
+                foreach ((string objectId, ObjectData entry) in from)
+                {
+                    BuffEffects? buffEffects = entry.Buff?.CustomAttributes != null
+                        ? new(entry.Buff?.CustomAttributes)
+                        : null;
+
+                    fields[0] = entry.Name;
+                    fields[1] = entry.Price.ToString();
+                    fields[2] = entry.Edibility.ToString();
+                    fields[3] = $"{entry.Type} {entry.Category}";
+                    fields[4] = StardewTokenParser.ParseText(entry.DisplayName);
+                    fields[5] = StardewTokenParser.ParseText(entry.Description);
+                    fields[6] = this.GetOldMiscellaneousField(objectId, entry);
+                    fields[7] = buffEffects?.HasAnyValue() is true ? string.Join(" ", buffEffects.ToLegacyAttributeFormat()) : string.Empty;
+                    fields[8] = entry.Buff?.Duration.ToString() ?? string.Empty;
+
+                    data[objectId] = string.Join('/', fields);
+                }
+
+                return data;
+            }
+
+            /// <summary>Merge pre-1.6 data into the new asset.</summary>
+            /// <param name="asset">The asset data to update.</param>
+            /// <param name="from">The pre-1.6 data to merge into the asset.</param>
+            /// <param name="fromBackup">A copy of <paramref name="from"/> before edits were applied.</param>
+            /// <param name="modId">The unique ID for the mod, used in auto-generated entry IDs.</param>
+            private void MergeIntoNewFormat(IDictionary<string, ObjectData> asset, IDictionary<string, string> from, IDictionary<string, string>? fromBackup, string modId)
+            {
+                // remove deleted entries
+                foreach (string key in asset.Keys)
+                {
+                    if (!from.ContainsKey(key))
+                        asset.Remove(key);
+                }
+
+                // apply entries
+                foreach ((string objectId, string fromEntry) in from)
+                {
+                    // get/add target record
+                    bool isNew = false;
+                    if (!asset.TryGetValue(objectId, out ObjectData? entry))
+                    {
+                        isNew = true;
+                        entry = new ObjectData();
+                    }
+
+                    // get backup
+                    string[]? backupFields = null;
+                    if (fromBackup is not null)
+                    {
+                        if (fromBackup.TryGetValue(objectId, out string? prevRow) && prevRow == fromEntry)
+                            continue; // no changes
+                        backupFields = prevRow?.Split('/');
+                    }
+
+                    // merge fields into new asset
+                    {
+                        string[] fields = fromEntry.Split('/');
+
+                        // main fields
+                        entry.Name = ArgUtility.Get(fields, 0, entry.Name, allowBlank: false);
+                        entry.Price = ArgUtility.GetInt(fields, 1, entry.Price);
+                        entry.Edibility = ArgUtility.GetInt(fields, 2, entry.Edibility);
+
+                        // type & category
+                        string rawTypeAndCategory = ArgUtility.Get(fields, 3);
+                        if (!string.IsNullOrWhiteSpace(rawTypeAndCategory) && rawTypeAndCategory != ArgUtility.Get(backupFields, 3))
+                        {
+                            string[] parts = rawTypeAndCategory.Split(' ', 2);
+
+                            entry.Type = parts[0];
+                            entry.Category = ArgUtility.GetInt(parts, 1, entry.Category);
+                        }
+
+                        // display name
+                        string displayName = ArgUtility.Get(fields, 4);
+                        if (!string.IsNullOrWhiteSpace(displayName) && displayName != ArgUtility.Get(backupFields, 4) && displayName != StardewTokenParser.ParseText(entry.DisplayName))
+                            entry.DisplayName = displayName;
+
+                        // description
+                        string description = ArgUtility.Get(fields, 5);
+                        if (!string.IsNullOrWhiteSpace(description) && description != ArgUtility.Get(backupFields, 5) && description != StardewTokenParser.ParseText(entry.Description))
+                            entry.Description = description;
+
+                        // miscellaneous
+                        string rawMiscellaneous = ArgUtility.Get(fields, 6);
+                        if (rawMiscellaneous != ArgUtility.Get(backupFields, 6))
+                            this.MergeMiscellaneousFieldIntoNewFormat(objectId, entry, rawMiscellaneous, modId);
+
+                        // buff effects
+                        string rawBuffEffects = ArgUtility.Get(fields, 7);
+                        if (rawBuffEffects != null && rawBuffEffects != ArgUtility.Get(backupFields, 7))
+                            this.MergeBuffFieldIntoNewFormat(entry, rawBuffEffects);
+
+                        // buff duration
+                        if (entry.Buff != null)
+                            entry.Buff.Duration = ArgUtility.GetInt(fields, 8, entry.Buff.Duration);
+                    }
+
+                    // set value
+                    if (isNew)
+                        asset[objectId] = entry;
+                }
+            }
+
+            /// <summary>Get the pre-1.6 'miscellaneous' field for the new object data.</summary>
+            /// <param name="objectId">The object ID.</param>
+            /// <param name="data">The object data.</param>
+            private string GetOldMiscellaneousField(string objectId, ObjectData data)
+            {
+                // geode
+                if (objectId is "275" or "535" or "536" or "537" or "749")
+                {
+                    if (data.GeodeDrops is null)
+                        return string.Empty;
+
+                    return string.Join(
+                        ' ',
+                        from drop in data.GeodeDrops
+                        where GameStateQuery.IsImmutablyTrue(drop.Condition)
+
+                        let itemId = this.ParseObjectId(drop.ItemId)
+                        where itemId != null
+
+                        select itemId
+                    );
+                }
+
+                // artifact
+                if (data.Type == "Arch")
+                {
+                    if (data.ArtifactSpotChances is null)
+                        return string.Empty;
+
+                    return string.Join(' ', data.ArtifactSpotChances.Select(p => $"{p.Key} {p.Value}"));
+                }
+
+                // food/drink
+                if (data.Buff != null)
+                    return data.IsDrink ? "drink" : "food";
+
+                // none
+                return string.Empty;
+            }
+
+            /// <summary>Merge a pre-1.6 'buff' field into the new object data.</summary>
+            /// <param name="entry">The object data.</param>
+            /// <param name="field">The field value.</param>
+            private void MergeBuffFieldIntoNewFormat(ObjectData entry, string field)
+            {
+                string[] fields = field.Split(' ');
+
+                entry.Buff ??= new ObjectBuffData() { BuffId = entry.IsDrink ? "drink" : "food" };
+                entry.Buff.CustomAttributes ??= new BuffAttributesData();
+
+                BuffAttributesData effects = entry.Buff.CustomAttributes;
+                effects.FarmingLevel = ArgUtility.GetInt(fields, 0, effects.FarmingLevel);
+                effects.FishingLevel = ArgUtility.GetInt(fields, 1, effects.FishingLevel);
+                effects.MiningLevel = ArgUtility.GetInt(fields, 2, effects.MiningLevel);
+                effects.LuckLevel = ArgUtility.GetInt(fields, 4, effects.LuckLevel);
+                effects.ForagingLevel = ArgUtility.GetInt(fields, 5, effects.ForagingLevel);
+                effects.MaxStamina = ArgUtility.GetInt(fields, 7, effects.MaxStamina);
+                effects.MagneticRadius = ArgUtility.GetInt(fields, 8, effects.MagneticRadius);
+                effects.Speed = ArgUtility.GetInt(fields, 9, effects.Speed);
+                effects.Defense = ArgUtility.GetInt(fields, 10, effects.Defense);
+                effects.Attack = ArgUtility.GetInt(fields, 11, effects.Attack);
+            }
+
+            /// <summary>Merge a pre-1.6 'miscellaneous' field into the new object data.</summary>
+            /// <param name="objectId">The object ID.</param>
+            /// <param name="data">The object data.</param>
+            /// <param name="miscellaneous">The miscellaneous field value.</param>
+            /// <param name="modId">The unique ID for the mod, used in auto-generated entry IDs.</param>
+            private void MergeMiscellaneousFieldIntoNewFormat(string objectId, ObjectData data, string miscellaneous, string modId)
+            {
+                // geode
+                if (objectId is "275" or "535" or "536" or "537" or "749")
+                {
+                    HashSet<string> dropIds = new HashSet<string>(miscellaneous.Split(' '));
+
+                    // step 1: remove existing entries
+                    if (data.GeodeDrops != null)
+                    {
+                        for (int i = 0; i < data.GeodeDrops.Count; i++)
+                        {
+                            var entry = data.GeodeDrops[i];
+
+                            // parse entry
+                            string? curObjectId = this.ParseObjectId(entry.ItemId);
+                            if (curObjectId is null || !GameStateQuery.IsImmutablyTrue(entry.Condition))
+                                continue;
+
+                            // remove if deleted
+                            if (!dropIds.Contains(curObjectId))
+                            {
+                                data.GeodeDrops.RemoveAt(i);
+                                i--;
+                                continue;
+                            }
+
+                            dropIds.Remove(curObjectId);
+                        }
+                    }
+
+                    // step 2: add any remaining as new entries
+                    if (dropIds.Count > 0)
+                    {
+                        data.GeodeDrops ??= new();
+
+                        foreach (string dropId in dropIds)
+                        {
+                            string qualifiedItemId = ItemRegistry.type_object + dropId;
+
+                            data.GeodeDrops.Add(
+                                new ObjectGeodeDropData
+                                {
+                                    Id = $"{modId}_{qualifiedItemId}",
+                                    ItemId = qualifiedItemId
+                                }
+                            );
+                        }
+                    }
+                }
+
+                // artifact
+                if (data.Type == "Arch")
+                {
+                    // parse artifact field
+                    Dictionary<string, double> drops = new();
+                    {
+                        string[] fields = miscellaneous.Split(' ');
+                        for (int i = 0; i < fields.Length - 1; i += 2)
+                        {
+                            string dropId = fields[i];
+                            if (double.TryParse(fields[i + 1], out double chance))
+                                drops[dropId] = chance;
+                        }
+                    }
+
+                    // step 1: remove or update existing entries
+                    if (data.ArtifactSpotChances.Count > 0)
+                    {
+                        foreach (string dropId in data.ArtifactSpotChances.Keys)
+                        {
+                            // remove if deleted
+                            if (!drops.TryGetValue(dropId, out double chance))
+                                data.ArtifactSpotChances.Remove(dropId);
+
+                            // else update
+                            else
+                            {
+                                data.ArtifactSpotChances[dropId] = (float)chance;
+                                drops.Remove(dropId);
+                            }
+                        }
+                    }
+
+                    // step 2: add any remaining as new entries
+                    if (drops.Count > 0)
+                    {
+                        data.ArtifactSpotChances ??= new();
+
+                        foreach ((string dropId, double chance) in drops)
+                        {
+                            string qualifiedItemId = ItemRegistry.type_object + dropId;
+
+                            data.ArtifactSpotChances[dropId] = (float)chance;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ContentPatcher/Framework/Migrations/Migration_2_0.cs
+++ b/ContentPatcher/Framework/Migrations/Migration_2_0.cs
@@ -44,8 +44,10 @@ namespace ContentPatcher.Framework.Migrations
             this.AddedTokens = new InvariantSet(
                 nameof(ConditionType.ModId)
             );
+            this.MigrationWarnings = [
+                "Some content packs haven't been updated for Stardew Valley 1.6.0. Content Patcher will try to auto-migrate them, but compatibility isn't guaranteed."
+            ];
         }
-
 
         /// <inheritdoc />
         public override bool TryMigrate(ref PatchConfig[] patches, [NotNullWhen(false)] out string? error)

--- a/ContentPatcher/Framework/Migrations/Migration_2_0.cs
+++ b/ContentPatcher/Framework/Migrations/Migration_2_0.cs
@@ -1,38 +1,29 @@
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using ContentPatcher.Framework.Conditions;
 using ContentPatcher.Framework.ConfigModels;
-using ContentPatcher.Framework.Lexing;
-using Newtonsoft.Json.Linq;
-using Pathoschild.Stardew.Common;
+using ContentPatcher.Framework.Patches;
 using Pathoschild.Stardew.Common.Utilities;
 using StardewModdingAPI;
-using StardewModdingAPI.Utilities;
-using InnerPatch = Pathoschild.Stardew.Common.Utilities.InvariantDictionary<Newtonsoft.Json.Linq.JToken?>;
+using StardewValley;
+using StardewValley.ItemTypeDefinitions;
 
 namespace ContentPatcher.Framework.Migrations
 {
-    internal record DataLocationsState(JArray forage, JArray fish, JArray artifacts);
-    internal class ObjectsState
-    {
-        // Assuming food if not present
-        public string Type { get; set; } = "food";
-    }
-    internal enum DataLocationType
-    {
-        Fish,
-        Forage,
-        Artifacts
-    }
-
-    /// <summary>Migrates patches to format version 2.0.</summary>
+    /// <summary>Migrates patches to format version 2.0 and Stardew Valley 1.6.</summary>
     [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Named for clarity.")]
-    internal class Migration_2_0 : BaseMigration
+    internal partial class Migration_2_0 : BaseRuntimeMigration
     {
-        /// <summary>Handles parsing raw strings into tokens.</summary>
-        private readonly Lexer Lexer = Lexer.Instance;
+        /*********
+        ** Fields
+        *********/
+        /// <summary>The backing cache for <see cref="ParseObjectId"/>.</summary>
+        private readonly Dictionary<string, string?> ParseObjectIdCache = new();
+
+        /// <summary>The migrators that convert pre-1.6 edit patches to a newer asset or format.</summary>
+        /// <remarks>For each edit, the first migrator which applies or returns errors is used.</remarks>
+        private readonly IEditAssetMigrator[] Migrators;
+
 
         /*********
         ** Public methods
@@ -47,6 +38,15 @@ namespace ContentPatcher.Framework.Migrations
             this.MigrationWarnings = [
                 "Some content packs haven't been updated for Stardew Valley 1.6.0. Content Patcher will try to auto-migrate them, but compatibility isn't guaranteed."
             ];
+
+            this.Migrators = new IEditAssetMigrator[]
+            {
+                new BigCraftableInformationMigrator(),
+                new CropsMigrator(),
+                new LocationsMigrator(this.ParseObjectId),
+                new NpcDispositionsMigrator(),
+                new ObjectInformationMigrator(this.ParseObjectId)
+            };
         }
 
         /// <inheritdoc />
@@ -65,763 +65,112 @@ namespace ContentPatcher.Framework.Migrations
                 }
             }
 
-            Dictionary<PatchConfig, (bool Replace, List<PatchConfig> Patches)> replacementMap = new();
-
-            foreach (PatchConfig? patch in patches)
-            {
-                if (this.HasAction(patch, PatchType.EditData))
-                {
-                    if (PathUtilities.NormalizeAssetName(patch.Target) == "Data/NPCDispositions")
-                    {
-                        patch.Target = "Data/Characters";
-                        if (patch.TargetField.Count > 0)
-                        {
-                            error = "Unable to convert NPCDispositions when TargetField is used";
-                            return false;
-                        }
-                        // Data/Dispositions -> Data/Characters doesn't need state management, passing in object? null instead
-                        if (!this.ConvertDataModel<object?>(null, patch,
-                            mapping: new()
-                            {
-                                ["0"] = this.MapSingle("Age", val => val.ToLowerInvariant() switch
-                                {
-                                    "child" => "Child",
-                                    "teen" => "Teen",
-                                    _ => "Adult"
-                                }),
-                                ["1"] = this.MapSingle("Manner", val => val.ToLowerInvariant() switch
-                                {
-                                    "rude" => "Rude",
-                                    "polite" => "Polite",
-                                    _ => "Neutral"
-                                }),
-                                ["2"] = this.MapSingle("SocialAnxiety", val => val.ToLowerInvariant() switch
-                                {
-                                    "shy" => "Shy",
-                                    "outgoing" => "Outgoing",
-                                    _ => "Neutral"
-                                }),
-                                ["3"] = this.MapSingle("Optimism", val => val.ToLowerInvariant() switch
-                                {
-                                    "negative" => "Negative",
-                                    "positive" => "Positive",
-                                    _ => "Neutral"
-                                }),
-                                ["4"] = this.MapSingle("Gender", val => val.ToLowerInvariant() switch
-                                {
-                                    "male" => "Male",
-                                    "female" => "Female",
-                                    _ => "Undefined"
-                                }),
-                                // in pre 1.6 it was "datable", "not-datable" or "secret". It is now a boolean.
-                                ["5"] = this.MapSingle("CanBeRomanced", val => val.ToLowerInvariant() == "datable"),
-                                ["6"] = this.MapSingle("LoveInterest"),
-                                ["7"] = this.MapSingle("HomeRegion"),
-                                ["8"] = (patch, outerKey, _, val) =>
-                                {
-                                    if (this.Lexer.MightContainTokens(val))
-                                    {
-                                        return $"Cannot convert the npc birthday information in {outerKey} when it is contains tokens ({val})";
-                                    }
-                                    // from 1.5.6's NPCDisposition parsing, with added checks for conventional "null"
-                                    if (val.Length > 0 && val != "null")
-                                    {
-                                        string[] birthInfo = val.Split(' ');
-                                        patch["BirthSeason"] = birthInfo[0];
-                                        patch["BirthDay"] = Convert.ToInt32(birthInfo[1]);
-                                    }
-                                    return null;
-                                },
-                                ["9"] = this.MapSingle("FriendsAndFamily", val =>
-                                {
-                                    var friendsAndFamily = new JObject();
-                                    if (val.Length > 0)
-                                    {
-                                        string[] relationComponents = val.Split(" ");
-                                        if (relationComponents.Length >= 2)
-                                        {
-                                            for (int i = 0; i < Math.Floor((double)relationComponents.Length / 2); i++)
-                                            {
-                                                // TODO: Replace common occurrences with the vanilla Translatable strings instead
-                                                friendsAndFamily[relationComponents[2 * i]] = relationComponents[2 * i + 1].Replace("'", "");
-                                            }
-                                        }
-                                    }
-                                    return friendsAndFamily;
-                                }),
-                                ["10"] = (patch, outerKey, _, val) =>
-                                {
-                                    this.ConvertDefaultLocation(patch, outerKey, val, out string? innerError);
-                                    return innerError;
-                                },
-                                ["11"] = this.MapSingle("DisplayName")
-                            },
-                            out error)
-                        )
-                        {
-                            return false;
-                        }
-                    }
-                    else if (PathUtilities.NormalizeAssetName(patch.Target) == "Data/Locations")
-                    {
-                        if (!this.ConvertDataModel(new DataLocationsState(new(), new(), new()), patch,
-                            mapping: new()
-                            {
-                                ["0"] = this.MapDataLocations("spring", DataLocationType.Forage, true),
-                                ["1"] = this.MapDataLocations("summer", DataLocationType.Forage, true),
-                                ["2"] = this.MapDataLocations("fall", DataLocationType.Forage, true),
-                                ["3"] = this.MapDataLocations("winter", DataLocationType.Forage, true),
-                                ["4"] = this.MapDataLocations("spring", DataLocationType.Fish, false),
-                                ["5"] = this.MapDataLocations("summer", DataLocationType.Fish, false),
-                                ["6"] = this.MapDataLocations("fall", DataLocationType.Fish, false),
-                                ["7"] = this.MapDataLocations("winter", DataLocationType.Fish, false),
-                                ["8"] = this.MapDataLocations(null, DataLocationType.Artifacts, true),
-                            },
-                            postMapping: (patch, data) =>
-                            {
-                                if (data == null)
-                                {
-                                    throw new NullReferenceException("Missing DataLocationState in MapDataLocations");
-                                }
-
-                                if (data.forage.HasValues)
-                                {
-                                    patch["Forage"] = new JArray(data.forage);
-                                }
-                                if (data.fish.HasValues)
-                                {
-                                    patch["Fish"] = new JArray(data.fish);
-                                }
-                                if (data.artifacts.HasValues)
-                                {
-                                    patch["ArtifactSpots"] = new JArray(data.artifacts);
-                                }
-                                // the data state is used for the entire EditData patch, which may contain data for multiple locations. This should be per location
-                                data.forage.Clear();
-                                data.fish.Clear();
-                                data.artifacts.Clear();
-                                return null;
-                            },
-                            error: out error)
-                        )
-                        {
-                            return false;
-                        }
-                        if (!this.ConvertTextOperations(patch,
-                            replacementMap,
-                            textOperationFilter: operation =>
-                            {
-                                return
-                                (
-                                    operation.Delimiter == " " &&
-                                    operation.Operation == "Append" &&
-                                    operation.Target.Length == 3 &&
-                                    operation.Target[0] == "Fields" &&
-                                    operation.Target[1] != null &&
-                                    operation.Value != null &&
-                                    int.TryParse(operation.Target[2], out int field3) &&
-                                    field3 >= 0 && field3 <= 8
-                                );
-                            },
-                            textOperationMapper: (patch, textOperation) =>
-                            {
-                                string outerKey = textOperation.Target[1]!;
-                                string index = textOperation.Target[2]!;
-                                DataLocationsState state = new(new(), new(), new());
-                                string value = textOperation.Value!;
-                                string? error = index switch
-                                {
-                                    // This.MapDataLocations does not look at the patch, so passing null in for simplicity
-                                    "0" => this.MapDataLocations("spring", DataLocationType.Forage, true)(null!, outerKey, state, value),
-                                    "1" => this.MapDataLocations("summer", DataLocationType.Forage, true)(null!, outerKey, state, value),
-                                    "2" => this.MapDataLocations("fall", DataLocationType.Forage, true)(null!, outerKey, state, value),
-                                    "3" => this.MapDataLocations("winter", DataLocationType.Forage, true)(null!, outerKey, state, value),
-                                    "4" => this.MapDataLocations("spring", DataLocationType.Fish, false)(null!, outerKey, state, value),
-                                    "5" => this.MapDataLocations("summer", DataLocationType.Fish, false)(null!, outerKey, state, value),
-                                    "6" => this.MapDataLocations("fall", DataLocationType.Fish, false)(null!, outerKey, state, value),
-                                    "7" => this.MapDataLocations("winter", DataLocationType.Forage, false)(null!, outerKey, state, value),
-                                    "8" => this.MapDataLocations(null, DataLocationType.Artifacts, true)(null!, outerKey, state, value),
-                                    _ => "Unknown index"
-                                };
-                                if (error != null)
-                                    return error;
-
-                                patch.TargetField.Add(textOperation.Target[1]!);
-                                JArray collection;
-                                if (state.fish.HasValues)
-                                {
-                                    patch.TargetField.Add("Fish");
-                                    collection = state.fish;
-                                }
-                                else if (state.forage.HasValues)
-                                {
-                                    patch.TargetField.Add("Forage");
-                                    collection = state.forage;
-                                }
-                                else if (state.artifacts.HasValues)
-                                {
-                                    patch.TargetField.Add("ArtifactSpots");
-                                    collection = state.artifacts;
-                                }
-                                else
-                                {
-                                    return "TextOperation patch did not contain anything";
-                                }
-
-                                int id = 0;
-                                foreach (var item in collection)
-                                {
-                                    string namedId = patch.LogName + id++;
-                                    item["Id"] = namedId;
-                                    patch.Entries[namedId] = item;
-                                }
-
-                                // no error
-                                return null;
-                            },
-                            out error
-                        ))
-                        {
-                            return false;
-                        }
-                    }
-                    else if (PathUtilities.NormalizeAssetName(patch.Target) == "Data/ObjectInformation")
-                    {
-                        patch.Target = "Data/Objects";
-                        if (patch.TargetField.Count > 0)
-                        {
-                            error = "Unable to convert ObjectInformation when TargetField is used";
-                            return false;
-                        }
-
-                        // Misc fields relate to a different field, tracking it in state
-                        if (!this.ConvertDataModel<ObjectsState>(new(), patch,
-                            mapping: new()
-                            {
-                                ["0"] = this.MapSingle("Name"),
-                                ["1"] = this.MapSingle("Price"),
-                                ["2"] = this.MapSingle("Edibility"),
-                                // Note 1.5.6 behavior for this field was... weird, so this may need more love
-                                ["3"] = (patch, _, _, val) =>
-                                {
-                                    if (val.Length > 0 && val != "null")
-                                    {
-                                        string[] typeAndCategory = val.Split(' ');
-                                        patch["Type"] = typeAndCategory[0];
-                                        if (typeAndCategory.Length > 1)
-                                        {
-                                            patch["Category"] = Convert.ToInt32(typeAndCategory[1]);
-                                        }
-                                    }
-                                    return null;
-                                },
-                                ["4"] = this.MapSingle("DisplayName"),
-                                ["5"] = this.MapSingle("Description"),
-                                ["6"] = (patch, _, state, val) =>
-                                {
-                                    state.Type = val;
-                                    if (val == "drink")
-                                    {
-                                        patch["IsDrink"] = true;
-                                    }
-                                    return null;
-                                },
-                                ["7"] = (patch, _, state, val) =>
-                                {
-                                    if (state.Type == "food" || state.Type == "drink")
-                                    {
-                                        string[] foodEffects = val.Split(" ");
-                                        for (int i = 0; i <= foodEffects.Length - 1; i++)
-                                        {
-                                            if (int.TryParse(foodEffects[i], out int foodEffect))
-                                            {
-                                                string? key = i switch
-                                                {
-                                                    00 => "FarmingLevel",
-                                                    01 => "FishingLevel",
-                                                    02 => "MiningLevel",
-                                                    03 => null,
-                                                    04 => "LuckLevel",
-                                                    05 => "ForagingLevel",
-                                                    06 => null,
-                                                    07 => "MaxStamina",
-                                                    08 => "MagneticRadius",
-                                                    09 => "Speed",
-                                                    10 => "Defense",
-                                                    11 => "Attack",
-                                                    _ => null
-                                                };
-                                                if (key == null) continue;
-                                                if (!patch.ContainsKey("Buff"))
-                                                {
-                                                    patch["Buff"] = new JObject();
-                                                }
-                                                if (!(patch["Buff"] as JObject)!.ContainsKey("CustomAttributes"))
-                                                {
-                                                    patch["Buff"]!["CustomAttributes"] = new JObject();
-                                                }
-                                                patch["Buff"]!["CustomAttributes"]![key] = foodEffect;
-                                            }
-                                        }
-                                    }
-                                    // TODO: implement other formats
-                                    else
-                                    {
-                                        return state.Type;
-                                    }
-
-                                    return null;
-                                },
-                                ["8"] = (patch, _, _, val) =>
-                                {
-                                    if (!patch.ContainsKey("Buff"))
-                                    {
-                                        patch["Buff"] = new JObject();
-                                    }
-                                    patch["Buff"]!["Duration"] = val;
-                                    return null;
-                                },
-                            },
-                            out error)
-                        )
-                        {
-                            return false;
-                        }
-                    }
-                    else if (PathUtilities.NormalizeAssetName(patch.Target) == "Data/BigCraftableInformation")
-                    {
-                        patch.Target = "Data/BigCraftables";
-                        if (patch.TargetField.Count > 0)
-                        {
-                            error = "Unable to convert BigCraftableInformation when TargetField is used";
-                            return false;
-                        }
-
-                        if (!this.ConvertDataModel<object?>(null, patch,
-                            mapping: new()
-                            {
-                                ["0"] = this.MapSingle("Name"),
-                                ["1"] = this.MapSingle("Price"),
-                                ["2"] = (patch, _, _, val) =>
-                                {
-                                    // This is 1.5.6 Edibility which doesn't exist anymore
-                                    return null;
-                                },
-                                ["3"] = (patch, _, _, val) =>
-                                {
-                                    // This is 1.5.6 type+category which doesn't exist anymore
-                                    return null;
-                                },
-                                ["4"] = this.MapSingle("DisplayName"),
-                                ["5"] = this.MapSingle("CanBePlacedOutdoors"),
-                                ["6"] = this.MapSingle("CanBePlacedIndoors"),
-                                ["7"] = this.MapSingle("Fragility"),
-                                ["8"] = this.MapSingle("IsLamp", val => val == "true"),
-                                ["9"] = this.MapSingle("DisplayName")
-                            },
-                            out error)
-                        )
-                        {
-                            return false;
-                        }
-                    }
-                    else if (PathUtilities.NormalizeAssetName(patch.Target) == "Data/Crops")
-                    {
-                        if (!this.ConvertDataModel<object?>(null, patch,
-                            mapping: new()
-                            {
-                                ["0"] = this.MapSingle("DaysInPhase", val => JArray.FromObject(val.Split(" "))),
-                                ["1"] = this.MapSingle("Seasons", val => JArray.FromObject(val.Split(" "))),
-                                ["2"] = this.MapSingle("SpriteIndex"),
-                                ["3"] = this.MapSingle("HarvestItemId"),
-                                ["4"] = this.MapSingle("RegrowDays"),
-                                ["5"] = this.MapSingle("HarvestMethod", val => val == "1" ? "Scythe" : "Grab"),
-                                ["6"] = (patch, _, _, val) =>
-                                {
-                                    /*
-                                     * Format in 1.5.6 was one of the following
-                                     * false
-                                     * true minHarvest maxHarvest maxHarvestIncreasePerFarmingLevel chanceForExtraCrops
-                                     */
-                                    string[] split = val.Split(" ");
-                                    if (split.Length > 0 && split[0] == "true")
-                                    {
-                                        patch["HarvestMinStack"] = split[1];
-                                        patch["HarvestMaxStack"] = split[2];
-                                        patch["HarvestMaxIncreasePerFarmingLevel"] = split[3];
-                                        patch["ExtraHarvestChance"] = split[4];
-                                    }
-                                    return null;
-                                },
-                                ["7"] = this.MapSingle("IsRaised"),
-                                ["8"] = (patch, _, _, val) =>
-                                {
-                                    /*
-                                     * Format in 1.5.6 was one of the following
-                                     * false
-                                     * true [R G B]
-                                     * where [] indicates repeating pairs of three values
-                                     */
-                                    string[] split = val.Split(" ");
-                                    if (split.Length > 0 && split[0] == "true")
-                                    {
-                                        string[] segments = split.Skip(1).Chunk(3).Select(row => string.Join(' ', row)).ToArray();
-                                        patch["TintColors"] = JArray.FromObject(segments);
-                                    }
-                                    return null;
-                                }
-                            },
-                            out error)
-                        )
-                        {
-                            return false;
-                        }
-                    }
-                }
-            }
-            if (replacementMap.Count > 0)
-            {
-                // TODO: work out if these in place expansions can be done easier than just making it a list and back to an array
-                var patchList = patches.ToList();
-                foreach (var (patch, replacementEntry) in replacementMap)
-                {
-                    int index = patchList.IndexOf(patch);
-                    if (replacementEntry.Replace)
-                    {
-                        patchList.RemoveAt(index);
-                    }
-                    // if we are not replacing, then the index needs to be incremented by 1, as EditDataPatch evaluates TextOperations after Entries/Records and Fields
-                    patchList.InsertRange(index + (replacementEntry.Replace ? 0 : 1), replacementEntry.Patches);
-                }
-                patches = patchList.ToArray();
-            }
-
             return true;
         }
 
-        /// <summary>This method converts previously <c>Dictionary&lt;string, string&gt;</c> data model patches into <c>Dictionary&lt;string, T&gt;</c></summary>
-        /// <remarks>
-        /// This method is intended to be operated on EditData patches where the target is 
-        /// where values were / separated values.
-        /// 
-        /// This method will convert the Fields and Entries of the patch into a form that can be run on  instead
-        /// mapping the keys from the old integer indexes into new string values represented in the new data model,
-        /// while doing transformation of values in the process.
-        /// </remarks>
-        /// <typeparam name="T">The Datatype for state management in <paramref name="data"/></typeparam>
-        /// <param name="data">State management which will be passed into every call in <paramref name="mapping"/> and <paramref name="postMapping"/></param>
-        /// <param name="patch">The patch that is being transformed</param>
-        /// <param name="mapping">
-        /// A dictionary of old keys and values are transformer methods to be operated on the inner patch contents.
-        /// The methods arguments are as follows:
-        /// <list type="number">
-        ///     <item>the inner patch contents the original dictionary key being referenced</item>
-        ///     <item>the key from the dictionary being accessed (i.e npc name in NPCDispositions)</item>
-        ///     <item>the state object from <paramref name="data"/></item>
-        ///     <item>The raw string value that is being mapped and potentially transformed on</item>
-        /// </list>
-        /// and would return an optional error message if things went wrong
-        /// </param>
-        /// <param name="error">An error message if things went wrong.</param>
-        /// <param name="postMapping">A method that is run after the all the Fields of a given entry key, or after each value in Entries to do any final transformations in bulk</param>
-        /// <returns>whether it was successful, if unsuccessful then <paramref name="error"/> will explain why</returns>
-        private bool ConvertDataModel<T>(
-            T data,
-            PatchConfig patch,
-            Dictionary<string, Func<InnerPatch, string, T, string, string?>> mapping,
-            [NotNullWhen(false)] out string? error,
-            Func<InnerPatch, T, string?>? postMapping = null
-        )
+        /// <inheritdoc />
+        public override IAssetName? RedirectTarget(IAssetName assetName, IPatch patch)
         {
-            bool InnerConversion(InnerPatch patch, string outerKey, [NotNullWhen(false)] out string? innerError)
+            foreach (IEditAssetMigrator migrator in this.Migrators)
             {
-                bool hasRun = false;
-                foreach (string key in patch.Keys.ToArray())
+                if (migrator.AppliesTo(assetName))
                 {
-                    var value = patch[key];
-                    if (value?.Type != JTokenType.String) continue;
-                    // This is invoking JToken's explicit string operator and tests if it was a string token, if so spit out the value.
-                    string? strValue = (string?)value;
-                    if (strValue == null) continue;
-                    if (mapping.TryGetValue(key, out var mapper))
-                    {
-                        innerError = mapper(patch, outerKey, data, strValue);
-                        if (innerError != null) return false;
-                        patch.Remove(key);
-                        hasRun = true;
-                    }
-                }
-                if (hasRun && postMapping != null)
-                {
-                    string? postError = postMapping(patch, data);
-                    if (postError != null)
-                    {
-                        innerError = postError;
-                        return false;
-                    }
-                }
-                innerError = null;
-                return true;
-            }
-
-            if (patch.Fields.Count > 0)
-            {
-                foreach (var (key, _) in patch.Fields)
-                {
-                    var field = patch.Fields[key];
-                    if (field == null) continue;
-                    if (!InnerConversion(field, key, out error))
-                    {
-                        return false;
-                    }
-                }
-            }
-            foreach (var (key, value) in patch.Entries)
-            {
-                if (value?.Type == JTokenType.String)
-                {
-                    string? strValue = (string?)value;
-                    if (strValue == null) continue;
-                    var components = this.SplitTokenAware(strValue, '/');
-                    // Converting the patch to look closer to a fully populated Fields patch so can reuse code
-                    var newPatch = new InnerPatch(components.Select((v, i) => new { Key = i, Value = v }).ToDictionary(item => item.Key.ToString(), item => (JToken?)new JValue(item.Value)));
-                    var newValue = new JObject();
-                    if (!InnerConversion(newPatch, key, out error))
-                    {
-                        return false;
-                    }
-                    patch.Entries[key] = JObject.FromObject(newPatch);
+                    IAssetName? newName = migrator.RedirectTarget(assetName, patch);
+                    if (newName != null)
+                        return newName;
                 }
             }
 
-            error = null;
-            return true;
+            return base.RedirectTarget(assetName, patch);
         }
 
-        /// <summary>
-        /// Converts TextOperations in complex patches into new patches using list insertion instead
-        /// </summary>
-        /// <param name="patch">The patch that may contain TextOperation entries</param>
-        /// <param name="replacementMap">A working collection of patches and the mapping back to the patch that causes them for upstream insertion in <see cref="TryMigrate(ref PatchConfig[], out string?)"/></param>
-        /// <param name="textOperationFilter">Whether this text operation is valid for the transformer.</param>
-        /// <param name="textOperationMapper">Transforms the empty patch with the text operation into a patch with content.</param>
-        /// <param name="error">The error message if anything went wrong</param>
-        /// <returns>This returns whether the conversion was successful. If it wasn't then <paramref name="error"/> will explain why.</returns>
-        private bool ConvertTextOperations(
-            PatchConfig patch,
-            Dictionary<PatchConfig, (bool, List<PatchConfig>)> replacementMap,
-            Func<TextOperationConfig, bool> textOperationFilter,
-            Func<PatchConfig, TextOperationConfig, string?> textOperationMapper,
-            [NotNullWhen(false)] out string? error)
+        /// <inheritdoc />
+        public override bool TryApplyLoadPatch<T>(LoadPatch patch, IAssetName assetName, [NotNullWhen(true)] ref T? asset, out string? error)
+            where T : default
         {
-            int textOperationId = 0;
-            var replacementPatches = new List<PatchConfig>();
-            foreach (var textOperation in patch.TextOperations.WhereNotNull())
+            foreach (IEditAssetMigrator migrator in this.Migrators)
             {
-                if (!textOperationFilter(textOperation))
+                if (migrator.AppliesTo(patch.TargetAssetBeforeRedirection ?? assetName))
                 {
-                    // TODO: Provide reason why
-                    error = $"Text Operation is invalid.";
-                    return false;
-                }
+                    if (migrator.TryApplyLoadPatch(patch, assetName, ref asset, out error))
+                        return true;
 
-                var newPatch = new PatchConfig()
-                {
-                    Action = patch.Action,
-                    Update = patch.Update,
-                    // This is post mutations from preValidation if target redirection is required
-                    Target = patch.Target,
-                    // TODO: Work out if this should be cloned when its technically a dead field and not supported since 1.25 (but still functions if format is <1.25)
-                    Enabled = patch.Enabled,
-                    // This migration runs after PatchLoader.UniquelyNamePatches so LogName will be present
-                    LogName = (patch.LogName ?? "") + "TextOperation" + textOperationId++,
-                };
-                // When isn't assignable, so just iterate over the old to make the new
-                foreach (var when in patch.When)
-                {
-                    newPatch.When.Add(when.Key, when.Value);
+                    if (error != null)
+                        return false;
                 }
-                error = textOperationMapper(newPatch, textOperation);
-                if (error != null)
-                {
-                    return false;
-                }
-                replacementPatches.Add(newPatch);
             }
-            if (replacementPatches.Count > 0)
-            {
-                // bool is if it should remove the original patch or not, which in this case is if the patch was exclusively textOperations or not
-                replacementMap[patch] = (patch.Entries.Count == 0 && patch.Fields.Count == 0, replacementPatches);
-            }
-            error = null;
-            return true;
+
+            return base.TryApplyLoadPatch<T>(patch, assetName, ref asset, out error);
         }
 
-        /// <summary>
-        /// This is an abstraction for the simple cases where you are just mapping an old key (like 4) to a new key (like LoveInterest) with an optional transformation
-        /// </summary>
-        /// <param name="newKey">The key you are mapping to</param>
-        /// <param name="transformer">An optional transformer that takes in the raw string value and spits out the <c>JToken</c> it should now be</param>
-        /// <returns>The return value can be directly inserted into the mapping table of <see cref="ConvertDataModel{T}" /></returns>
-        private Func<InnerPatch, string, object?, string, string?> MapSingle(string newKey, Func<string, JToken>? transformer = null)
+        /// <inheritdoc />
+        public override bool TryApplyEditPatch<T>(IPatch patch, IAssetData asset, out string? error)
         {
-            return (patch, _, _, val) =>
+            if (patch is EditDataPatch editPatch)
             {
-                JToken output = val;
-                if (transformer != null)
+                foreach (IEditAssetMigrator migrator in this.Migrators)
                 {
-                    output = transformer(val);
+                    if (migrator.AppliesTo(patch.TargetAssetBeforeRedirection ?? asset.Name))
+                    {
+                        if (migrator.TryApplyEditPatch<T>(editPatch, asset, out error))
+                            return true;
+
+                        if (error != null)
+                            return false;
+                    }
                 }
-                patch[newKey] = output;
+            }
+
+            return base.TryApplyEditPatch<T>(patch, asset, out error);
+        }
+
+
+        /*********
+        ** Private methods
+        *********/
+        /// <summary>Get the unqualified object ID, if it's a valid object ID.</summary>
+        /// <param name="rawItemId">The raw item ID, which may be an item query or non-object ID.</param>
+        /// <returns>Returns the unqualified object ID, or <c>null</c> if it's not a valid object ID.</returns>
+        private string? ParseObjectId(string rawItemId)
+        {
+            // skip null
+            if (rawItemId is null)
                 return null;
-            };
-        }
 
-        /// <summary>
-        /// Converts NPCDisposition index 10 into the data model in use in 1.6
-        /// </summary>
-        /// <param name="patch">The patch that is being operated on.</param>
-        /// <param name="outerKey">The npc name we are operating on. Only used for error messaging and is informational only.</param>
-        /// <param name="defaultLocationInfo">the previous value in NPCDisposition that needs transforming</param>
-        /// <param name="error">The error message if something went wrong.</param>
-        /// <returns>This returns a boolean as to whether the conversion was successful or not. If not, then <paramref name="error"/> will explain why.</returns>
-        private bool ConvertDefaultLocation(InnerPatch patch, string outerKey, string defaultLocationInfo, [NotNullWhen(false)] out string? error)
-        {
-            if (this.Lexer.MightContainTokens(defaultLocationInfo))
+            // skip cached
             {
-                error = $"Cannot convert the npc default location information in {outerKey} when it is contains tokens ({defaultLocationInfo})";
-                return false;
+                if (this.ParseObjectIdCache.TryGetValue(rawItemId, out string? cached))
+                    return cached;
             }
 
-            string[] locationParts = defaultLocationInfo.Split(' ');
-            // Vanilla parsing splits and looks at 0,1,2 indexes, some mods put in a 4th section which is unread
-            if (locationParts.Length < 3)
+            // skip non-object-ID value
+            ItemMetadata metadata = ItemRegistry.GetMetadata(rawItemId);
+            if (metadata?.Exists() is not true || metadata.TypeIdentifier != ItemRegistry.type_object)
             {
-                error = $"Cannot convert the npc default location information in {outerKey} when it isn't 'LocationName X Y' ({defaultLocationInfo})";
-                return false;
-            }
-
-            patch["Home"] = new JArray
-            {
-                new JObject()
-                {
-                    ["Id"] = "Default",
-                    ["Location"] = locationParts[0],
-                    ["Tile"] = new JObject()
-                    {
-                        ["X"] = Convert.ToInt32(locationParts[1]),
-                        ["Y"] = Convert.ToInt32(locationParts[2])
-                    }
-                }
-            };
-            error = null;
-            return true;
-        }
-
-        /// <summary>
-        /// This is an abstraction for all the cases in Data/Locations where they are all space separated strings working in pairs.
-        /// </summary>
-        /// <param name="season">The season this index of the patch is operating on, or null if it doesn't operate on a season.</param>
-        /// <param name="dataset">Which dataset is this index associated with</param>
-        /// <param name="hasChance">Whether the second value in the string pairs should be interpreted as chance or not.</param>
-        /// <returns>An error message if anything went wrong, otherwise null</returns>
-        /// <exception cref="MissingFieldException">If dataset wasn't a valid value.</exception>
-        private Func<InnerPatch, string, DataLocationsState, string, string?> MapDataLocations(string? season, DataLocationType dataset, bool hasChance)
-        {
-            return (patch, _, data, val) =>
-            {
-                var args = this.SplitTokenAware(val, ' ');
-                if (args.Count > 1)
-                {
-                    for (int i = 0; i < args.Count; i += 2)
-                    {
-                        // If this is the last argument and there is an odd number of arguments just ignore it :(
-                        // Fishing and Artifact code would error in this condition normally, but forage code silently handled it
-                        if (i == args.Count - 1 && args.Count % 2 == 1)
-                        {
-                            continue;
-                        }
-                        var newObject = new JObject()
-                        {
-                            ["ItemId"] = "(O)" + args[i],
-                        };
-                        // TODO: Attempt if its worth trying to port legacy fish area id's over
-                        if (hasChance)
-                        {
-                            newObject["Chance"] = args[i + 1];
-                        }
-                        if (season != null)
-                        {
-                            // On the event of multiple seasons, have unique ID's
-                            newObject["ID"] = $"{args[i]}_${season}";
-                            newObject["Season"] = season;
-                        }
-                        (dataset switch
-                        {
-                            DataLocationType.Forage => data.forage,
-                            DataLocationType.Fish => data.fish,
-                            DataLocationType.Artifacts => data.artifacts,
-                            _ => throw new MissingFieldException(dataset.ToString()),
-                        }).Add(newObject);
-                    }
-                }
+                this.ParseObjectIdCache[rawItemId] = null;
                 return null;
-            };
+            }
+
+            // apply
+            this.ParseObjectIdCache[rawItemId] = metadata.LocalItemId;
+            return metadata.LocalItemId;
         }
 
-        // TODO: Look into seeing if this should be a utility method, as its not strictly related to migration
-        /// <summary>
-        /// This utility method splits <paramref name="rawText"/> by <paramref name="separator"/> but will not cut inside a Token.
-        /// </summary>
-        /// <param name="rawText">The string that may contain tokens that needs to be split</param>
-        /// <param name="separator">The character that will be splitting by</param>
-        /// <returns>A list of strings split by <paramref name="separator"/> This will include empty values.</returns>
-        /// <exception cref="Exception">If an unknown LexerTokenType is hit, this will throw</exception>
-        private List<string> SplitTokenAware(string rawText, char separator)
+        /// <summary>The migration logic to apply pre-1.6 edit patches to a new asset or format.</summary>
+        private interface IEditAssetMigrator
         {
+            /// <summary>Get whether this migration applies to a patch.</summary>
+            /// <param name="assetName">The asset name to check. If the asset was redirected, this is the asset name before redirection.</param>
+            bool AppliesTo(IAssetName assetName);
 
-            /**
-             * This code block is being very generous and is assuming a token will not contain spaces that impacts how Data/Locations will be mapped.
-             * Examples that this code block is intended to handle is JsonAssets ObjectId tokens that contained spaces in the item names
-             */
-            var tokens = this.Lexer.ParseBits(rawText, false).ToArray();
-            List<string> args = new();
+            /// <inheritdoc cref="IRuntimeMigration.RedirectTarget" />
+            IAssetName? RedirectTarget(IAssetName assetName, IPatch patch);
 
-            for (int i = 0; i < tokens.Length; i++)
-            {
-                var token = tokens[i];
-                if (token.Type == Lexing.LexTokens.LexTokenType.Literal)
-                {
-                    string tokenStr = token.ToString();
-                    List<string> literalSplit = tokenStr.Split(separator).ToList();
-                    // If the previous token was a token, and we start with a separator, it would be an empty string arg so we append
-                    // Otherwise if it didn't start with a separator, we need to append anyway
-                    if (i > 0)
-                    {
-                        args[args.Count - 1] += literalSplit[0];
-                        literalSplit.RemoveAt(0);
-                    }
-                    args.AddRange(literalSplit);
-                }
-                else if (token.Type == Lexing.LexTokens.LexTokenType.Token)
-                {
-                    // If the previous token ended without a separator, we need to append to the previous
-                    // If the previous token ended with a separator, there would be an empty string arg, append to previous anyway
-                    if (i > 0)
-                    {
-                        args[args.Count - 1] += token.ToString();
-                    }
-                    else
-                    {
-                        args.Add(token.ToString());
-                    }
-                }
-                else
-                {
-                    throw new Exception($"Unknown token type {token.Type} while parsing Data/Locations string");
-                }
-            }
-            return args;
+            /// <inheritdoc cref="IRuntimeMigration.TryApplyLoadPatch{T}" />
+            bool TryApplyLoadPatch<T>(LoadPatch patch, IAssetName assetName, [NotNullWhen(true)] ref T? asset, out string? error);
+
+            /// <inheritdoc cref="IRuntimeMigration.TryApplyEditPatch{T}" />
+            bool TryApplyEditPatch<T>(EditDataPatch patch, IAssetData asset, out string? error);
         }
     }
 }

--- a/ContentPatcher/Framework/Migrations/Migration_2_0.cs
+++ b/ContentPatcher/Framework/Migrations/Migration_2_0.cs
@@ -32,7 +32,7 @@ namespace ContentPatcher.Framework.Migrations
     internal class Migration_2_0 : BaseMigration
     {
         /// <summary>Handles parsing raw strings into tokens.</summary>
-        private readonly Lexer Lexer = this.Lexer.Instance;
+        private readonly Lexer Lexer = Lexer.Instance;
 
         /*********
         ** Public methods
@@ -660,7 +660,7 @@ namespace ContentPatcher.Framework.Migrations
         /// </summary>
         /// <param name="newKey">The key you are mapping to</param>
         /// <param name="transformer">An optional transformer that takes in the raw string value and spits out the <c>JToken</c> it should now be</param>
-        /// <returns>The return value can be directly inserted into the mapping table of <see cref="ConvertDataModel" /></returns>
+        /// <returns>The return value can be directly inserted into the mapping table of <see cref="ConvertDataModel{T}" /></returns>
         private Func<InnerPatch, string, object?, string, string?> MapSingle(string newKey, Func<string, JToken>? transformer = null)
         {
             return (patch, _, _, val) =>

--- a/ContentPatcher/Framework/Migrations/Migration_2_0.cs
+++ b/ContentPatcher/Framework/Migrations/Migration_2_0.cs
@@ -63,7 +63,7 @@ namespace ContentPatcher.Framework.Migrations
                 }
             }
 
-            Dictionary<PatchConfig, (bool, List<PatchConfig>)> replacementMap = new();
+            Dictionary<PatchConfig, (bool Replace, List<PatchConfig> Patches)> replacementMap = new();
 
             foreach (PatchConfig? patch in patches)
             {
@@ -484,12 +484,12 @@ namespace ContentPatcher.Framework.Migrations
                 foreach (var (patch, replacementEntry) in replacementMap)
                 {
                     int index = patchList.IndexOf(patch);
-                    if (replacementEntry.Item1)
+                    if (replacementEntry.Replace)
                     {
                         patchList.RemoveAt(index);
                     }
                     // if we are not replacing, then the index needs to be incremented by 1, as EditDataPatch evaluates TextOperations after Entries/Records and Fields
-                    patchList.InsertRange(index + (replacementEntry.Item1 ? 0 : 1), replacementEntry.Item2);
+                    patchList.InsertRange(index + (replacementEntry.Replace ? 0 : 1), replacementEntry.Patches);
                 }
                 patches = patchList.ToArray();
             }
@@ -500,7 +500,7 @@ namespace ContentPatcher.Framework.Migrations
         /// <summary>This method converts previously <c>Dictionary&lt;string, string&gt;</c> data model patches into <c>Dictionary&lt;string, T&gt;</c></summary>
         /// <remarks>
         /// This method is intended to be operated on EditData patches where the target is 
-        /// where values were / seperated values.
+        /// where values were / separated values.
         /// 
         /// This method will convert the Fields and Entries of the patch into a form that can be run on  instead
         /// mapping the keys from the old integer indexes into new string values represented in the new data model,
@@ -604,7 +604,7 @@ namespace ContentPatcher.Framework.Migrations
         /// <param name="textOperationFilter">Whether this text operation is valid for the transformer.</param>
         /// <param name="textOperationMapper">Transforms the empty patch with the text operation into a patch with content.</param>
         /// <param name="error">The error message if anything went wrong</param>
-        /// <returns>This returns whether the conversion was successsful. If it wasn't then <paramref name="error"/> will explain why.</returns>
+        /// <returns>This returns whether the conversion was successful. If it wasn't then <paramref name="error"/> will explain why.</returns>
         private bool ConvertTextOperations(
             PatchConfig patch,
             Dictionary<PatchConfig, (bool, List<PatchConfig>)> replacementMap,
@@ -717,7 +717,7 @@ namespace ContentPatcher.Framework.Migrations
         }
 
         /// <summary>
-        /// This is an abstraction for all the cases in Data/Locations where they are all space seperated strings working in pairs.
+        /// This is an abstraction for all the cases in Data/Locations where they are all space separated strings working in pairs.
         /// </summary>
         /// <param name="season">The season this index of the patch is operating on, or null if it doesn't operate on a season.</param>
         /// <param name="dataset">Which dataset is this index associated with</param>

--- a/ContentPatcher/Framework/Migrations/Migration_2_0.cs
+++ b/ContentPatcher/Framework/Migrations/Migration_2_0.cs
@@ -707,8 +707,8 @@ namespace ContentPatcher.Framework.Migrations
                     ["Location"] = locationParts[0],
                     ["Tile"] = new JObject()
                     {
-                        ["X"] = Convert.ToInt32(locationParts[1]) * 64,
-                        ["Y"] = Convert.ToInt32(locationParts[2]) * 64
+                        ["X"] = Convert.ToInt32(locationParts[1]),
+                        ["Y"] = Convert.ToInt32(locationParts[2])
                     }
                 }
             };

--- a/ContentPatcher/Framework/Migrations/Migration_2_0.cs
+++ b/ContentPatcher/Framework/Migrations/Migration_2_0.cs
@@ -750,6 +750,8 @@ namespace ContentPatcher.Framework.Migrations
                         }
                         if (season != null)
                         {
+                            // On the event of multiple seasons, have unique ID's
+                            newObject["ID"] = $"{args[i]}_${season}";
                             newObject["Season"] = season;
                         }
                         (dataset switch

--- a/ContentPatcher/Framework/Migrations/Migration_2_0.cs
+++ b/ContentPatcher/Framework/Migrations/Migration_2_0.cs
@@ -1,15 +1,34 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using ContentPatcher.Framework.Conditions;
 using ContentPatcher.Framework.ConfigModels;
+using ContentPatcher.Framework.Lexing;
+using Newtonsoft.Json.Linq;
+using Pathoschild.Stardew.Common;
 using Pathoschild.Stardew.Common.Utilities;
 using StardewModdingAPI;
+using StardewModdingAPI.Utilities;
+using InnerPatch = Pathoschild.Stardew.Common.Utilities.InvariantDictionary<Newtonsoft.Json.Linq.JToken?>;
 
 namespace ContentPatcher.Framework.Migrations
 {
+    internal record DataLocationsState(JArray forage, JArray fish, JArray artifacts);
+    internal enum DataLocationType
+    {
+        Fish,
+        Forage,
+        Artifacts
+    }
+
     /// <summary>Migrates patches to format version 2.0.</summary>
     [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Named for clarity.")]
     internal class Migration_2_0 : BaseMigration
     {
+        /// <summary>Handles parsing raw strings into tokens.</summary>
+        private readonly Lexer Lexer = this.Lexer.Instance;
+
         /*********
         ** Public methods
         *********/
@@ -39,7 +58,565 @@ namespace ContentPatcher.Framework.Migrations
                 }
             }
 
+            Dictionary<PatchConfig, (bool, List<PatchConfig>)> replacementMap = new();
+
+            foreach (PatchConfig? patch in patches)
+            {
+                if (this.HasAction(patch, PatchType.EditData))
+                {
+                    if (PathUtilities.NormalizeAssetName(patch.Target) == "Data/NPCDispositions")
+                    {
+                        patch.Target = "Data/Characters";
+                        if (patch.TargetField.Count > 0)
+                        {
+                            error = "Unable to convert NPCDispositions when TargetField is used";
+                            return false;
+                        }
+                        // Data/Dispositions -> Data/Characters doesn't need state management, passing in object? null instead
+                        if (!this.ConvertDataModel<object?>(null, patch,
+                            mapping: new()
+                            {
+                                ["0"] = this.MapSingle("Age", val => val.ToLowerInvariant() switch
+                                {
+                                    "child" => "Child",
+                                    "teen" => "Teen",
+                                    _ => "Adult"
+                                }),
+                                ["1"] = this.MapSingle("Manner", val => val.ToLowerInvariant() switch
+                                {
+                                    "rude" => "Rude",
+                                    "polite" => "Polite",
+                                    _ => "Neutral"
+                                }),
+                                ["2"] = this.MapSingle("SocialAnxiety", val => val.ToLowerInvariant() switch
+                                {
+                                    "shy" => "Shy",
+                                    "outgoing" => "Outgoing",
+                                    _ => "Neutral"
+                                }),
+                                ["3"] = this.MapSingle("Optimism", val => val.ToLowerInvariant() switch
+                                {
+                                    "negative" => "Negative",
+                                    "positive" => "Positive",
+                                    _ => "Neutral"
+                                }),
+                                ["4"] = this.MapSingle("Gender", val => val.ToLowerInvariant() switch
+                                {
+                                    "male" => "Male",
+                                    "female" => "Female",
+                                    _ => "Undefined"
+                                }),
+                                // in pre 1.6 it was "datable", "not-datable" or "secret". It is now a boolean.
+                                ["5"] = this.MapSingle("CanBeRomanced", val => val.ToLowerInvariant() == "datable"),
+                                ["6"] = this.MapSingle("LoveInterest"),
+                                ["7"] = this.MapSingle("HomeRegion"),
+                                ["8"] = (patch, _, _, val) =>
+                                {
+                                    // from 1.5.6's NPCDisposition parsing, with added checks for conventional "null"
+                                    if (val.Length > 0 && val != "null")
+                                    {
+                                        string[] birthInfo = val.Split(' ');
+                                        patch["BirthSeason"] = birthInfo[0];
+                                        patch["BirthDay"] = Convert.ToInt32(birthInfo[1]);
+                                    }
+                                    return null;
+                                },
+                                ["9"] = this.MapSingle("FriendsAndFamily", val =>
+                                {
+                                    var friendsAndFamily = new JObject();
+                                    if (val.Length > 0)
+                                    {
+                                        string[] relationComponents = val.Split(" ");
+                                        if (relationComponents.Length >= 2)
+                                        {
+                                            for (int i = 0; i < Math.Floor((double)relationComponents.Length / 2); i++)
+                                            {
+                                                // TODO: Replace common occurances with the vanilla Translatable strings instead
+                                                friendsAndFamily[relationComponents[2 * i]] = relationComponents[2 * i + 1].Replace("'", "");
+                                            }
+                                        }
+                                    }
+                                    return friendsAndFamily;
+                                }),
+                                ["10"] = (patch, outerKey, _, val) =>
+                                {
+                                    this.ConvertDefaultLocation(patch, outerKey, val, out string? innerError);
+                                    return innerError;
+                                },
+                                ["11"] = this.MapSingle("DisplayName")
+                            },
+                            out error)
+                        )
+                        {
+                            return false;
+                        }
+                    }
+                    else if (PathUtilities.NormalizeAssetName(patch.Target) == "Data/Locations")
+                    {
+                        if (!this.ConvertDataModel(new DataLocationsState(new(), new(), new()), patch,
+                            mapping: new()
+                            {
+                                ["0"] = this.MapDataLocations("spring", DataLocationType.Forage, true),
+                                ["1"] = this.MapDataLocations("summer", DataLocationType.Forage, true),
+                                ["2"] = this.MapDataLocations("fall", DataLocationType.Forage, true),
+                                ["3"] = this.MapDataLocations("winter", DataLocationType.Forage, true),
+                                ["4"] = this.MapDataLocations("spring", DataLocationType.Fish, false),
+                                ["5"] = this.MapDataLocations("summer", DataLocationType.Fish, false),
+                                ["6"] = this.MapDataLocations("fall", DataLocationType.Fish, false),
+                                ["7"] = this.MapDataLocations("winter", DataLocationType.Fish, false),
+                                ["8"] = this.MapDataLocations(null, DataLocationType.Artifacts, true),
+                            },
+                            postMapping: (patch, data) =>
+                            {
+                                if (data == null)
+                                {
+                                    throw new NullReferenceException("Missing DataLocationState in MapDataLocations");
+                                }
+
+                                if (data.forage.HasValues)
+                                {
+                                    patch["Forage"] = new JArray(data.forage);
+                                }
+                                if (data.fish.HasValues)
+                                {
+                                    patch["Fish"] = new JArray(data.fish);
+                                }
+                                if (data.artifacts.HasValues)
+                                {
+                                    patch["ArtifactSpots"] = new JArray(data.artifacts);
+                                }
+                                // the data state is used for the entire EditData patch, which may contain data for multiple locations. This should be per location
+                                data.forage.Clear();
+                                data.fish.Clear();
+                                data.artifacts.Clear();
+                                return null;
+                            },
+                            error: out error)
+                        )
+                        {
+                            return false;
+                        }
+                        if (!this.ConvertTextOperations(patch,
+                            replacementMap,
+                            textOperationFilter: operation =>
+                            {
+                                return
+                                (
+                                    operation.Delimiter == " " &&
+                                    operation.Operation == "Append" &&
+                                    operation.Target.Length == 3 &&
+                                    operation.Target[0] == "Fields" &&
+                                    operation.Target[1] != null &&
+                                    operation.Value != null &&
+                                    int.TryParse(operation.Target[2], out int field3) &&
+                                    field3 >= 0 && field3 <= 8
+                                );
+                            },
+                            textOperationMapper: (patch, textOperation) =>
+                            {
+                                string outerKey = textOperation.Target[1]!;
+                                string index = textOperation.Target[2]!;
+                                DataLocationsState state = new(new(), new(), new());
+                                string value = textOperation.Value!;
+                                string? error = index switch
+                                {
+                                    // This.MapDataLocations does not look at the patch, so passing null in for simplicity
+                                    "0" => this.MapDataLocations("spring", DataLocationType.Forage, true)(null!, outerKey, state, value),
+                                    "1" => this.MapDataLocations("summer", DataLocationType.Forage, true)(null!, outerKey, state, value),
+                                    "2" => this.MapDataLocations("fall", DataLocationType.Forage, true)(null!, outerKey, state, value),
+                                    "3" => this.MapDataLocations("winter", DataLocationType.Forage, true)(null!, outerKey, state, value),
+                                    "4" => this.MapDataLocations("spring", DataLocationType.Fish, false)(null!, outerKey, state, value),
+                                    "5" => this.MapDataLocations("summer", DataLocationType.Fish, false)(null!, outerKey, state, value),
+                                    "6" => this.MapDataLocations("fall", DataLocationType.Fish, false)(null!, outerKey, state, value),
+                                    "7" => this.MapDataLocations("winter", DataLocationType.Forage, false)(null!, outerKey, state, value),
+                                    "8" => this.MapDataLocations(null, DataLocationType.Artifacts, true)(null!, outerKey, state, value),
+                                    _ => "Unknown index"
+                                };
+                                if (error != null)
+                                    return error;
+
+                                patch.TargetField.Add(textOperation.Target[1]!);
+                                JArray collection;
+                                if (state.fish.HasValues)
+                                {
+                                    patch.TargetField.Add("Fish");
+                                    collection = state.fish;
+                                }
+                                else if (state.forage.HasValues)
+                                {
+                                    patch.TargetField.Add("Forage");
+                                    collection = state.forage;
+                                }
+                                else if (state.artifacts.HasValues)
+                                {
+                                    patch.TargetField.Add("ArtifactSpots");
+                                    collection = state.artifacts;
+                                }
+                                else
+                                {
+                                    return "TextOperation patch did not contain anything";
+                                }
+
+                                int id = 0;
+                                foreach (var item in collection)
+                                {
+                                    string namedId = patch.LogName + id++;
+                                    item["Id"] = namedId;
+                                    patch.Entries[namedId] = item;
+                                }
+
+                                // no error
+                                return null;
+                            },
+                            out error
+                        ))
+                        {
+                            return false;
+                        }
+                    }
+                }
+            }
+            if (replacementMap.Count > 0)
+            {
+                // TODO: work out if these in place expansions can be done easier than just making it a list and back to an array
+                var patchList = patches.ToList();
+                foreach (var (patch, replacementEntry) in replacementMap)
+                {
+                    int index = patchList.IndexOf(patch);
+                    if (replacementEntry.Item1)
+                    {
+                        patchList.RemoveAt(index);
+                    }
+                    // if we are not replacing, then the index needs to be incremented by 1, as EditDataPatch evaluates TextOperations after Entries/Records and Fields
+                    patchList.InsertRange(index + (replacementEntry.Item1 ? 0 : 1), replacementEntry.Item2);
+                }
+                patches = patchList.ToArray();
+            }
+
             return true;
+        }
+
+        /// <summary>This method converts previously <c>Dictionary&lt;string, string&gt;</c> data model patches into <c>Dictionary&lt;string, T&gt;</c></summary>
+        /// <remarks>
+        /// This method is intended to be operated on EditData patches where the target is 
+        /// where values were / seperated values.
+        /// 
+        /// This method will convert the Fields and Entries of the patch into a form that can be run on  instead
+        /// mapping the keys from the old integer indexes into new string values represented in the new data model,
+        /// while doing transformation of values in the process.
+        /// </remarks>
+        /// <typeparam name="T">The Datatype for state management in <paramref name="data"/></typeparam>
+        /// <param name="data">State management which will be passed into every call in <paramref name="mapping"/> and <paramref name="postMapping"/></param>
+        /// <param name="patch">The patch that is being transformed</param>
+        /// <param name="mapping">
+        /// A dictionary of old keys and values are transformer methods to be operated on the inner patch contents.
+        /// The methods arguments are as follows:
+        /// <list type="number">
+        ///     <item>the inner patch contents the original dictionary key being referenced</item>
+        ///     <item>the key from the dictionary being accessed (i.e npc name in NPCDispositions)</item>
+        ///     <item>the state object from <paramref name="data"/></item>
+        ///     <item>The raw string value that is being mapped and potentially transformed on</item>
+        /// </list>
+        /// and would return an optional error message if things went wrong
+        /// </param>
+        /// <param name="error">An error message if things went wrong.</param>
+        /// <param name="postMapping">A method that is run after the all the Fields of a given entry key, or after each value in Entries to do any final transformations in bulk</param>
+        /// <returns>whether it was successful, if unsuccessful then <paramref name="error"/> will explain why</returns>
+        private bool ConvertDataModel<T>(
+            T data,
+            PatchConfig patch,
+            Dictionary<string, Func<InnerPatch, string, T, string, string?>> mapping,
+            [NotNullWhen(false)] out string? error,
+            Func<InnerPatch, T, string?>? postMapping = null
+        )
+        {
+            bool InnerConversion(InnerPatch patch, string outerKey, [NotNullWhen(false)] out string? innerError)
+            {
+                bool hasRun = false;
+                foreach (string key in patch.Keys.ToArray())
+                {
+                    var value = patch[key];
+                    if (value.Type != JTokenType.String) continue;
+                    // This is invoking JToken's explicit string operator and tests if it was a string token, if so spit out the value.
+                    string? strValue = (string?)value;
+                    if (strValue == null) continue;
+                    if (mapping.TryGetValue(key, out var mapper))
+                    {
+                        innerError = mapper(patch, outerKey, data, strValue);
+                        if (innerError != null) return false;
+                        patch.Remove(key);
+                        hasRun = true;
+                    }
+                }
+                if (hasRun && postMapping != null)
+                {
+                    string? postError = postMapping(patch, data);
+                    if (postError != null)
+                    {
+                        innerError = postError;
+                        return false;
+                    }
+                }
+                innerError = null;
+                return true;
+            }
+
+            if (patch.Fields.Count > 0)
+            {
+                foreach (var (key, _) in patch.Fields)
+                {
+                    var field = patch.Fields[key];
+                    if (field == null) continue;
+                    if (!InnerConversion(field, key, out error))
+                    {
+                        return false;
+                    }
+                }
+            }
+            foreach (var (key, value) in patch.Entries)
+            {
+                if (value?.Type == JTokenType.String)
+                {
+                    string? strValue = (string?)value;
+                    if (strValue == null) continue;
+                    var components = this.SplitTokenAware(strValue, '/');
+                    // Converting the patch to look closer to a fully populated Fields patch so can reuse code
+                    var newPatch = new InnerPatch(components.Select((v, i) => new { Key = i, Value = v }).ToDictionary(item => item.Key.ToString(), item => (JToken?)new JValue(item.Value)));
+                    var newValue = new JObject();
+                    if (!InnerConversion(newPatch, key, out error))
+                    {
+                        return false;
+                    }
+                    patch.Entries[key] = JObject.FromObject(newPatch);
+                }
+            }
+
+            error = null;
+            return true;
+        }
+
+        /// <summary>
+        /// Converts TextOperations in complex patches into new patches using list insertion instead
+        /// </summary>
+        /// <param name="patch">The patch that may contain TextOperation entries</param>
+        /// <param name="replacementMap">A working collection of patches and the mapping back to the patch that causes them for upstream insertion in <see cref="TryMigrate(ref PatchConfig[], out string?)"/></param>
+        /// <param name="textOperationFilter">Whether this text operation is valid for the transformer.</param>
+        /// <param name="textOperationMapper">Transforms the empty patch with the text operation into a patch with content.</param>
+        /// <param name="error">The error message if anything went wrong</param>
+        /// <returns>This returns whether the conversion was successsful. If it wasn't then <paramref name="error"/> will explain why.</returns>
+        private bool ConvertTextOperations(
+            PatchConfig patch,
+            Dictionary<PatchConfig, (bool, List<PatchConfig>)> replacementMap,
+            Func<TextOperationConfig, bool> textOperationFilter,
+            Func<PatchConfig, TextOperationConfig, string?> textOperationMapper,
+            [NotNullWhen(false)] out string? error)
+        {
+            int textOperationId = 0;
+            var replacementPatches = new List<PatchConfig>();
+            foreach (var textOperation in patch.TextOperations.WhereNotNull())
+            {
+                if (!textOperationFilter(textOperation))
+                {
+                    // TODO: Provide reason why
+                    error = $"Text Operation is invalid.";
+                    return false;
+                }
+
+                var newPatch = new PatchConfig()
+                {
+                    Action = patch.Action,
+                    Update = patch.Update,
+                    // This is post mutations from preValidation if target redirection is required
+                    Target = patch.Target,
+                    // TODO: Work out if this should be cloned when its technically a dead field and not supported since 1.25 (but still functions if format is <1.25)
+                    Enabled = patch.Enabled,
+                    // This migration runs after PatchLoader.UniquelyNamePatches so LogName will be present
+                    LogName = (patch.LogName ?? "") + "TextOperation" + textOperationId++,
+                };
+                // When isn't assignable, so just iterate over the old to make the new
+                foreach (var when in patch.When)
+                {
+                    newPatch.When.Add(when.Key, when.Value);
+                }
+                error = textOperationMapper(newPatch, textOperation);
+                if (error != null)
+                {
+                    return false;
+                }
+                replacementPatches.Add(newPatch);
+            }
+            if (replacementPatches.Count > 0)
+            {
+                // bool is if it should remove the original patch or not, which in this case is if the patch was exclusively textOperations or not
+                replacementMap[patch] = (patch.Entries.Count == 0 && patch.Fields.Count == 0, replacementPatches);
+            }
+            error = null;
+            return true;
+        }
+
+        /// <summary>
+        /// This is an abstraction for the simple cases where you are just mapping an old key (like 4) to a new key (like LoveInterest) with an optional transformation
+        /// </summary>
+        /// <param name="newKey">The key you are mapping to</param>
+        /// <param name="transformer">An optional transformer that takes in the raw string value and spits out the <c>JToken</c> it should now be</param>
+        /// <returns>The return value can be directly inserted into the mapping table of <see cref="ConvertDataModel" /></returns>
+        private Func<InnerPatch, string, object?, string, string?> MapSingle(string newKey, Func<string, JToken>? transformer = null)
+        {
+            return (patch, _, _, val) =>
+            {
+                JToken output = val;
+                if (transformer != null)
+                {
+                    output = transformer(val);
+                }
+                patch[newKey] = output;
+                return null;
+            };
+        }
+
+        /// <summary>
+        /// Converts NPCDisposition index 10 into the data model in use in 1.6
+        /// </summary>
+        /// <param name="patch">The patch that is being operated on.</param>
+        /// <param name="outerKey">The npc name we are operating on. Only used for error messaging and is informational only.</param>
+        /// <param name="defaultLocationInfo">the previous value in NPCDisposition that needs transforming</param>
+        /// <param name="error">The error message if something went wrong.</param>
+        /// <returns>This returns a boolean as to whether the conversion was successful or not. If not, then <paramref name="error"/> will explain why.</returns>
+        private bool ConvertDefaultLocation(InnerPatch patch, string outerKey, string defaultLocationInfo, [NotNullWhen(false)] out string? error)
+        {
+            if (this.Lexer.MightContainTokens(defaultLocationInfo))
+            {
+                error = $"Cannot convert the npc default location information in {outerKey} when it is contains tokens ({defaultLocationInfo})";
+                return false;
+            }
+
+            string[] locationParts = defaultLocationInfo.Split(' ');
+            // Vanilla parsing splits and looks at 0,1,2 indexes, some mods put in a 4th section which is unread
+            if (locationParts.Length < 3)
+            {
+                error = $"Cannot convert the npc default location information in {outerKey} when it isn't 'LocationName X Y' ({defaultLocationInfo})";
+                return false;
+            }
+
+            patch["Home"] = new JArray
+            {
+                new JObject()
+                {
+                    ["Id"] = "Default",
+                    ["Location"] = locationParts[0],
+                    ["Tile"] = new JObject()
+                    {
+                        ["X"] = Convert.ToInt32(locationParts[1]) * 64,
+                        ["Y"] = Convert.ToInt32(locationParts[2]) * 64
+                    }
+                }
+            };
+            error = null;
+            return true;
+        }
+
+        /// <summary>
+        /// This is an abstraction for all the cases in Data/Locations where they are all space seperated strings working in pairs.
+        /// </summary>
+        /// <param name="season">The season this index of the patch is operating on, or null if it doesn't operate on a season.</param>
+        /// <param name="dataset">Which dataset is this index associated with</param>
+        /// <param name="hasChance">Whether the second value in the string pairs should be interpreted as chance or not.</param>
+        /// <returns>An error message if anything went wrong, otherwise null</returns>
+        /// <exception cref="MissingFieldException">If dataset wasn't a valid value.</exception>
+        private Func<InnerPatch, string, DataLocationsState, string, string?> MapDataLocations(string? season, DataLocationType dataset, bool hasChance)
+        {
+            return (patch, _, data, val) =>
+            {
+                var args = this.SplitTokenAware(val, ' ');
+                if (args.Count > 1)
+                {
+                    for (int i = 0; i < args.Count; i += 2)
+                    {
+                        // If this is the last argument and there is an odd number of arguments just ignore it :(
+                        // Fishing and Artifact code would error in this condition normally, but forage code silently handled it
+                        if (i == args.Count - 1 && args.Count % 2 == 1)
+                        {
+                            continue;
+                        }
+                        var newObject = new JObject()
+                        {
+                            ["ItemId"] = "(O)" + args[i],
+                        };
+                        // TODO: Attempt if its worth trying to port legacy fish area id's over
+                        if (hasChance)
+                        {
+                            newObject["Chance"] = args[i + 1];
+                        }
+                        if (season != null)
+                        {
+                            newObject["Season"] = season;
+                        }
+                        (dataset switch
+                        {
+                            DataLocationType.Forage => data.forage,
+                            DataLocationType.Fish => data.fish,
+                            DataLocationType.Artifacts => data.artifacts,
+                            _ => throw new MissingFieldException(dataset.ToString()),
+                        }).Add(newObject);
+                    }
+                }
+                return null;
+            };
+        }
+
+        // TODO: Look into seeing if this should be a utility method, as its not strictly related to migration
+        /// <summary>
+        /// This utility method splits <paramref name="rawText"/> by <paramref name="separator"/> but will not cut inside a Token.
+        /// </summary>
+        /// <param name="rawText">The string that may contain tokens that needs to be split</param>
+        /// <param name="separator">The character that will be splitting by</param>
+        /// <returns>A list of strings split by <paramref name="separator"/> This will include empty values.</returns>
+        /// <exception cref="Exception">If an unknown LexerTokenType is hit, this will throw</exception>
+        private List<string> SplitTokenAware(string rawText, char separator)
+        {
+
+            /**
+             * This code block is being very generous and is assuming a token will not contain spaces that impacts how Data/Locations will be mapped.
+             * Examples that this code block is intended to handle is JsonAssets ObjectId tokens that contained spaces in the item names
+             */
+            var tokens = this.Lexer.ParseBits(rawText, false).ToArray();
+            List<string> args = new();
+
+            for (int i = 0; i < tokens.Length; i++)
+            {
+                var token = tokens[i];
+                if (token.Type == Lexing.LexTokens.LexTokenType.Literal)
+                {
+                    string tokenStr = token.ToString();
+                    List<string> literalSplit = tokenStr.Split(separator).ToList();
+                    // If the previous token was a token, and we start with a separator, it would be an empty string arg so we append
+                    // Otherwise if it didn't start with a separator, we need to append anyway
+                    if (i > 0)
+                    {
+                        args[args.Count - 1] += literalSplit[0];
+                        literalSplit.RemoveAt(0);
+                    }
+                    args.AddRange(literalSplit);
+                }
+                else if (token.Type == Lexing.LexTokens.LexTokenType.Token)
+                {
+                    // If the previous token ended without a separator, we need to append to the previous
+                    // If the previous token ended with a separator, there would be an empty string arg, append to previous anyway
+                    if (i > 0)
+                    {
+                        args[args.Count - 1] += token.ToString();
+                    }
+                    else
+                    {
+                        args.Add(token.ToString());
+                    }
+                }
+                else
+                {
+                    throw new Exception($"Unknown token type {token.Type} while parsing Data/Locations string");
+                }
+            }
+            return args;
         }
     }
 }

--- a/ContentPatcher/Framework/PatchLoader.cs
+++ b/ContentPatcher/Framework/PatchLoader.cs
@@ -486,6 +486,7 @@ namespace ContentPatcher.Framework
                                 conditions: conditions,
                                 localAsset: fromAsset,
                                 contentPack: pack,
+                                migrator: rawContentPack.Migrator,
                                 parentPatch: parentPatch,
                                 parseAssetName: this.ParseAssetName
                             );
@@ -548,6 +549,7 @@ namespace ContentPatcher.Framework
                                 targetField: targetField,
                                 updateRate: updateRate,
                                 contentPack: pack,
+                                migrator: rawContentPack.Migrator,
                                 parentPatch: parentPatch,
                                 monitor: this.Monitor,
                                 parseAssetName: this.ParseAssetName,
@@ -595,6 +597,7 @@ namespace ContentPatcher.Framework
                                 patchMode: patchMode,
                                 updateRate: updateRate,
                                 contentPack: pack,
+                                migrator: rawContentPack.Migrator,
                                 parentPatch: parentPatch,
                                 monitor: this.Monitor,
                                 parseAssetName: this.ParseAssetName
@@ -733,6 +736,7 @@ namespace ContentPatcher.Framework
                                 textOperations: textOperations,
                                 updateRate: updateRate,
                                 contentPack: pack,
+                                migrator: rawContentPack.Migrator,
                                 parentPatch: parentPatch,
                                 monitor: this.Monitor,
                                 parseAssetName: this.ParseAssetName

--- a/ContentPatcher/Framework/Patches/EditDataPatch.cs
+++ b/ContentPatcher/Framework/Patches/EditDataPatch.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using ContentPatcher.Framework.Conditions;
 using ContentPatcher.Framework.ConfigModels;
 using ContentPatcher.Framework.Constants;
+using ContentPatcher.Framework.Migrations;
 using ContentPatcher.Framework.Patches.EditData;
 using ContentPatcher.Framework.TextOperations;
 using ContentPatcher.Framework.Tokens;
@@ -89,11 +90,12 @@ namespace ContentPatcher.Framework.Patches
         /// <param name="targetField">The field within the data asset to which edits should be applied, or empty to apply to the root asset.</param>
         /// <param name="updateRate">When the patch should be updated.</param>
         /// <param name="contentPack">The content pack which requested the patch.</param>
+        /// <param name="migrator">The aggregate migration which applies for this patch.</param>
         /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
         /// <param name="monitor">Encapsulates monitoring and logging.</param>
         /// <param name="parseAssetName">Parse an asset name.</param>
         /// <param name="tryParseFields">Parse the data change fields for an <see cref="PatchType.EditData"/> patch.</param>
-        public EditDataPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString? fromFile, IEnumerable<EditDataPatchRecord>? records, IEnumerable<EditDataPatchField>? fields, IEnumerable<EditDataPatchMoveRecord>? moveRecords, IEnumerable<ITextOperation>? textOperations, IEnumerable<IManagedTokenString>? targetField, UpdateRate updateRate, IContentPack contentPack, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName, TryParseFieldsDelegate tryParseFields)
+        public EditDataPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString? fromFile, IEnumerable<EditDataPatchRecord>? records, IEnumerable<EditDataPatchField>? fields, IEnumerable<EditDataPatchMoveRecord>? moveRecords, IEnumerable<ITextOperation>? textOperations, IEnumerable<IManagedTokenString>? targetField, UpdateRate updateRate, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName, TryParseFieldsDelegate tryParseFields)
             : base(
                 indexPath: indexPath,
                 path: path,
@@ -103,6 +105,7 @@ namespace ContentPatcher.Framework.Patches
                 updateRate: updateRate,
                 conditions: conditions,
                 contentPack: contentPack,
+                migrator: migrator,
                 parentPatch: parentPatch,
                 parseAssetName: parseAssetName,
                 fromAsset: fromFile

--- a/ContentPatcher/Framework/Patches/EditImagePatch.cs
+++ b/ContentPatcher/Framework/Patches/EditImagePatch.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using ContentPatcher.Framework.Conditions;
 using ContentPatcher.Framework.ConfigModels;
+using ContentPatcher.Framework.Migrations;
 using ContentPatcher.Framework.Tokens;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -56,10 +57,11 @@ namespace ContentPatcher.Framework.Patches
         /// <param name="patchMode">Indicates how the image should be patched.</param>
         /// <param name="updateRate">When the patch should be updated.</param>
         /// <param name="contentPack">The content pack which requested the patch.</param>
+        /// <param name="migrator">The aggregate migration which applies for this patch.</param>
         /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
         /// <param name="monitor">Encapsulates monitoring and logging.</param>
         /// <param name="parseAssetName">Parse an asset name.</param>
-        public EditImagePatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString fromAsset, TokenRectangle? fromArea, TokenRectangle? toArea, PatchImageMode patchMode, UpdateRate updateRate, IContentPack contentPack, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName)
+        public EditImagePatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString fromAsset, TokenRectangle? fromArea, TokenRectangle? toArea, PatchImageMode patchMode, UpdateRate updateRate, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName)
             : base(
                 indexPath: indexPath,
                 path: path,
@@ -71,6 +73,7 @@ namespace ContentPatcher.Framework.Patches
                 parseAssetName: parseAssetName,
                 fromAsset: fromAsset,
                 contentPack: contentPack,
+                migrator: migrator,
                 parentPatch: parentPatch
             )
         {

--- a/ContentPatcher/Framework/Patches/EditMapPatch.cs
+++ b/ContentPatcher/Framework/Patches/EditMapPatch.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using ContentPatcher.Framework.Conditions;
 using ContentPatcher.Framework.ConfigModels;
 using ContentPatcher.Framework.Constants;
+using ContentPatcher.Framework.Migrations;
 using ContentPatcher.Framework.TextOperations;
 using ContentPatcher.Framework.Tokens;
 using Microsoft.Xna.Framework;
@@ -76,10 +77,11 @@ namespace ContentPatcher.Framework.Patches
         /// <param name="textOperations">The text operations to apply to existing values.</param>
         /// <param name="updateRate">When the patch should be updated.</param>
         /// <param name="contentPack">The content pack which requested the patch.</param>
+        /// <param name="migrator">The aggregate migration which applies for this patch.</param>
         /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
         /// <param name="monitor">Encapsulates monitoring and logging.</param>
         /// <param name="parseAssetName">Parse an asset name.</param>
-        public EditMapPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString? fromAsset, TokenRectangle? fromArea, TokenRectangle? toArea, PatchMapMode patchMode, IEnumerable<EditMapPatchProperty>? mapProperties, IEnumerable<EditMapPatchTile>? mapTiles, IEnumerable<IManagedTokenString>? addWarps, IEnumerable<ITextOperation>? textOperations, UpdateRate updateRate, IContentPack contentPack, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName)
+        public EditMapPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString? fromAsset, TokenRectangle? fromArea, TokenRectangle? toArea, PatchMapMode patchMode, IEnumerable<EditMapPatchProperty>? mapProperties, IEnumerable<EditMapPatchTile>? mapTiles, IEnumerable<IManagedTokenString>? addWarps, IEnumerable<ITextOperation>? textOperations, UpdateRate updateRate, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName)
             : base(
                 indexPath: indexPath,
                 path: path,
@@ -90,6 +92,7 @@ namespace ContentPatcher.Framework.Patches
                 conditions: conditions,
                 fromAsset: fromAsset,
                 contentPack: contentPack,
+                migrator: migrator,
                 parentPatch: parentPatch,
                 parseAssetName: parseAssetName
             )

--- a/ContentPatcher/Framework/Patches/IPatch.cs
+++ b/ContentPatcher/Framework/Patches/IPatch.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using ContentPatcher.Framework.Conditions;
+using ContentPatcher.Framework.Migrations;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
@@ -28,6 +29,9 @@ namespace ContentPatcher.Framework.Patches
         /// <summary>The content pack which requested the patch.</summary>
         IContentPack ContentPack { get; }
 
+        /// <summary>The aggregate migration which applies for this patch.</summary>
+        IRuntimeMigration Migrator { get; }
+
         /// <summary>The normalized asset key from which to load the local asset (if applicable).</summary>
         string? FromAsset { get; }
 
@@ -36,6 +40,9 @@ namespace ContentPatcher.Framework.Patches
 
         /// <summary>The normalized asset name to intercept.</summary>
         IAssetName? TargetAsset { get; }
+
+        /// <summary>If the <see cref="TargetAsset"/> was redirected by a runtime migration, the asset name before it was redirected.</summary>
+        public IAssetName? TargetAssetBeforeRedirection { get; }
 
         /// <summary>The raw asset name to intercept, including tokens.</summary>
         ITokenString? RawTargetAsset { get; }

--- a/ContentPatcher/Framework/Patches/IncludePatch.cs
+++ b/ContentPatcher/Framework/Patches/IncludePatch.cs
@@ -65,6 +65,7 @@ namespace ContentPatcher.Framework.Patches
                 fromAsset: fromFile,
                 parentPatch: parentPatch,
                 contentPack: contentPack.ContentPack,
+                migrator: contentPack.Migrator,
                 parseAssetName: parseAssetName
             )
         {

--- a/ContentPatcher/Framework/Patches/LoadPatch.cs
+++ b/ContentPatcher/Framework/Patches/LoadPatch.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ContentPatcher.Framework.Conditions;
+using ContentPatcher.Framework.Migrations;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 
@@ -21,9 +22,10 @@ namespace ContentPatcher.Framework.Patches
         /// <param name="updateRate">When the patch should be updated.</param>
         /// <param name="conditions">The conditions which determine whether this patch should be applied.</param>
         /// <param name="contentPack">The content pack which requested the patch.</param>
+        /// <param name="migrator">The aggregate migration which applies for this patch.</param>
         /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
         /// <param name="parseAssetName">Parse an asset name.</param>
-        public LoadPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString localAsset, AssetLoadPriority priority, UpdateRate updateRate, IEnumerable<Condition> conditions, IContentPack contentPack, IPatch? parentPatch, Func<string, IAssetName> parseAssetName)
+        public LoadPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString localAsset, AssetLoadPriority priority, UpdateRate updateRate, IEnumerable<Condition> conditions, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, Func<string, IAssetName> parseAssetName)
             : base(
                 indexPath: indexPath,
                 path: path,
@@ -33,6 +35,7 @@ namespace ContentPatcher.Framework.Patches
                 updateRate: updateRate,
                 conditions: conditions,
                 contentPack: contentPack,
+                migrator: migrator,
                 parentPatch: parentPatch,
                 parseAssetName: parseAssetName,
                 fromAsset: localAsset

--- a/ContentPatcher/Framework/RawContentPack.cs
+++ b/ContentPatcher/Framework/RawContentPack.cs
@@ -20,7 +20,7 @@ namespace ContentPatcher.Framework
         private ContentConfig? ContentImpl;
 
         /// <summary>The backing field for <see cref="Migrator"/>.</summary>
-        private IMigration? MigratorImpl;
+        private IRuntimeMigration? MigratorImpl;
 
 
         /*********
@@ -36,7 +36,7 @@ namespace ContentPatcher.Framework
         public ContentConfig Content => this.ContentImpl ?? throw new InvalidOperationException($"Must call {nameof(RawContentPack)}.{nameof(this.TryReloadContent)} before accessing the {nameof(this.Content)} field.");
 
         /// <summary>The migrations to apply for the content pack version.</summary>
-        public IMigration Migrator => this.MigratorImpl ?? throw new InvalidOperationException($"Must call {nameof(RawContentPack)}.{nameof(this.TryReloadContent)} before accessing the {nameof(this.Migrator)} field.");
+        public IRuntimeMigration Migrator => this.MigratorImpl ?? throw new InvalidOperationException($"Must call {nameof(RawContentPack)}.{nameof(this.TryReloadContent)} before accessing the {nameof(this.Migrator)} field.");
 
         /// <summary>The content pack's index in the load order.</summary>
         public int Index { get; }
@@ -98,7 +98,7 @@ namespace ContentPatcher.Framework
 
             // apply high-level migrations
             // patch-level migrations are applied by PatchLoader
-            IMigration migrator = new AggregateMigration(content.Format, this.GetMigrations(content));
+            IRuntimeMigration migrator = new AggregateMigration(content.Format, this.GetMigrations(content));
             if (!migrator.TryMigrateMainContent(content, out error))
                 return false;
 

--- a/ContentPatcher/ModEntry.cs
+++ b/ContentPatcher/ModEntry.cs
@@ -270,6 +270,22 @@ namespace ContentPatcher
                     this.Monitor.Log($"{group.ModName} added {(group.TokenNames.Length == 1 ? "a custom token" : $"{group.TokenNames.Length} custom tokens")} with prefix '{group.ModPrefix}': {string.Join(", ", group.TokenNames)}.");
             }
 
+            // log content pack migration warnings
+            {
+                ILookup<string, string> contentPacksByWarning =
+                    this.ContentPacks
+                        .SelectMany(pack => pack.Migrator.MigrationWarnings.Select(warning => new { pack.Manifest.Name, Warning = warning }))
+                        .ToLookup(p => p.Warning, p => p.Name);
+
+                foreach (IGrouping<string, string> warningGroup in contentPacksByWarning.OrderBy(p => p.Key, new HumanSortComparer()))
+                {
+                    this.Monitor.Log(
+                        $"{warningGroup.Key}\n\nAffected content packs:\n- {string.Join("\n- ", warningGroup.OrderByHuman(p => p))}\n\nFor mod authors, see how to update a mod: https://github.com/Pathoschild/StardewMods/blob/develop/ContentPatcher/docs/author-migration-guide.md.",
+                        LogLevel.Info
+                    );
+                }
+            }
+
             // set up events
             if (this.Config.EnableDebugFeatures)
                 helper.Events.Input.ButtonsChanged += this.OnButtonsChanged;

--- a/ContentPatcher/docs/author-migration-guide.md
+++ b/ContentPatcher/docs/author-migration-guide.md
@@ -21,7 +21,7 @@ This document helps mod authors update their content packs for newer versions of
 
 ## FAQs
 <dl>
-<dt>Does this affect me as a player?</dt>
+<dt>Does this page affect me as a player?</dt>
 <dd>
 
 No, this is only for content pack authors. Existing content packs should work fine.
@@ -31,31 +31,28 @@ No, this is only for content pack authors. Existing content packs should work fi
 <dt>Are Content Patcher updates backwards-compatible?</dt>
 <dd>
 
-Yep; even content packs written for Content Patcher 1.0 still work in the latest versions.
-
-Content Patcher updates rarely have breaking changes, but the [`Format` field in your
-`content.json`](author-guide.md#format) says which version it was created for. When a future
-version of Content Patcher loads your content pack, it internally migrates your `content.json` to
-the latest format (without changing the actual files). Content Patcher itself no longer supports
-older formats, but your content pack is just changed to use the latest one.
+Yes, even content packs written for Content Patcher 1.0.0 should still work. Content Patcher uses
+your [`Format` field](author-guide.md#format) to convert the content pack to the latest version if
+needed (without changing the actual files).
 
 </dd>
 
-<dt>So I never need to update my content packs?</dt>
+<dt>Do I need to update my content packs?</dt>
 <dd>
 
-Technically you don't need to (aside from game changes), but **updating your `Format` version when
-you update the content pack is strongly encouraged**.
+Usually your content packs will work indefinitely without manual updates. Game changes may
+sometimes break content packs (though Content Patcher will try to rewrite those too).
 
-Using an old `Format` version has major disadvantages:
+However, using an old `Format` version has some major disadvantages. Your content pack...
 
-* You can't use newer features.
-* You may have undocumented behavior. (For example, the `Weather` token before `Format` version 1.6
-  uses the same value for sunny and windy days, but that's not documented since it only does so for
-  backwards compatibility.)
-* There's more risk of bugs and startup time is impacted. (For example, a content pack which uses
-  `"Format": "1.0"` has over a dozen automated migrations applied, which increases the chance that
-  something will be migrated incorrectly and increases startup time.)
+* Won't have access to newer features.
+* May have legacy behavior that doesn't match the current docs.
+* May increase startup time or cause in-game lag. Rewriting code for compatibility is sometimes
+  complicated and inefficient, so it's much faster if the code is already updated instead.
+* May have more bugs. For example, a content pack for `Format` version 1.0 has dozens of automated
+  migrations applied, which increases the chance that something will be migrated incorrectly.
+
+Migrating to the latest format when you update the content pack is strongly encouraged.
 
 </dd>
 
@@ -66,7 +63,8 @@ Just set the `Format` field to the latest version shown in the [author guide](au
 then review the sections below for any changes you need to make. If a version isn't listed on this
 page, there's nothing else to change for that version.
 
-Feel free to [ask on Discord](https://smapi.io/community#Discord) if you need help!
+> [!TIP]
+> Feel free to [ask on Discord](https://smapi.io/community#Discord) if you need help!
 
 </dd>
 </dl>
@@ -93,8 +91,9 @@ compatibility by using it when relevant.
 </li>
 <li>
 
-[`CustomLocations`](custom-locations.md) is now deprecated, since you can add custom locations directly using the [new
-`Data/Locations` asset](https://stardewvalleywiki.com/Modding:Location_data) in Stardew Valley 1.6.
+[`CustomLocations`](custom-locations.md) is now deprecated. You should add custom locations to the
+[new `Data/Locations` asset](https://stardewvalleywiki.com/Modding:Location_data) in Stardew Valley
+1.6 instead.
 
 For example, if you have a custom location like this:
 
@@ -114,7 +113,7 @@ You can now add it to the game directly like this:
     // add map
     {
         "Action": "Load",
-        "Target": "Maps/Your.ModId_AbigailCloset",
+        "Target": "Maps/{{ModId}}_AbigailCloset",
         "FromFile": "assets/abigail-closet.tmx"
     },
 
@@ -123,8 +122,8 @@ You can now add it to the game directly like this:
         "Action": "EditData",
         "Target": "Data/Locations",
         "Entries": {
-            "Your.ModId_AbigailCloset": {
-                "CreateOnLoad": { "MapPath": "Maps/Your.ModId_AbigailCloset" },
+            "{{ModId}}_AbigailCloset": {
+                "CreateOnLoad": { "MapPath": "Maps/{{ModId}}_AbigailCloset" },
                 "FormerLocationNames": [ "Custom_ExampleMod_AbigailCloset" ]
             }
         }
@@ -133,9 +132,11 @@ You can now add it to the game directly like this:
 ```
 
 The game uses a standard [unique string ID](https://stardewvalleywiki.com/Modding:Modder_Guide/Game_Fundamentals#Unique_string_IDs)
-format for the location name. In the example above, we use the new name format (`Your.ModId_AbigailCloset`) and add the
+format for the location name. In the example above, we use the new name format (`{{ModId}}_AbigailCloset`) and add the
 old name (`Custom_ExampleMod_AbigailCloset`) to the `FormerLocationNames` field so the location will be migrated
-automatically for current players. You should replace `Your.ModId` with [your mod's manifest `UniqueId`](https://stardewvalleywiki.com/Modding:Modder_Guide/APIs/Manifest).
+automatically for current players.
+
+Content Patcher will replace `{{ModId}}` automatically with [your mod's manifest `UniqueId`](https://stardewvalleywiki.com/Modding:Modder_Guide/APIs/Manifest).
 
 **Known limitations:**
 * You can't migrate TMXL Map Toolkit locations directly to Data/Locations. If you need to support migrations from TMXL,

--- a/ContentPatcher/docs/release-notes.md
+++ b/ContentPatcher/docs/release-notes.md
@@ -12,16 +12,16 @@ When releasing a format change, don't forget to update the smapi.io/json schema!
 ## Upcoming release for Stardew Valley 1.6
 * Updated for Stardew Valley 1.6.
 * Added asset load & edit priority (see updated [action docs](author-guide.md#actions)).
-* Added new tokens:
-  * [`ModId`](author-guide/tokens.md#ModId) to get the unique ID of the current content pack.
-* `CustomLocations` is now deprecated in favor of the new [`Data/Locations` asset](https://stardewvalleywiki.com/Modding:Location_data).
-  Locations added through it are now added to `Data/Locations` automatically.
-* `CustomLocations` now allows the [new location name format](https://stardewvalleywiki.com/Modding:Modder_Guide/Game_Fundamentals#Unique_string_IDs).
+* Added [`ModId`](author-guide/tokens.md#ModId) token to get the unique ID of the current content pack.
+* Added runtime migrations for content assets which changed in Stardew Valley 1.6. (Thanks to SinZ for the help creating some of the main migrations!)
+* Deprecated `CustomLocations`. This is now a shortcut for editing the new [`Data/Locations` asset](https://stardewvalleywiki.com/Modding:Location_data), and now allows the [new location name format](https://stardewvalleywiki.com/Modding:Modder_Guide/Game_Fundamentals#Unique_string_IDs).
 * Removed `GroupEditsByMod` config option. Edits are now grouped automatically based on mod and priority.
 * Fixed off-by-one position with `MoveEntries` when the target entry is already before the anchor entry.
 
 **Update notes for mod authors:**  
-See the [migration guide](author-migration-guide.md#20) for help updating content pack code.
+* Stardew Valley 1.6 has major content changes. Your content packs may still work due to the new runtime migrations,
+  but these can have a significant performance impact. [Updating your code to the latest format](author-migration-guide.md#20)
+  is strongly recommended.
 
 ## 1.30.4
 Released 01 December 2023 for SMAPI 3.18.1 or later.
@@ -61,12 +61,6 @@ Released 27 August 2023 for SMAPI 3.18.1 or later.
 * Fixed `EditData` replacing fields explicitly set to null with empty strings.
 * Fixed `IsJojaMartComplete` token not working consistently.
 * Fixed `Render` token incorrectly including named arguments.
-
-**Update notes for mod authors:**  
-* Added backwards compatibility for older content packs editing `Data/NPCDispositions` and `Data/Locations` in a best effort capacity.
-  Mod authors are advised to migrate to the 1.6 native formats regardless, particularly if wanting to access newer 1.6 capabilities in these assets.
-  * For `Data/NPCDispositions` Tokens in the NPC Default Location are not backwards compatible and will not load.
-  * For `Data/Locations` Fish Area Id restrictions are not mapped to the new data model, so fish entries running in this backwards compatible mode will be caught everywhere in the given location.
 
 ## 1.29.3
 Released 26 June 2023 for SMAPI 3.18.1 or later.

--- a/ContentPatcher/docs/release-notes.md
+++ b/ContentPatcher/docs/release-notes.md
@@ -62,6 +62,12 @@ Released 27 August 2023 for SMAPI 3.18.1 or later.
 * Fixed `IsJojaMartComplete` token not working consistently.
 * Fixed `Render` token incorrectly including named arguments.
 
+**Update notes for mod authors:**  
+* Added backwards compatibility for older content packs editing `Data/NPCDispositions` and `Data/Locations` in a best effort capacity.
+  Mod authors are advised to migrate to the 1.6 native formats regardless, particularly if wanting to access newer 1.6 capabilities in these assets.
+  * For `Data/NPCDispositions` Tokens in the NPC Default Location are not backwards compatible and will not load.
+  * For `Data/Locations` Fish Area Id restrictions are not mapped to the new data model, so fish entries running in this backwards compatible mode will be caught everywhere in the given location.
+
 ## 1.29.3
 Released 26 June 2023 for SMAPI 3.18.1 or later.
 


### PR DESCRIPTION
Tentatively for Content Patcher 2.0 (unclear if 1.6 is getting that version bump or not).

Error messages still need improving to be more human friendly, and some edge cases still need handling, but it can read my 1.5.6 modlist with 3 exceptions (all for the same reason).

Log when it runs (Ignore the billion warnings from CP, they are likely due to a custom SMAPI build to ignore dependencies so I could run the migrator on as much as possible)
https://smapi.io/log/81ca6c3c7daf49749697ba0f18c5f70e
and the patch exported Data/Characters https://smapi.io/json/none/ba8015287b64466f9580fe117a507740

