### PR TITLE
Fix 'Error Item' preserve recipes, fix all objects except coffee beans being treated as seeds

### DIFF
--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -446,25 +446,22 @@ namespace Pathoschild.Stardew.LookupAnything
             {
                 if (inputID != null)
                 {
-                    switch (ItemRegistry.GetDataOrErrorItem(outputID).ItemId)
+                    var objectDefinition = ItemRegistry.GetObjectTypeDefinition();
+                    switch (ItemRegistry.QualifyItemId(outputID))
                     {
-                        case "342":
-                            obj.preserve.Value = SObject.PreserveType.Pickle;
+                        case "(O)342":
+                            obj = objectDefinition.CreateFlavoredPickle(ItemRegistry.Create(inputID) as SObject);
                             break;
-                        case "344":
-                            obj.preserve.Value = SObject.PreserveType.Jelly;
+                        case "(O)344":
+                            obj = objectDefinition.CreateFlavoredJelly(ItemRegistry.Create(inputID) as SObject);
                             break;
-                        case "348":
-                            obj.preserve.Value = SObject.PreserveType.Wine;
+                        case "(O)348":
+                            obj = objectDefinition.CreateFlavoredWine(ItemRegistry.Create(inputID) as SObject);
                             break;
-                        case "350":
-                            obj.preserve.Value = SObject.PreserveType.Juice;
+                        case "(O)350":
+                            obj = objectDefinition.CreateFlavoredJuice(ItemRegistry.Create(inputID) as SObject);
                             break;
                     }
-                }
-                if (obj.preserve.Value.HasValue)
-                {
-                    obj.preservedParentSheetIndex.Value = ItemRegistry.GetDataOrErrorItem(inputID).ItemId;
                 }
 
                 if (output != null)
@@ -472,6 +469,7 @@ namespace Pathoschild.Stardew.LookupAnything
                     obj.preservedParentSheetIndex.Value = output.PreservedParentSheetIndex ?? obj.preservedParentSheetIndex.Value;
                     obj.preserve.Value = output.PreserveType ?? obj.preserve.Value;
                 }
+                return obj;
             }
 
             return item;

--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -446,29 +446,25 @@ namespace Pathoschild.Stardew.LookupAnything
             {
                 if (inputID != null)
                 {
-                    switch (outputID)
+                    switch (ItemRegistry.GetDataOrErrorItem(outputID).ItemId)
                     {
-                        case "(O)342":
                         case "342":
                             obj.preserve.Value = SObject.PreserveType.Pickle;
-                            obj.preservedParentSheetIndex.Value = inputID;
                             break;
-                        case "(O)344":
                         case "344":
                             obj.preserve.Value = SObject.PreserveType.Jelly;
-                            obj.preservedParentSheetIndex.Value = inputID;
                             break;
-                        case "(O)348":
                         case "348":
                             obj.preserve.Value = SObject.PreserveType.Wine;
-                            obj.preservedParentSheetIndex.Value = inputID;
                             break;
-                        case "(O)350":
                         case "350":
                             obj.preserve.Value = SObject.PreserveType.Juice;
-                            obj.preservedParentSheetIndex.Value = inputID;
                             break;
                     }
+                }
+                if (obj.preserve.Value.HasValue)
+                {
+                    obj.preservedParentSheetIndex.Value = ItemRegistry.GetDataOrErrorItem(inputID).ItemId;
                 }
 
                 if (output != null)

--- a/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
+++ b/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
@@ -467,10 +467,14 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Items
 
             try
             {
-                Crop crop = new(seed.ItemId, 0, 0, location ?? Game1.getFarm());
-                return CommonHelper.IsItemId(crop.netSeedIndex.Value)
-                    ? crop
-                    : null;
+                if (Crop.TryGetData(seed.ItemId, out _))
+                {
+                    Crop crop = new(seed.ItemId, 0, 0, location ?? Game1.getFarm());
+                    return CommonHelper.IsItemId(crop.netSeedIndex.Value)
+                        ? crop
+                        : null;
+                }
+                return null;
             }
             catch
             {

--- a/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
+++ b/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
@@ -468,14 +468,9 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Items
 
             try
             {
-                if (Crop.TryGetData(seed.ItemId, out _))
-                {
-                    Crop crop = new(seed.ItemId, 0, 0, location ?? Game1.getFarm());
-                    return CommonHelper.IsItemId(crop.netSeedIndex.Value)
-                        ? crop
-                        : null;
-                }
-                return null;
+                return Crop.TryGetData(seed.ItemId, out _)
+                    ? new(seed.ItemId, 0, 0, location ?? Game1.getFarm())
+                    : null;
             }
             catch
             {

--- a/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
+++ b/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
@@ -14,6 +14,7 @@ using Pathoschild.Stardew.LookupAnything.Framework.Models;
 using StardewModdingAPI.Utilities;
 using StardewValley;
 using StardewValley.Buildings;
+using StardewValley.Extensions;
 using StardewValley.GameData.FishPonds;
 using StardewValley.GameData.Movies;
 using StardewValley.Locations;
@@ -462,7 +463,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Items
         /// <param name="location">The location containing the crop, if applicable.</param>
         private Crop? TryGetCropForSeed(Item seed, GameLocation? location)
         {
-            if (seed is not SObject obj || obj.bigCraftable.Value)
+            if (!seed.HasTypeId(ItemRegistry.type_object))
                 return null;
 
             try


### PR DESCRIPTION
This fixes all objects (except Coffee Seeds) being treated as a Seed, along with fixing Error Preserves due to multiple (O) getting appended and becoming error items.

Before:
![image](https://github.com/Pathoschild/StardewMods/assets/767456/bcba4d38-4ff9-4586-ad79-6547444416d0)
![image](https://github.com/Pathoschild/StardewMods/assets/767456/26f48802-fda8-43f4-866e-e1bd4ec8494b)

After:
![image](https://github.com/Pathoschild/StardewMods/assets/767456/74ec52ec-0957-4caf-9cc2-cee125ea168f)
![image](https://github.com/Pathoschild/StardewMods/assets/767456/a9295d93-f9cf-415c-9172-020fc668fa40)

