### PR TITLE
Add custom WildTreeGrowthStage enum with added SmallTree value

### DIFF
--- a/LookupAnything/Framework/Constants/WildTreeGrowthStage.cs
+++ b/LookupAnything/Framework/Constants/WildTreeGrowthStage.cs
@@ -1,0 +1,15 @@
+using STree = StardewValley.TerrainFeatures.Tree;
+
+namespace Pathoschild.Stardew.LookupAnything.Framework.Constants
+{
+    /// <summary>Indicates a wild tree's growth stage.</summary>
+    internal enum WildTreeGrowthStage
+    {
+        Seed = STree.seedStage,
+        Sprout = STree.sproutStage,
+        Sapling = STree.saplingStage,
+        Bush = STree.bushStage,
+        SmallTree = STree.treeStage - 1, // there is no smallTreeStage constant, so we compute this
+        Tree = STree.treeStage
+    }
+}

--- a/LookupAnything/Framework/I18nExtensions.cs
+++ b/LookupAnything/Framework/I18nExtensions.cs
@@ -10,7 +10,6 @@ using Pathoschild.Stardew.LookupAnything.Framework.Constants;
 using StardewModdingAPI;
 using StardewModdingAPI.Utilities;
 using StardewValley;
-using StardewValley.GameData.WildTrees;
 using StardewValley.Mods;
 using StardewValley.Network;
 using StardewValley.Pathfinding;

--- a/LookupAnything/Framework/Lookups/TerrainFeatures/TreeSubject.cs
+++ b/LookupAnything/Framework/Lookups/TerrainFeatures/TreeSubject.cs
@@ -4,10 +4,10 @@ using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Pathoschild.Stardew.Common;
+using Pathoschild.Stardew.LookupAnything.Framework.Constants;
 using Pathoschild.Stardew.LookupAnything.Framework.DebugFields;
 using Pathoschild.Stardew.LookupAnything.Framework.Fields;
 using StardewValley;
-using StardewValley.GameData.WildTrees;
 using StardewValley.TerrainFeatures;
 
 namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.TerrainFeatures
@@ -49,7 +49,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.TerrainFeatures
         public override IEnumerable<ICustomField> GetData()
         {
             Tree tree = this.Target;
-            WildTreeData data = tree.GetData();
+            StardewValley.GameData.WildTrees.WildTreeData data = tree.GetData();
             GameLocation location = tree.Location;
             bool isFertilized = tree.fertilized.Value;
 
@@ -67,7 +67,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.TerrainFeatures
                 string label = I18n.Tree_NextGrowth();
                 if (!data.GrowsInWinter && location.GetSeason() == Season.Winter && !location.SeedsIgnoreSeasonsHere() && !isFertilized)
                     yield return new GenericField(label, I18n.Tree_NextGrowth_Winter());
-                else if (stage == WildTreeGrowthStage.Tree - 1 && this.HasAdjacentTrees(this.Tile))
+                else if (stage == WildTreeGrowthStage.SmallTree && this.HasAdjacentTrees(this.Tile))
                     yield return new GenericField(label, I18n.Tree_NextGrowth_AdjacentTrees());
                 else
                     yield return new GenericField(label, I18n.Tree_NextGrowth_Chance(stage: I18n.For(stage + 1), chance: (isFertilized ? data.FertilizedGrowthChance : data.GrowthChance) * 100));
@@ -170,7 +170,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.TerrainFeatures
                 let otherTree = location.terrainFeatures.ContainsKey(adjacentTile)
                     ? location.terrainFeatures[adjacentTile] as Tree
                     : null
-                select otherTree != null && otherTree.growthStage.Value >= (int)(WildTreeGrowthStage.Tree - 1)
+                select otherTree != null && otherTree.growthStage.Value >= (int)(WildTreeGrowthStage.SmallTree)
             ).Any(p => p);
         }
     }

--- a/LookupAnything/Framework/Lookups/TerrainFeatures/TreeTarget.cs
+++ b/LookupAnything/Framework/Lookups/TerrainFeatures/TreeTarget.cs
@@ -3,7 +3,6 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Pathoschild.Stardew.LookupAnything.Framework.Constants;
 using StardewValley;
-using StardewValley.GameData.WildTrees;
 using StardewValley.TerrainFeatures;
 
 namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.TerrainFeatures


### PR DESCRIPTION
Added a new enum `WildTreeGrowthStage`. It's identical to the game's internal `StardewValley.GameData.WildTrees.WildTreeGrowthStage`, but with the added value `SmallTree` (between `Bush` and `Tree`).

I removed `using StardewValley.GameData.WildTrees;` from a few files where there was a naming conflict between the new enum and the one under `StardewValley.GameData`.

There were a few places in `TreeSubject.cs` that computed the "small tree" stage by subtracting 1 from `WildTreeGrowthStage.Tree`. I replaced any instances of this with the new enum value `SmallTree`.

Resolves https://github.com/Pathoschild/StardewMods/issues/887. Here are some screenshots from the game running with this change:
<img width="692" alt="tree-stage-3" src="https://github.com/Pathoschild/StardewMods/assets/76674774/dad513de-1b26-4f33-a6ae-bce4261a1934">
<img width="694" alt="tree-stage-4" src="https://github.com/Pathoschild/StardewMods/assets/76674774/e37313a2-0807-416d-aa32-db6146e8fb7b">