### PR TITLE
[LookupAnything] Fix machine lookup issues for mods that use both item IDs and context tags

### DIFF
--- a/LookupAnything/Framework/Fields/ItemRecipesField.cs
+++ b/LookupAnything/Framework/Fields/ItemRecipesField.cs
@@ -440,9 +440,12 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
 
                 if (input is not null)
                 {
+                    string name = input.DisplayName ?? input.ItemId;
+                    if (ingredient.InputContextTags.Length > 0) // if the item has both item ID and context tags, show tags to disambiguate
+                        name += $" ({string.Join(", ", ingredient.InputContextTags.Select(HumanReadableContextTagParser.Parse))})";
+
                     return this.CreateItemEntry(
-                        name: (input.DisplayName ?? string.Empty)
-                        + (ingredient.InputContextTags.Length > 0 ? $" ({string.Join(", ", ingredient.InputContextTags.Select(HumanReadableContextTagParser.Parse))})" : string.Empty),
+                        name: name,
                         item: input,
                         minCount: ingredient.Count,
                         maxCount: ingredient.Count

--- a/LookupAnything/Framework/Fields/ItemRecipesField.cs
+++ b/LookupAnything/Framework/Fields/ItemRecipesField.cs
@@ -441,7 +441,8 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                 if (input is not null)
                 {
                     return this.CreateItemEntry(
-                        name: input.DisplayName ?? string.Empty,
+                        name: (input.DisplayName ?? string.Empty)
+                        + (ingredient.InputContextTags.Length > 0 ? $" ({string.Join(", ", ingredient.InputContextTags.Select(HumanReadableContextTagParser.Parse))})" : string.Empty),
                         item: input,
                         minCount: ingredient.Count,
                         maxCount: ingredient.Count

--- a/LookupAnything/Framework/Models/RecipeIngredientModel.cs
+++ b/LookupAnything/Framework/Models/RecipeIngredientModel.cs
@@ -54,10 +54,15 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Models
 
             // item fields
             bool matchesId =
-                this.InputId == item.Category.ToString()
+                (this.InputId != null || this.InputContextTags.Length > 0)
+                &&
+                (this.InputId == null
+                || this.InputId == item.Category.ToString()
                 || this.InputId == item.ItemId
-                || this.InputId == item.QualifiedItemId
-                || ItemContextTagManager.DoAllTagsMatch(this.InputContextTags, item.GetContextTags());
+                || this.InputId == item.QualifiedItemId)
+                &&
+                (this.InputContextTags.Length == 0
+                || ItemContextTagManager.DoAllTagsMatch(this.InputContextTags, item.GetContextTags()));
             if (!matchesId)
                 return false;
 

--- a/LookupAnything/Framework/Models/RecipeIngredientModel.cs
+++ b/LookupAnything/Framework/Models/RecipeIngredientModel.cs
@@ -55,14 +55,16 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Models
             // item fields
             bool matchesId =
                 (this.InputId != null || this.InputContextTags.Length > 0)
-                &&
-                (this.InputId == null
-                || this.InputId == item.Category.ToString()
-                || this.InputId == item.ItemId
-                || this.InputId == item.QualifiedItemId)
-                &&
-                (this.InputContextTags.Length == 0
-                || ItemContextTagManager.DoAllTagsMatch(this.InputContextTags, item.GetContextTags()));
+                && (
+                    this.InputId == null
+                    || this.InputId == item.Category.ToString()
+                    || this.InputId == item.ItemId
+                    || this.InputId == item.QualifiedItemId
+                )
+                && (
+                    this.InputContextTags.Length == 0
+                    || ItemContextTagManager.DoAllTagsMatch(this.InputContextTags, item.GetContextTags())
+                );
             if (!matchesId)
                 return false;
 


### PR DESCRIPTION
The issue reported on the Nexus page (unrelated recipes showing up in item lookups) is caused by mods that add recipes that use both item IDs and context tags. The code currently assumes that only one will be used, and thus match every item that matches either one or the other, not both.

Additionally, change the lookup display field to also append context tags to the item ID if applicable.

To test, install the [Copper Still](https://www.nexusmods.com/stardewvalley/mods/15333) mod. Before this PR a couple of its recipes will show up in every item lookup because it defines a recipe with both `"RequiredItemId": "(O)348"` (Wine) and `"RequiredTags": [ "!preserve_sheet_index_90" ]` (not Cactus Fruit flavored), and the latter is matching with every item in the game. After this fix they should no longer show up, and will also display properly when the Still is looked up.