### PR TITLE
[Lookup Anything] Fix flavored item names in preserve jar & keg lookups, and incorrect caviar recipes in roe lookups

### DIFF
--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -451,11 +451,13 @@ namespace Pathoschild.Stardew.LookupAnything
             Item output;
             switch (outputId)
             {
-                case "(O)342":
+                // if ingredient is Preserves Jar, we want generic pickles instead of flavored
+                case "(O)342" when ingredient.ItemId != "15":
                     output = ItemRegistry.GetObjectTypeDefinition().CreateFlavoredPickle(ingredient as SObject);
                     break;
 
-                case "(O)344":
+                // if ingredient is Preserves Jar, we want generic jelly instead of flavored
+                case "(O)344" when ingredient.ItemId != "15":
                     output = ItemRegistry.GetObjectTypeDefinition().CreateFlavoredJelly(ingredient as SObject);
                     break;
 

--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -448,25 +448,34 @@ namespace Pathoschild.Stardew.LookupAnything
         {
             outputId = ItemRegistry.QualifyItemId(outputId);
 
+            bool isIngredientKeg = ingredient.ItemId == "12";
+            bool isIngredientPreservesJar = ingredient.ItemId == "15";
+            bool isIngredientRoe = ingredient.ItemId == "812";
+
             Item output;
             switch (outputId)
             {
-                // if ingredient is Preserves Jar, we want generic pickles instead of flavored
-                case "(O)342" when ingredient.ItemId != "15":
+                // if ingredient is preserves jar we want generic pickles / jelly instead
+                case "(O)342" when !isIngredientPreservesJar:
                     output = ItemRegistry.GetObjectTypeDefinition().CreateFlavoredPickle(ingredient as SObject);
                     break;
 
-                // if ingredient is Preserves Jar, we want generic jelly instead of flavored
-                case "(O)344" when ingredient.ItemId != "15":
+                case "(O)344" when !isIngredientPreservesJar:
                     output = ItemRegistry.GetObjectTypeDefinition().CreateFlavoredJelly(ingredient as SObject);
                     break;
 
-                case "(O)348":
+                // if ingredient is keg we want generic wine / juice instead
+                case "(O)348" when !isIngredientKeg: 
                     output = ItemRegistry.GetObjectTypeDefinition().CreateFlavoredWine(ingredient as SObject);
                     break;
 
-                case "(O)350":
+                case "(O)350" when !isIngredientKeg:
                     output = ItemRegistry.GetObjectTypeDefinition().CreateFlavoredJuice(ingredient as SObject);
+                    break;
+
+                // if ingredient is non-sturgeon roe, get the flavored aged roe. Otherwise we want caviar
+                case "(O)445" when isIngredientRoe && ingredient is SObject ingredientObj && ingredientObj.preservedParentSheetIndex.Value != "698": // 698 = sturgeon
+                    output = ItemRegistry.GetObjectTypeDefinition().CreateFlavoredAgedRoe(ingredient as SObject);
                     break;
 
                 default:
@@ -475,11 +484,11 @@ namespace Pathoschild.Stardew.LookupAnything
             }
 
             if (outputData != null && output is SObject obj)
-            {
-                obj.preservedParentSheetIndex.Value = outputData.PreservedParentSheetIndex ?? obj.preservedParentSheetIndex.Value;
-                obj.preserve.Value = outputData.PreserveType ?? obj.preserve.Value;
-            }
-
+                {
+                    obj.preservedParentSheetIndex.Value = outputData.PreservedParentSheetIndex ?? obj.preservedParentSheetIndex.Value;
+                    obj.preserve.Value = outputData.PreserveType ?? obj.preserve.Value;
+                }
+                                    
             return output;
         }
     }

--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -444,44 +444,38 @@ namespace Pathoschild.Stardew.LookupAnything
         /// <param name="ingredient">The input ingredient.</param>
         /// <param name="outputId">The output item ID.</param>
         /// <param name="outputData">The output data, if applicable.</param>
-        private Item CreateRecipeItem(Item ingredient, string outputId, MachineRecipeOutputData? outputData)
+        private Item CreateRecipeItem(Item? ingredient, string outputId, MachineRecipeOutputData? outputData)
         {
             outputId = ItemRegistry.QualifyItemId(outputId);
 
-            bool isIngredientKeg = ingredient.ItemId == "12";
-            bool isIngredientPreservesJar = ingredient.ItemId == "15";
-            bool isIngredientRoe = ingredient.ItemId == "812";
-
-            Item output;
-            switch (outputId)
+            Item? output = null;
+            if (ingredient is SObject fromObj)
             {
-                // if ingredient is preserves jar we want generic pickles / jelly instead
-                case "(O)342" when !isIngredientPreservesJar:
-                    output = ItemRegistry.GetObjectTypeDefinition().CreateFlavoredPickle(ingredient as SObject);
-                    break;
+                switch (outputId)
+                {
+                    case "(O)342":
+                        output = ItemRegistry.GetObjectTypeDefinition().CreateFlavoredPickle(fromObj);
+                        break;
 
-                case "(O)344" when !isIngredientPreservesJar:
-                    output = ItemRegistry.GetObjectTypeDefinition().CreateFlavoredJelly(ingredient as SObject);
-                    break;
+                    case "(O)344":
+                        output = ItemRegistry.GetObjectTypeDefinition().CreateFlavoredJelly(fromObj);
+                        break;
 
-                // if ingredient is keg we want generic wine / juice instead
-                case "(O)348" when !isIngredientKeg: 
-                    output = ItemRegistry.GetObjectTypeDefinition().CreateFlavoredWine(ingredient as SObject);
-                    break;
+                    case "(O)348":
+                        output = ItemRegistry.GetObjectTypeDefinition().CreateFlavoredWine(fromObj);
+                        break;
 
-                case "(O)350" when !isIngredientKeg:
-                    output = ItemRegistry.GetObjectTypeDefinition().CreateFlavoredJuice(ingredient as SObject);
-                    break;
+                    case "(O)350":
+                        output = ItemRegistry.GetObjectTypeDefinition().CreateFlavoredJuice(fromObj);
+                        break;
 
-                // if ingredient is non-sturgeon roe, get the flavored aged roe. Otherwise we want caviar
-                case "(O)445" when isIngredientRoe && ingredient is SObject ingredientObj && ingredientObj.preservedParentSheetIndex.Value != "698": // 698 = sturgeon
-                    output = ItemRegistry.GetObjectTypeDefinition().CreateFlavoredAgedRoe(ingredient as SObject);
-                    break;
-
-                default:
-                    output = ItemRegistry.Create(outputId);
-                    break;
+                    case "(O)445" when fromObj.preservedParentSheetIndex.Value != "698": // 698 = sturgeon
+                        output = ItemRegistry.GetObjectTypeDefinition().CreateFlavoredAgedRoe(fromObj);
+                        break;
+                }
             }
+
+            output ??= ItemRegistry.Create(outputId);
 
             if (outputData != null && output is SObject obj)
             {

--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -484,11 +484,11 @@ namespace Pathoschild.Stardew.LookupAnything
             }
 
             if (outputData != null && output is SObject obj)
-                {
-                    obj.preservedParentSheetIndex.Value = outputData.PreservedParentSheetIndex ?? obj.preservedParentSheetIndex.Value;
-                    obj.preserve.Value = outputData.PreserveType ?? obj.preserve.Value;
-                }
-                                    
+            {
+                obj.preservedParentSheetIndex.Value = outputData.PreservedParentSheetIndex ?? obj.preservedParentSheetIndex.Value;
+                obj.preserve.Value = outputData.PreserveType ?? obj.preserve.Value;
+            }
+
             return output;
         }
     }

--- a/LookupAnything/Framework/Fields/ItemRecipesField.cs
+++ b/LookupAnything/Framework/Fields/ItemRecipesField.cs
@@ -180,7 +180,9 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                 // (e.g. a recipe with several possible inputs => several recipes with one possible input)
                 .SelectMany(recipe =>
                 {
-                    Item? outputItem = recipe.TryCreateItem(ingredient);
+                    Item? outputItem = recipe.IsForMachine(ingredient)
+                        ? recipe.TryCreateItem(null)
+                        : recipe.TryCreateItem(ingredient);
 
                     RecipeItemEntry output = this.CreateItemEntry(
                         name: recipe.SpecialOutput?.DisplayText ?? outputItem?.DisplayName ?? string.Empty,

--- a/LookupAnything/Framework/Fields/ItemRecipesField.cs
+++ b/LookupAnything/Framework/Fields/ItemRecipesField.cs
@@ -344,7 +344,8 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                 {
                     if (ingredient.PreservedItemId != null)
                         obj.preservedParentSheetIndex.Value = ingredient.PreservedItemId;
-                    if (ingredient.PreserveType != null)
+                    // setting preserve.Value on any Roe breaks its Display Name
+                    if (ingredient.PreserveType != null && ingredient.PreserveType != SObject.PreserveType.Roe)
                         obj.preserve.Value = ingredient.PreserveType.Value;
                 }
 

--- a/LookupAnything/Framework/Fields/ItemRecipesField.cs
+++ b/LookupAnything/Framework/Fields/ItemRecipesField.cs
@@ -344,8 +344,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                 {
                     if (ingredient.PreservedItemId != null)
                         obj.preservedParentSheetIndex.Value = ingredient.PreservedItemId;
-                    // setting preserve.Value on any Roe breaks its Display Name
-                    if (ingredient.PreserveType != null && ingredient.PreserveType != SObject.PreserveType.Roe)
+                    if (ingredient.PreserveType != null)
                         obj.preserve.Value = ingredient.PreserveType.Value;
                 }
 


### PR DESCRIPTION
Fixes https://github.com/Pathoschild/StardewMods/issues/913, which happens on lookups on Preserve Jars due to a `NullReferenceException`. The exception is thrown when roe is created as a recipe item in `ItemRecipeField.TryCreateItemEntry`. I don't know why but updating `preserve.Value` on the roe breaks its display name property, which causes the exception.

I added a check to `TryCreateItemEntry` so we no longer update `preserve.Value` for roe. This fixes the lookup on Preserve Jars, but it reveals another problem with the names of the generic jelly and pickles:

<img width="655" alt="preserves-jar-bugged-recipes" src="https://github.com/Pathoschild/StardewMods/assets/76674774/b0395af3-16ae-4421-9a07-0ae4f564bb95">

I found a similar error on the lookup for Kegs, this time with the names for the generic wine and juice:

<img width="655" alt="keg-bugged-recipes" src="https://github.com/Pathoschild/StardewMods/assets/76674774/a524a4dd-e127-480f-be58-504d7e81a42f">

These are happening in the `CreateRecipeItem` method because when we do a lookup on a Keg or Preserve Jar, the machine becomes the ingredient. We are trying to make a flavored jelly / pickle out of a Preserve Jar and a flavored wine / juice out of a Keg.

To fix the issue I added checks to `CreateRecipeItem`  so that we don't try to create a flavored item out of Kegs or Preserve Jars. I also added logic for when to create flavored aged roe, because I was seeing a bug where looking up any roe would give the caviar recipe.

Here are the lookups for Preserve Jars and Kegs after these changes:

<img width="662" alt="keg-fixed-recipes" src="https://github.com/Pathoschild/StardewMods/assets/76674774/ee031739-f64f-447c-ae8b-7a8803cf6c5e">

<img width="647" alt="preserves-jar-fixed-recipes" src="https://github.com/Pathoschild/StardewMods/assets/76674774/658460ae-e42c-4112-b250-ebe5172f1d50">

