### PR TITLE
[Tractor Mod] Adds constant energy drain.

### DIFF
--- a/TractorMod/Framework/GenericModConfigMenuIntegrationForTractor.cs
+++ b/TractorMod/Framework/GenericModConfigMenuIntegrationForTractor.cs
@@ -436,6 +436,22 @@ namespace Pathoschild.Stardew.TractorMod.Framework
                     set: (config, value) => config.StandardAttachments.Slingshot.Enable = value
                 )
 
+                .AddSectionTitle(I18n.Config_Fuel)
+                .AddCheckbox(
+                    name: I18n.Config_FuelEnabled_Name,
+                    tooltip: I18n.Config_FuelEnabled_Tooltip,
+                    get: config => config.FuelEnabled,
+                    set: (config, value) => config.FuelEnabled = value
+                )
+                .AddNumberField(
+                    name: I18n.Config_FuelValue_Name,
+                    tooltip: () => I18n.Config_FuelValue_Tooltip(defaultConfig.FuelAmount),
+                    get: config => config.FuelAmount,
+                    set: (config, value) => config.FuelAmount = value,
+                    min: 0,
+                    max: 20
+                )
+
                 // custom tools
                 .AddSectionTitle(I18n.Config_CustomTools)
                 .AddTextbox(

--- a/TractorMod/Framework/ModConfig.cs
+++ b/TractorMod/Framework/ModConfig.cs
@@ -48,5 +48,11 @@ namespace Pathoschild.Stardew.TractorMod.Framework
 
         /// <summary>Whether the player should be invincible while they're on the tractor.</summary>
         public bool InvincibleOnTractor { get; set; } = true;
+
+        /// <summary>Whether energy should be drained as fuel while the tractor is in use.</summary>
+        public bool FuelEnabled { get; set; } = true;
+
+        /// <summary>The amount of energy that will be drained as fuel while the tractor is in use.</summary>
+        public float FuelAmount { get; set; } = 1.0F;
     }
 }

--- a/TractorMod/Framework/TractorManager.cs
+++ b/TractorMod/Framework/TractorManager.cs
@@ -312,6 +312,10 @@ namespace Pathoschild.Stardew.TractorMod.Framework
                     }
                 }
             });
+
+            // deplete stamina if enabled
+            // currently depletes 1 stamina for testing
+            player.Stamina = player.Stamina - 1;
         }
 
         /// <summary>Get the attachments which are ready and can be applied to the given tile, after applying cooldown.</summary>

--- a/TractorMod/Framework/TractorManager.cs
+++ b/TractorMod/Framework/TractorManager.cs
@@ -62,6 +62,11 @@ namespace Pathoschild.Stardew.TractorMod.Framework
         /// <summary>The rider health to maintain if they're invincible.</summary>
         private int RiderHealth;
 
+        /// <summary>The number of ticks between each tractor fuel check.</summary>
+        private readonly int TicksPerFuelCheck = 60; // roughly one time per second
+
+        /// <summary>The number of ticks since the tractor last checked for fuel drain.</summary>
+        private int SkippedFuelTicks;
 
         /*********
         ** Accessors
@@ -169,6 +174,15 @@ namespace Pathoschild.Stardew.TractorMod.Framework
                     if (enabled)
                         this.UpdateAttachmentEffects();
                 }
+
+                // apply fuel drain
+                if (this.FuelCooldown())
+                {
+                    if (this.Config.FuelEnabled)
+                    {
+                        Game1.player.Stamina = Game1.player.Stamina - this.Config.FuelAmount;
+                    }
+                }
             }
         }
 
@@ -261,6 +275,19 @@ namespace Pathoschild.Stardew.TractorMod.Framework
             return true;
         }
 
+        /// <summary>Update the fuel cooldown.</summary>
+        /// <returns>Returns whether the cooldown has ended.</returns>
+        private bool FuelCooldown()
+        {
+            this.SkippedFuelTicks++;
+
+            if (this.SkippedFuelTicks % this.TicksPerFuelCheck != 0)
+                return false;
+
+            this.SkippedFuelTicks = 0;
+            return true;
+        }
+
         /// <summary>Notify attachments that effects have been enabled for a location.</summary>
         /// <param name="location">The current tractor location.</param>
         private void OnActivated(GameLocation location)
@@ -312,10 +339,6 @@ namespace Pathoschild.Stardew.TractorMod.Framework
                     }
                 }
             });
-
-            // deplete stamina if enabled
-            // currently depletes 1 stamina for testing
-            player.Stamina = player.Stamina - 1;
         }
 
         /// <summary>Get the attachments which are ready and can be applied to the given tile, after applying cooldown.</summary>

--- a/TractorMod/i18n/de.json
+++ b/TractorMod/i18n/de.json
@@ -23,7 +23,7 @@
     "config.melee-dagger": "Nahkampfdolch Eigenschaften",
     "config.melee-sword": "Nahkampfschwert Eigenschaften",
     "config.other-tools": "Andere Tools",
-    "config.fuel": "Fuel",
+    "config.fuel": "Treibstoff",
     "config.custom-tools": "Benutzerdefinierte Tools",
 
 

--- a/TractorMod/i18n/de.json
+++ b/TractorMod/i18n/de.json
@@ -23,6 +23,7 @@
     "config.melee-dagger": "Nahkampfdolch Eigenschaften",
     "config.melee-sword": "Nahkampfschwert Eigenschaften",
     "config.other-tools": "Andere Tools",
+    "config.fuel": "Fuel",
     "config.custom-tools": "Benutzerdefinierte Tools",
 
 
@@ -175,6 +176,14 @@
     "config.Attack-monsters.name": "Monster angreifen",
     "config.Attack-monsters.tooltip": "Ob man Monster angreift. (Dies ist aufgrund der Geschwindigkeit des Traktorwerkzeugs extrem overpowered).",
 
+    /****
+    ** Fuel options
+    ****/
+    "config.fuel-enabled.name": "Aktiviere Energieverlust",
+    "config.fuel-enabled.tooltip": "Ob eine bestimmte Menge Energie pro Sekunde abgezogen werden soll.",
+
+    "config.fuel-value.name": "Energieverlust",
+    "config.fuel-value.tooltip": "Die Menge an Energie die während der Nutzung des Traktors abgezogen wird. Standard {{defaultValue}}.",
 
     /****
     ** Other

--- a/TractorMod/i18n/default.json
+++ b/TractorMod/i18n/default.json
@@ -23,6 +23,7 @@
     "config.melee-dagger": "Melee Dagger Features",
     "config.melee-sword": "Melee Sword Features",
     "config.other-tools": "Other Tools",
+    "config.fuel": "Fuel",
     "config.custom-tools": "Custom Tools",
 
 
@@ -175,6 +176,14 @@
     "config.Attack-monsters.name": "Attack Monsters",
     "config.Attack-monsters.tooltip": "Whether to attack monsters. (This is massively overpowered due to the tractor tool speed.)",
 
+    /****
+    ** Fuel options
+    ****/
+    "config.fuel-enabled.name": "Enable energy drain",
+    "config.fuel-enabled.tooltip": "Whether to drain a set amount of energy per second of use",
+
+    "config.fuel-value.name": "Drainage amount",
+    "config.fuel-value.tooltip": "The amount of energy that gets drained while using the tractor. Default {{defaultValue}}.",
 
     /****
     ** Other


### PR DESCRIPTION
Hello!
This might be a possible or partial solution to #194.

These proposed changes add a constant energy drain while the Tractor is mounted.
They also add menu bindings to toggle and modify said energy drain.

This uses the stamina property of the player, so the timing isn't ideal with the upcoming 1.6 changes.

My first thought was to add a drain equivalent to the actions as if they had been done with the tools.
I didnt find a function to do that without copy-pasting the calcuations from the game, however, and i couldnt figure out how to implement it in a way that didnt trigger every update.
There'd need to be some way to get a list of eligible actions taken every tick i think.