### PR TITLE
Fix runtime migrations adding spaces to context tags

### DIFF
--- a/ContentPatcher/Framework/Migrations/Migration_2_0.ForObjectContextTags.cs
+++ b/ContentPatcher/Framework/Migrations/Migration_2_0.ForObjectContextTags.cs
@@ -133,7 +133,7 @@ namespace ContentPatcher.Framework.Migrations
 
                     foreach ((string oldKey, string rawTags) in contextTags)
                     {
-                        string[] tags = rawTags.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
+                        string[] tags = rawTags.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
                         // add by ID
                         if (oldKey.StartsWith("id_"))


### PR DESCRIPTION
This fixes issues like the mayo machine not making mayo anymore if contexttags ever gets migrated.
As currently all but the first tag gets replaced with a version starting with a space, which doesn't get matched with machine logic anymore.

Prior to the change:
![image](https://github.com/Pathoschild/StardewMods/assets/767456/016dd356-3d03-4c3e-a94c-75472d56d0c1)

