### PR TITLE
Fix crafting/cooking recipes missing when queried by ingredient

### DIFF
--- a/LookupAnything/Framework/Models/RecipeIngredientModel.cs
+++ b/LookupAnything/Framework/Models/RecipeIngredientModel.cs
@@ -75,6 +75,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Models
             // item fields
             bool matchesId =
                 this.PossibleIds.Contains(item.Category.ToString())
+                || this.PossibleIds.Contains(item.ItemId)
                 || this.PossibleIds.Contains(item.QualifiedItemId);
             if (!matchesId)
                 return false;

--- a/LookupAnything/Framework/Models/RecipeModel.cs
+++ b/LookupAnything/Framework/Models/RecipeModel.cs
@@ -172,7 +172,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Models
         public static RecipeIngredientModel[] ParseIngredients(CraftingRecipe recipe)
         {
             return recipe.recipeList
-                .Select(p => new RecipeIngredientModel(p.Key, p.Value))
+                .Select(p => new RecipeIngredientModel(ItemRegistry.QualifyItemId(p.Key), p.Value))
                 .ToArray();
         }
 

--- a/LookupAnything/Framework/Models/RecipeModel.cs
+++ b/LookupAnything/Framework/Models/RecipeModel.cs
@@ -172,7 +172,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Models
         public static RecipeIngredientModel[] ParseIngredients(CraftingRecipe recipe)
         {
             return recipe.recipeList
-                .Select(p => new RecipeIngredientModel(ItemRegistry.QualifyItemId(p.Key), p.Value))
+                .Select(p => new RecipeIngredientModel(p.Key, p.Value))
                 .ToArray();
         }
 


### PR DESCRIPTION
This later causes mismatches in RecipeIngredientModel.Matches(Item item) as it does Qualified Id string comparisons.

(Note crop info on an iridium bar is fixed by #840)
Previous:
![image](https://github.com/Pathoschild/StardewMods/assets/767456/894a2b41-4a84-44da-9d87-4bab086e4459)
Now:
![image](https://github.com/Pathoschild/StardewMods/assets/767456/33a60ed6-4582-4e7a-9c3c-69f9c0eb8bb6)
