### PR TITLE
Add convention to lookup NPCs in custom mod menus

### DIFF
--- a/LookupAnything/Framework/Lookups/Characters/CharacterLookupProvider.cs
+++ b/LookupAnything/Framework/Lookups/Characters/CharacterLookupProvider.cs
@@ -200,6 +200,15 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Characters
                         }
                     }
                     break;
+
+                /****
+                ** Custom mod menu with NPCs
+                ****/
+                case not null when this.Reflection.GetField<NPC?>(targetMenu, "hoveredNpc", false)?.GetValue() != null:
+                    {
+                        NPC npc = this.Reflection.GetField<NPC>(targetMenu, "hoveredNpc").GetValue();
+                        return this.BuildSubject(npc);
+                    }
             }
 
             return null;

--- a/LookupAnything/docs/README.md
+++ b/LookupAnything/docs/README.md
@@ -293,6 +293,14 @@ a `HoveredItem` field with any `Item` type and Lookup Menu will detect it:
 public Object HoveredItem;
 ```
 
+### Hovered NPCs in custom menus
+Lookup Anything detects when the cursor is over an NPC in standard menus. For custom menus, create
+a `hoveredNpc` field with an `NPC` type and Lookup Menu will detect it:
+
+```c#
+public NPC hoveredNpc;
+```
+
 ## See also
 * [Release notes](release-notes.md)
 * [Nexus mod](https://www.nexusmods.com/stardewvalley/mods/518)


### PR DESCRIPTION
Added an additional case to the CharacterLookupProvider to check for a `hoveredNpc` field. Updated the readme with info about the new field for other modders.

I updated my mod [ScheduleViewer](https://github.com/BinaryLip/ScheduleViewer/releases/tag/v1.6.0) with the `hoveredNpc` fields in my 2 menus and it worked!
![LookupAnythingHoveredNpc](https://github.com/Pathoschild/StardewMods/assets/16822674/3b2bb964-9d65-4edb-bc89-44da0fabff8b)
