### PR TITLE
[LookupAnything] Don't show recipes for nonexistent machines

### DIFF
--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -407,10 +407,7 @@ namespace Pathoschild.Stardew.LookupAnything
             {
                 string qualifiedMachineId = entryKey; // avoid referencing loop variable in closure
 
-                if (ItemRegistry.ResolveMetadata(qualifiedMachineId) == null)
-                    continue;
-
-                if (machineData?.OutputRules?.Count is not > 0)
+                if (!ItemRegistry.Exists(qualifiedMachineId) || machineData?.OutputRules?.Count is not > 0)
                     continue;
 
                 RecipeIngredientModel[] additionalConsumedItems =

--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -407,6 +407,9 @@ namespace Pathoschild.Stardew.LookupAnything
             {
                 string qualifiedMachineId = entryKey; // avoid referencing loop variable in closure
 
+                if (ItemRegistry.ResolveMetadata(qualifiedMachineId) == null)
+                    continue;
+
                 if (machineData?.OutputRules?.Count is not > 0)
                     continue;
 


### PR DESCRIPTION
Some mods (ie. H&W Baking) has config options that toggles machines on and off while still leaving their recipe data in Data/Machines intact. Those recipes are, by proxy, disabled because there are no machines to process them, but they still show up in ingredient lookup regardless. This change stops those recipes from showing up.

(modders on Discord suggest still showing these if show debug is on. I'm not sure how I would implement that, so leaving it up to you whether you think the idea is useful).