### PR TITLE
[LookupAnything] Add support for extra fuels added by ExtraMachineConfig

### DIFF
--- a/Common/Common.projitems
+++ b/Common/Common.projitems
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
@@ -49,6 +49,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\ProducerFrameworkMod\ProducerFrameworkRecipe.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\SimpleSprinkler\ISimplerSprinklerApi.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\SimpleSprinkler\SimpleSprinklerIntegration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Integrations\ExtraMachineConfig\IExtraMachineConfigApi.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Integrations\ExtraMachineConfig\ExtraMachineConfigIntegration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Items\SearchableItem.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Items\ItemRepository.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ListExtensions.cs" />

--- a/Common/Common.projitems
+++ b/Common/Common.projitems
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
@@ -39,6 +39,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\BetterSprinklers\IBetterSprinklersApi.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\CustomFarmingRedux\CustomFarmingReduxIntegration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\CustomFarmingRedux\ICustomFarmingApi.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Integrations\ExtraMachineConfig\ExtraMachineConfigIntegration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Integrations\ExtraMachineConfig\IExtraMachineConfigApi.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\IModIntegration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\LineSprinklers\ILineSprinklersApi.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\LineSprinklers\LineSprinklersIntegration.cs" />
@@ -49,8 +51,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\ProducerFrameworkMod\ProducerFrameworkRecipe.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\SimpleSprinkler\ISimplerSprinklerApi.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\SimpleSprinkler\SimpleSprinklerIntegration.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Integrations\ExtraMachineConfig\IExtraMachineConfigApi.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Integrations\ExtraMachineConfig\ExtraMachineConfigIntegration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Items\SearchableItem.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Items\ItemRepository.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ListExtensions.cs" />

--- a/Common/Integrations/ExtraMachineConfig/ExtraMachineConfigIntegration.cs
+++ b/Common/Integrations/ExtraMachineConfig/ExtraMachineConfigIntegration.cs
@@ -1,0 +1,17 @@
+using StardewModdingAPI;
+
+namespace Pathoschild.Stardew.Common.Integrations.ExtraMachineConfig
+{
+    /// <summary>Handles the logic for integrating with the Custom Bush mod.</summary>
+    internal class ExtraMachineConfigIntegration : BaseIntegration<IExtraMachineConfigApi>
+    {
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="modRegistry">An API for fetching metadata about loaded mods.</param>
+        /// <param name="monitor">Encapsulates monitoring and logging.</param>
+        public ExtraMachineConfigIntegration(IModRegistry modRegistry, IMonitor monitor)
+            : base("ExtraMachineConfig", "selph.ExtraMachineConfig", "1.4.0", modRegistry, monitor) { }
+    }
+}

--- a/Common/Integrations/ExtraMachineConfig/ExtraMachineConfigIntegration.cs
+++ b/Common/Integrations/ExtraMachineConfig/ExtraMachineConfigIntegration.cs
@@ -2,7 +2,7 @@ using StardewModdingAPI;
 
 namespace Pathoschild.Stardew.Common.Integrations.ExtraMachineConfig
 {
-    /// <summary>Handles the logic for integrating with the Custom Bush mod.</summary>
+    /// <summary>Handles the logic for integrating with the Extra Machine Config mod.</summary>
     internal class ExtraMachineConfigIntegration : BaseIntegration<IExtraMachineConfigApi>
     {
         /*********

--- a/Common/Integrations/ExtraMachineConfig/IExtraMachineConfigApi.cs
+++ b/Common/Integrations/ExtraMachineConfig/IExtraMachineConfigApi.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using StardewValley.GameData.Machines;
+using StardewValley.TerrainFeatures;
+
+namespace Pathoschild.Stardew.Common.Integrations.ExtraMachineConfig
+{
+    /// <summary>The API provided by the Custom Bush mod.</summary>
+    [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "The naming convention is defined by the Custom Bush mod.")]
+    public interface IExtraMachineConfigApi
+    {
+        /// <summary>Retrieves the extra fuels consumed by this recipe.</summary>
+        IList<(string, int)> GetExtraRequirements(MachineItemOutput outputData);
+
+        /// <summary>Retrieves the extra tag-defined fuels consumed by this recipe.</summary>
+        IList<(string, int)> GetExtraTagsRequirements(MachineItemOutput outputData);
+    }
+}

--- a/Common/Integrations/ExtraMachineConfig/IExtraMachineConfigApi.cs
+++ b/Common/Integrations/ExtraMachineConfig/IExtraMachineConfigApi.cs
@@ -1,18 +1,17 @@
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using StardewValley.GameData.Machines;
-using StardewValley.TerrainFeatures;
 
 namespace Pathoschild.Stardew.Common.Integrations.ExtraMachineConfig
 {
-    /// <summary>The API provided by the Custom Bush mod.</summary>
-    [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "The naming convention is defined by the Custom Bush mod.")]
+    /// <summary>The API provided by the Extra Machine Config mod.</summary>
     public interface IExtraMachineConfigApi
     {
         /// <summary>Retrieves the extra fuels consumed by this recipe.</summary>
+        /// <param name="outputData">The output rule to check.</param>
         IList<(string, int)> GetExtraRequirements(MachineItemOutput outputData);
 
         /// <summary>Retrieves the extra tag-defined fuels consumed by this recipe.</summary>
+        /// <param name="outputData">The output rule to check.</param>
         IList<(string, int)> GetExtraTagsRequirements(MachineItemOutput outputData);
     }
 }

--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Pathoschild.Stardew.Common;
+using Pathoschild.Stardew.Common.Integrations.ExtraMachineConfig;
 using Pathoschild.Stardew.LookupAnything.Framework;
 using Pathoschild.Stardew.LookupAnything.Framework.Constants;
 using Pathoschild.Stardew.LookupAnything.Framework.Data;
@@ -369,7 +370,8 @@ namespace Pathoschild.Stardew.LookupAnything
         /// <summary>Get the recipe ingredients.</summary>
         /// <param name="metadata">Provides metadata that's not available from the game data directly.</param>
         /// <param name="monitor">The monitor with which to log errors.</param>
-        public RecipeModel[] GetRecipes(Metadata metadata, IMonitor monitor)
+        /// <param name="extraMachineConfig">API integration with extra fuels added by the Extra Machine Config mod.</param>
+        public RecipeModel[] GetRecipes(Metadata metadata, IMonitor monitor, ExtraMachineConfigIntegration extraMachineConfig)
         {
             List<RecipeModel> recipes = new List<RecipeModel>();
 
@@ -442,6 +444,26 @@ namespace Pathoschild.Stardew.LookupAnything
                                 new RecipeIngredientModel(inputId, trigger.RequiredCount, inputContextTags)
                             };
                             ingredients.AddRange(additionalConsumedItems);
+
+                            // if there are extra fuels added by the Extra Machine Config mod, add them here
+                            if (extraMachineConfig.IsLoaded)
+                            {
+                                foreach (var extraFuelEntry in extraMachineConfig.ModApi.GetExtraRequirements(outputItem))
+                                {
+                                    ingredients.Add(new RecipeIngredientModel(
+                                                extraFuelEntry.Item1,
+                                                extraFuelEntry.Item2,
+                                                null));
+                                }
+                                foreach (var extraTagFuelEntry in extraMachineConfig.ModApi.GetExtraTagsRequirements(outputItem))
+                                {
+                                    ingredients.Add(new RecipeIngredientModel(
+                                                null,
+                                                extraTagFuelEntry.Item2,
+                                                extraTagFuelEntry.Item1.Split(","),
+                                                null));
+                                }
+                            }
 
                             // add produced item
                             ItemQueryContext itemQueryContext = new();

--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -370,7 +370,7 @@ namespace Pathoschild.Stardew.LookupAnything
         /// <summary>Get the recipe ingredients.</summary>
         /// <param name="metadata">Provides metadata that's not available from the game data directly.</param>
         /// <param name="monitor">The monitor with which to log errors.</param>
-        /// <param name="extraMachineConfig">API integration with extra fuels added by the Extra Machine Config mod.</param>
+        /// <param name="extraMachineConfig">The Extra Machine Config mod's API.</param>
         public RecipeModel[] GetRecipes(Metadata metadata, IMonitor monitor, ExtraMachineConfigIntegration extraMachineConfig)
         {
             List<RecipeModel> recipes = new List<RecipeModel>();
@@ -448,21 +448,11 @@ namespace Pathoschild.Stardew.LookupAnything
                             // if there are extra fuels added by the Extra Machine Config mod, add them here
                             if (extraMachineConfig.IsLoaded)
                             {
-                                foreach (var extraFuelEntry in extraMachineConfig.ModApi.GetExtraRequirements(outputItem))
-                                {
-                                    ingredients.Add(new RecipeIngredientModel(
-                                                extraFuelEntry.Item1,
-                                                extraFuelEntry.Item2,
-                                                null));
-                                }
-                                foreach (var extraTagFuelEntry in extraMachineConfig.ModApi.GetExtraTagsRequirements(outputItem))
-                                {
-                                    ingredients.Add(new RecipeIngredientModel(
-                                                null,
-                                                extraTagFuelEntry.Item2,
-                                                extraTagFuelEntry.Item1.Split(","),
-                                                null));
-                                }
+                                foreach ((string extraItemId, int extraCount) in extraMachineConfig.ModApi.GetExtraRequirements(outputItem))
+                                    ingredients.Add(new RecipeIngredientModel(extraItemId, extraCount));
+
+                                foreach ((string extraContextTags, int extraCount) in extraMachineConfig.ModApi.GetExtraTagsRequirements(outputItem))
+                                    ingredients.Add(new RecipeIngredientModel(null, extraCount, extraContextTags.Split(",")));
                             }
 
                             // add produced item

--- a/LookupAnything/GameHelper.cs
+++ b/LookupAnything/GameHelper.cs
@@ -79,9 +79,8 @@ namespace Pathoschild.Stardew.LookupAnything
         /// <summary>The MultiFertilizer integration.</summary>
         public MultiFertilizerIntegration MultiFertilizer { get; }
 
-        /// <summary>The ExtraMachineConfig integration.</summary>
+        /// <summary>The Extra Machine Config integration.</summary>
         public ExtraMachineConfigIntegration ExtraMachineConfig { get; }
-
 
 
         /*********
@@ -99,10 +98,10 @@ namespace Pathoschild.Stardew.LookupAnything
             this.ModRegistry = modRegistry;
             this.WorldItemScanner = new WorldItemScanner(reflection);
 
-            this.CustomBush = new CustomBushIntegration(modRegistry, this.Monitor);
-            this.CustomFarmingRedux = new CustomFarmingReduxIntegration(modRegistry, this.Monitor);
+            this.CustomBush = new CustomBushIntegration(modRegistry, monitor);
+            this.CustomFarmingRedux = new CustomFarmingReduxIntegration(modRegistry, monitor);
             this.MultiFertilizer = new MultiFertilizerIntegration(modRegistry, monitor);
-            this.ProducerFrameworkMod = new ProducerFrameworkModIntegration(modRegistry, this.Monitor);
+            this.ProducerFrameworkMod = new ProducerFrameworkModIntegration(modRegistry, monitor);
             this.ExtraMachineConfig = new ExtraMachineConfigIntegration(modRegistry, monitor);
 
             this.ResetCache(monitor);

--- a/LookupAnything/GameHelper.cs
+++ b/LookupAnything/GameHelper.cs
@@ -7,6 +7,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Pathoschild.Stardew.Common;
 using Pathoschild.Stardew.Common.Integrations.CustomBush;
 using Pathoschild.Stardew.Common.Integrations.CustomFarmingRedux;
+using Pathoschild.Stardew.Common.Integrations.ExtraMachineConfig;
 using Pathoschild.Stardew.Common.Integrations.MultiFertilizer;
 using Pathoschild.Stardew.Common.Integrations.ProducerFrameworkMod;
 using Pathoschild.Stardew.Common.Items;
@@ -78,6 +79,10 @@ namespace Pathoschild.Stardew.LookupAnything
         /// <summary>The MultiFertilizer integration.</summary>
         public MultiFertilizerIntegration MultiFertilizer { get; }
 
+        /// <summary>The ExtraMachineConfig integration.</summary>
+        public ExtraMachineConfigIntegration ExtraMachineConfig { get; }
+
+
 
         /*********
         ** Public methods
@@ -98,6 +103,7 @@ namespace Pathoschild.Stardew.LookupAnything
             this.CustomFarmingRedux = new CustomFarmingReduxIntegration(modRegistry, this.Monitor);
             this.MultiFertilizer = new MultiFertilizerIntegration(modRegistry, monitor);
             this.ProducerFrameworkMod = new ProducerFrameworkModIntegration(modRegistry, this.Monitor);
+            this.ExtraMachineConfig = new ExtraMachineConfigIntegration(modRegistry, monitor);
 
             this.ResetCache(monitor);
         }
@@ -644,7 +650,7 @@ namespace Pathoschild.Stardew.LookupAnything
         private RecipeModel[] GetAllRecipes(IMonitor monitor)
         {
             // get vanilla recipes
-            List<RecipeModel> recipes = this.DataParser.GetRecipes(this.Metadata, monitor).ToList();
+            List<RecipeModel> recipes = this.DataParser.GetRecipes(this.Metadata, monitor, this.ExtraMachineConfig).ToList();
 
             // get recipes from Producer Framework Mod
             if (this.ProducerFrameworkMod.IsLoaded)


### PR DESCRIPTION
[Extra Machine Config](https://www.nexusmods.com/stardewvalley/mods/22256) allows machine recipes to define extra inputs aside from the main input and the machine's global fuel.

This mod's API has 2 functions:
- `GetExtraRequirements`: returns a map of fuel qualified ID to quantity for the specified output item rule.
- `GetExtraTagRequirements`: same as above, but the key is a context tag list instead.

To test, you can install [Visit Mount Vapius](https://www.nexusmods.com/stardewvalley/mods/9600). With EMC installed some recipes are modified to have different or multiple additional inputs:

- Jewelry Machine: Flower Globe use Glass Shard instead of Gold Bar like the rest of the recipes in the Jewelry Machine
- Preserves Jar: Tapenade needs Anchovy as additional input
- Loom: Night Silk needs bat wings
- Loom: Night Silk can also be made using silk flowers, bat wings and wool