### PR TITLE
Round chance of wild tree growth

### DIFF
--- a/LookupAnything/Framework/Lookups/TerrainFeatures/TreeSubject.cs
+++ b/LookupAnything/Framework/Lookups/TerrainFeatures/TreeSubject.cs
@@ -70,7 +70,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.TerrainFeatures
                 else if (stage == WildTreeGrowthStage.Tree - 1 && this.HasAdjacentTrees(this.Tile))
                     yield return new GenericField(label, I18n.Tree_NextGrowth_AdjacentTrees());
                 else
-                    yield return new GenericField(label, I18n.Tree_NextGrowth_Chance(stage: I18n.For(stage + 1), chance: (isFertilized ? data.FertilizedGrowthChance : data.GrowthChance) * 100));
+                    yield return new GenericField(label, I18n.Tree_NextGrowth_Chance(stage: I18n.For(stage + 1), chance: Math.Round((isFertilized ? data.FertilizedGrowthChance : data.GrowthChance) * 100)));
             }
 
             // get fertilizer


### PR DESCRIPTION
Added rounding to where we print the chance for a wild tree to progress to the next growth stage. Resolves https://github.com/Pathoschild/StardewMods/issues/886.

Here are some screenshots of the growth chance with this change:

<img width="658" alt="mahogany-tree-unfertalized" src="https://github.com/Pathoschild/StardewMods/assets/76674774/c0f97f94-d8d7-40a2-bb95-4399a9c5cb51">
<img width="654" alt="mahogany-tree-fertalized" src="https://github.com/Pathoschild/StardewMods/assets/76674774/88fb2db5-68fb-4b95-b5ba-c2861669ddce">
