### PR TITLE
Fix JSON syntax in Content Patcher EditData docs

### DIFF
--- a/ContentPatcher/docs/author-guide/action-editdata.md
+++ b/ContentPatcher/docs/author-guide/action-editdata.md
@@ -261,8 +261,9 @@ example, this [adds a new item](https://stardewvalleywiki.com/Modding:Items) wit
                     "Category": -74,
                     "Price": 1200,
                     "Texture": "Mods/{{ModId}}/Objects"
-            }
-        },
+                }
+            },
+        }
     ]
 }
 ```


### PR DESCRIPTION
Fairly self-explanatory -- we had someone confused in #making-mods.

Though this probably ought to be an issue of its own, but is there a reason `js` is being used instead of `json` for styling the code blocks?