### PR TITLE
Fix zoom level issues in Chests Anywhere

### DIFF
--- a/Common/UI/BaseOverlay.cs
+++ b/Common/UI/BaseOverlay.cs
@@ -44,7 +44,7 @@ namespace Pathoschild.Stardew.Common.UI
         /// <summary>Release all resources.</summary>
         public virtual void Dispose()
         {
-            this.Events.Display.Rendered -= this.OnRendered;
+            this.Events.Display.RenderedActiveMenu -= this.OnRendered;
             this.Events.Display.RenderedWorld -= this.OnRenderedWorld;
             this.Events.GameLoop.UpdateTicked -= this.OnUpdateTicked;
             this.Events.Input.ButtonPressed -= this.OnButtonPressed;
@@ -79,7 +79,7 @@ namespace Pathoschild.Stardew.Common.UI
             events.GameLoop.UpdateTicked += this.OnUpdateTicked;
 
             if (this.IsMethodOverridden(nameof(this.DrawUi)))
-                events.Display.Rendered += this.OnRendered;
+                events.Display.RenderedActiveMenu += this.OnRendered;
             if (this.IsMethodOverridden(nameof(this.DrawWorld)))
                 events.Display.RenderedWorld += this.OnRenderedWorld;
             if (this.IsMethodOverridden(nameof(this.ReceiveLeftClick)))
@@ -157,7 +157,7 @@ namespace Pathoschild.Stardew.Common.UI
         /// <inheritdoc cref="IDisplayEvents.Rendered"/>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event data.</param>
-        private void OnRendered(object? sender, RenderedEventArgs e)
+        private void OnRendered(object? sender, RenderedActiveMenuEventArgs e)
         {
             if (Context.ScreenId != this.ScreenId)
                 return;


### PR DESCRIPTION
I don't entirely know *why* this fixes it, but it does...

Before (100% ui, 100% zoom):
![image](https://github.com/Pathoschild/StardewMods/assets/767456/2ce01154-6969-4121-8491-355574d189f7)
Before (100% ui, 75% zoom):
![image](https://github.com/Pathoschild/StardewMods/assets/767456/c199ae76-9419-4349-b5f4-b1ae517762bb)
Before (150% ui, 75% zoom):
![image](https://github.com/Pathoschild/StardewMods/assets/767456/c66e394c-9da0-44c9-aa1c-7ac8628128f6)


After (100% ui, 100% zoom):
![image](https://github.com/Pathoschild/StardewMods/assets/767456/e71fa30f-fa0c-4f8e-935b-80d0c7b54428)
After (100% ui, 75% zoom):
![image](https://github.com/Pathoschild/StardewMods/assets/767456/b01a0daf-11eb-45b4-8df5-436b4dc7cb69)
After (150% ui, 75% zoom):
![image](https://github.com/Pathoschild/StardewMods/assets/767456/cc009258-1d7c-4096-8177-c8209756e465)

