### PR TITLE
Simplify Lookup Anything level progression bars

### DIFF
--- a/LookupAnything/Framework/Fields/SkillBarField.cs
+++ b/LookupAnything/Framework/Fields/SkillBarField.cs
@@ -52,9 +52,18 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
             const int barWidth = 25;
             float leftOffset = 0;
             int barHeight = 0;
-            foreach (int levelExp in pointsPerLevel)
+            for (int i = 0; i < pointsPerLevel.Length; i++)
             {
+                int levelExp = pointsPerLevel[i];
                 float progress = Math.Min(1f, this.CurrentValue / (levelExp * 1f));
+                if (i < currentLevel)
+                {
+                    progress = 1f;
+                }
+                else if (i > currentLevel)
+                {
+                    progress = 0f;
+                }
                 Vector2 barSize = this.DrawBar(spriteBatch, position + new Vector2(leftOffset, 0), progress, this.FilledColor, this.EmptyColor, barWidth);
                 barHeight = (int)barSize.Y;
                 leftOffset += barSize.X + 2;

--- a/LookupAnything/Framework/Fields/SkillBarField.cs
+++ b/LookupAnything/Framework/Fields/SkillBarField.cs
@@ -52,18 +52,19 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
             const int barWidth = 25;
             float leftOffset = 0;
             int barHeight = 0;
-            for (int i = 0; i < pointsPerLevel.Length; i++)
+            for (int level = 0; level < pointsPerLevel.Length; level++)
             {
-                int levelExp = pointsPerLevel[i];
-                float progress = Math.Min(1f, this.CurrentValue / (levelExp * 1f));
-                if (i < currentLevel)
-                {
+                float progress;
+                if (level < currentLevel)
                     progress = 1f;
-                }
-                else if (i > currentLevel)
-                {
+                else if (level > currentLevel)
                     progress = 0f;
+                else
+                {
+                    int levelExp = pointsPerLevel[level];
+                    progress = Math.Min(1f, this.CurrentValue / (levelExp * 1f));
                 }
+
                 Vector2 barSize = this.DrawBar(spriteBatch, position + new Vector2(leftOffset, 0), progress, this.FilledColor, this.EmptyColor, barWidth);
                 barHeight = (int)barSize.Y;
                 leftOffset += barSize.X + 2;


### PR DESCRIPTION
First of all, thanks for this awesome set of mods! LookupAnything is one of the most useful mods I've found, and ever since I got it years ago I can't imagine playing Stardew without it. 😄 

However, just as long as I have been using the mod, this issue has been nagging me, so I decided to do something about it. On the player info window, it draws experience bars for your progress in each skill. The problem is that it calculates the progress for _each_ bar relative to your current level's exp value! This looks really awkward with multiple bars partially filled. Comparison of before and after:

![LookupAnythingExpBarFix](https://github.com/Pathoschild/StardewMods/assets/2908553/6e1df20e-4d6e-4e5a-8c69-383bb200a0ad)
