### PR TITLE
Make Content Patcher ignore comments

### DIFF
--- a/ContentPatcher/Framework/TokenParser.cs
+++ b/ContentPatcher/Framework/TokenParser.cs
@@ -164,7 +164,7 @@ namespace ContentPatcher.Framework
         /// <param name="parsed">The parsed value, which may be legitimately <c>null</c> even if successful.</param>
         public bool TryParseJson(JToken? rawJson, IInvariantSet assumeModIds, LogPathBuilder path, [NotNullWhen(false)] out string? error, out TokenizableJToken? parsed)
         {
-            if (rawJson == null || rawJson.Type == JTokenType.Null)
+            if (rawJson == null || rawJson.Type == JTokenType.Null || rawJson.Type == JTokenType.Comment)
             {
                 error = null;
                 parsed = null;
@@ -254,6 +254,7 @@ namespace ContentPatcher.Framework
             switch (token)
             {
                 case JValue valueToken:
+                    if (valueToken.Type != JTokenType.Comment)
                     {
                         string? value = valueToken.Value<string?>();
                         if (!this.TryInjectJsonProxyField(value, assumeModIds, val => valueToken.Value = val, path, out error, out TokenizableProxy? proxy))


### PR DESCRIPTION
Currently, CP will attempt to analyze comments for tokens and stuff. This should be enough to get CP to completely ignore comments.

This is the patch I tested with

```
        {
            "Action": "EditData",
            "Target": "Data/Objects",
            "Entries": {
                "atravita.TestRing": {
                    // Look, ma, a comment! {{ThisIsABadToken}}
                    "Name": "Test Ring",
                    "DisplayName": "Test Ring",
                    "Description": "Test Ring Description",
                    "Type": "Ring",
                    "Texture": "{{InternalAssetKey: weapon.png}}",
                }
            }
        },
        ```