### PR TITLE
Update item retrieval method in BushMachine

### DIFF
--- a/Automate/Framework/Machines/TerrainFeatures/BushMachine.cs
+++ b/Automate/Framework/Machines/TerrainFeatures/BushMachine.cs
@@ -53,12 +53,13 @@ namespace Pathoschild.Stardew.Automate.Framework.Machines.TerrainFeatures
         /// <summary>Get the output item.</summary>
         public override ITrackedStack GetOutput()
         {
+            string itemId = this.Machine.GetShakeOffItem();
+
             // tea bush
             if (this.Machine.size.Value == Bush.greenTeaBush)
-                return new TrackedItem(ItemRegistry.Create("(O)815"), onReduced: this.OnOutputReduced);
+                return new TrackedItem(ItemRegistry.Create(itemId), onReduced: this.OnOutputReduced);
 
             // berry bush
-            string itemId = Game1.GetSeasonForLocation(this.Machine.Location) == Season.Fall ? "(O)410"/*blackberry*/ : "(O)296"/*salmonberry*/;
             int quality = Game1.player.professions.Contains(Farmer.botanist) ? SObject.bestQuality : SObject.lowQuality;
             int count = 1 + Game1.player.ForagingLevel / 4;
             return new TrackedItem(ItemRegistry.Create(itemId, count, quality), onReduced: this.OnOutputReduced);


### PR DESCRIPTION
This alone does not accomplish Custom Bush integration because it doesn't account for the stack or quality, but at least produces the correct (modded) item without affecting the original vanilla logic.