### PR TITLE
Use CanApplyFertilizer to check if fertilizer can be placed on that tile instead of HasFertilizer

### DIFF
--- a/TractorMod/Framework/Attachments/FertilizerAttachment.cs
+++ b/TractorMod/Framework/Attachments/FertilizerAttachment.cs
@@ -73,7 +73,7 @@ namespace Pathoschild.Stardew.TractorMod.Framework.Attachments
                 // crop fertilizer
                 default:
                     // get unfertilized dirt
-                    if (!this.TryGetHoeDirt(tileFeature, tileObj, out HoeDirt? dirt, out bool dirtCoveredByObj, out _) || dirt.HasFertilizer())
+                    if (!this.TryGetHoeDirt(tileFeature, tileObj, out HoeDirt? dirt, out bool dirtCoveredByObj, out _) || dirt.CanApplyFertilizer(item.ItemId))
                         return false;
 
                     // ignore if there's a giant crop, meteorite, etc covering the tile

--- a/TractorMod/Framework/Attachments/FertilizerAttachment.cs
+++ b/TractorMod/Framework/Attachments/FertilizerAttachment.cs
@@ -73,7 +73,7 @@ namespace Pathoschild.Stardew.TractorMod.Framework.Attachments
                 // crop fertilizer
                 default:
                     // get unfertilized dirt
-                    if (!this.TryGetHoeDirt(tileFeature, tileObj, out HoeDirt? dirt, out bool dirtCoveredByObj, out _) || dirt.CanApplyFertilizer(item.ItemId))
+                    if (!this.TryGetHoeDirt(tileFeature, tileObj, out HoeDirt? dirt, out bool dirtCoveredByObj, out _) || !dirt.CanApplyFertilizer(item.ItemId))
                         return false;
 
                     // ignore if there's a giant crop, meteorite, etc covering the tile

--- a/TractorMod/Framework/Attachments/FertilizerAttachment.cs
+++ b/TractorMod/Framework/Attachments/FertilizerAttachment.cs
@@ -73,7 +73,7 @@ namespace Pathoschild.Stardew.TractorMod.Framework.Attachments
                 // crop fertilizer
                 default:
                     // get unfertilized dirt
-                    if (!this.TryGetHoeDirt(tileFeature, tileObj, out HoeDirt? dirt, out bool dirtCoveredByObj, out _) || !dirt.CanApplyFertilizer(item.ItemId))
+                    if (!this.TryGetHoeDirt(tileFeature, tileObj, out HoeDirt? dirt, out bool dirtCoveredByObj, out _) || !dirt.CanApplyFertilizer(item.QualifiedItemId))
                         return false;
 
                     // ignore if there's a giant crop, meteorite, etc covering the tile


### PR DESCRIPTION
CanApplyFertilizer is the method that the base game hand planting and green box rendering use, it can more reliably indicate whether fertilizer can be placed on that tile or not, and thus improve mod compatibility ~(with my mod)~. This also fixes a bug/feature, you can place fertilizer after a crop have grown with tractor, which is not a vanilla behaviour, player can install additional mod to alter vanilla behaviour if they want to