### PR TITLE
Fix fertilizer translations and missing crafting recipes

### DIFF
--- a/Common/GameI18n.cs
+++ b/Common/GameI18n.cs
@@ -19,7 +19,7 @@ namespace Pathoschild.Stardew.Common
 
             try
             {
-                var data = ItemRegistry.GetData($"{ItemRegistry.type_bigCraftable}{id}");
+                var data = ItemRegistry.GetData(ItemRegistry.ManuallyQualifyItemId(id, ItemRegistry.type_bigCraftable));
                 return data?.DisplayName ?? $"(missing translation: no bigcraftable #{id})";
             }
             catch
@@ -37,7 +37,7 @@ namespace Pathoschild.Stardew.Common
 
             try
             {
-                var data = ItemRegistry.GetData($"{ItemRegistry.type_object}{id}");
+                var data = ItemRegistry.GetData(ItemRegistry.ManuallyQualifyItemId(id, ItemRegistry.type_object));
                 return data?.DisplayName ?? $"(missing translation: no object #{id})";
             }
             catch


### PR DESCRIPTION
Previously, Fertilizer translations were failing due to double qualifying when trying to get the display name.
(Note: Crop and Error Wine are both fixed in #840)
![image](https://github.com/Pathoschild/StardewMods/assets/767456/61e8503e-c867-4f89-bb50-5aaa50f897e5)
Now, it correctly shows the value.
![image](https://github.com/Pathoschild/StardewMods/assets/767456/6429fe65-1cd7-4e1c-8afa-7732d1007028)