### PR TITLE
[ChestsAnywhere] Feature: Auto item sorting from anywhere

### DIFF
--- a/ChestsAnywhere/Framework/GenericModConfigMenuIntegrationForChestsAnywhere.cs
+++ b/ChestsAnywhere/Framework/GenericModConfigMenuIntegrationForChestsAnywhere.cs
@@ -77,6 +77,20 @@ namespace Pathoschild.Stardew.ChestsAnywhere.Framework
                     allowedValues: Enum.GetNames<ChestRange>(),
                     formatAllowedValue: name => I18n.GetByKey($"config.range.{name}")
                 )
+                .AddCheckbox(
+                    name: I18n.Config_AutoSorter_Name,
+                    tooltip: I18n.Config_AutoSorter_Desc,
+                    get: config => config.EnableAutoSort,
+                    set: (config, value) => config.EnableAutoSort = value
+                )
+                .AddDropdown(
+                    name: I18n.Config_AutoSorterRange_Name,
+                    tooltip: I18n.Config_AutoSorterRange_Desc,
+                    get: config => config.AutoSortRange.ToString(),
+                    set: (config, value) => config.AutoSortRange = Enum.Parse<ChestRange>(value, ignoreCase: true),
+                    allowedValues: Enum.GetNames<ChestRange>(),
+                    formatAllowedValue: name => I18n.GetByKey($"config.auto-sorter-range.{name}")
+                )
 
                 .AddSectionTitle(I18n.Config_Title_GeneralControls)
                 .AddKeyBinding(
@@ -134,6 +148,12 @@ namespace Pathoschild.Stardew.ChestsAnywhere.Framework
                     tooltip: I18n.Config_HoldToScrollChests_Desc,
                     get: config => config.Controls.HoldToMouseWheelScrollChests,
                     set: (config, value) => config.Controls.HoldToMouseWheelScrollChests = value
+                )
+                .AddKeyBinding(
+                    name: I18n.Config_AutoSorterKey_Name,
+                    tooltip: I18n.Config_AutoSorterKey_Desc,
+                    get: config => config.Controls.AutoSortItems,
+                    set: (config, value) => config.Controls.AutoSortItems = value
                 )
 
                 .AddSectionTitle(I18n.Config_Title_DisableInLocations)

--- a/ChestsAnywhere/Framework/GenericModConfigMenuIntegrationForChestsAnywhere.cs
+++ b/ChestsAnywhere/Framework/GenericModConfigMenuIntegrationForChestsAnywhere.cs
@@ -99,6 +99,12 @@ namespace Pathoschild.Stardew.ChestsAnywhere.Framework
                     get: config => config.Controls.Toggle,
                     set: (config, value) => config.Controls.Toggle = value
                 )
+                .AddKeyBinding(
+                    name: I18n.Config_AutoSorterKey_Name,
+                    tooltip: I18n.Config_AutoSorterKey_Desc,
+                    get: config => config.Controls.AutoSortItems,
+                    set: (config, value) => config.Controls.AutoSortItems = value
+                )
 
                 .AddSectionTitle(I18n.Config_Title_MenuControls)
                 .AddKeyBinding(
@@ -148,12 +154,6 @@ namespace Pathoschild.Stardew.ChestsAnywhere.Framework
                     tooltip: I18n.Config_HoldToScrollChests_Desc,
                     get: config => config.Controls.HoldToMouseWheelScrollChests,
                     set: (config, value) => config.Controls.HoldToMouseWheelScrollChests = value
-                )
-                .AddKeyBinding(
-                    name: I18n.Config_AutoSorterKey_Name,
-                    tooltip: I18n.Config_AutoSorterKey_Desc,
-                    get: config => config.Controls.AutoSortItems,
-                    set: (config, value) => config.Controls.AutoSortItems = value
                 )
 
                 .AddSectionTitle(I18n.Config_Title_DisableInLocations)

--- a/ChestsAnywhere/Framework/ModConfig.cs
+++ b/ChestsAnywhere/Framework/ModConfig.cs
@@ -35,6 +35,11 @@ namespace Pathoschild.Stardew.ChestsAnywhere.Framework
         [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Auto)]
         public HashSet<string> DisabledInLocations { get; } = new(StringComparer.OrdinalIgnoreCase);
 
+        /// <sumary>Wheter to anable the auto sort feature.</sumary>
+        public bool EnableAutoSort = false;
+
+        /// <sumary>The ranage at which auto sort will work.</sumary>
+        public ChestRange AutoSortRange { get; set; } = ChestRange.Unlimited;
 
         /*********
         ** Public methods

--- a/ChestsAnywhere/Framework/ModConfigKeys.cs
+++ b/ChestsAnywhere/Framework/ModConfigKeys.cs
@@ -39,6 +39,8 @@ namespace Pathoschild.Stardew.ChestsAnywhere.Framework
         /// <summary>The keys which, when held, enable scrolling the category dropdown with the mouse scroll wheel.</summary>
         public KeybindList HoldToMouseWheelScrollCategories { get; set; } = new(SButton.LeftAlt);
 
+        /// <summary>The keys which, when held, will automatically sort the player itens.</summary>
+        public KeybindList AutoSortItems { get; set; } = new(SButton.R);
 
         /*********
         ** Public methods
@@ -59,6 +61,7 @@ namespace Pathoschild.Stardew.ChestsAnywhere.Framework
             this.SortItems ??= new KeybindList();
             this.HoldToMouseWheelScrollChests ??= new KeybindList();
             this.HoldToMouseWheelScrollCategories ??= new KeybindList();
+            this.AutoSortItems ??= new KeybindList();
         }
     }
 }

--- a/ChestsAnywhere/ModEntry.cs
+++ b/ChestsAnywhere/ModEntry.cs
@@ -401,16 +401,19 @@ namespace Pathoschild.Stardew.ChestsAnywhere
                                         // If stack is half full, fill it and search other stack
                                         else if ((chestItem.Stack + item.Stack) >= chestItem.maximumStackSize())
                                         {
+
                                             int toStore = chestItem.maximumStackSize() - chestItem.Stack;
-                                            Item toAdd = item.DeepClone();
-                                            toAdd.Stack = toStore;
-                                            chest.addItem(toAdd);
+                                            chestItem.Stack += toStore;
 
                                             // Avoid a bug where we left a "ghost" stack to the player
-                                            if ((item.Stack - toStore) == 0)
-                                                Game1.player.removeItemFromInventory(item);
-                                            else
+                                            if ((item.Stack - toStore) != 0)
                                                 item.Stack -= toStore;
+                                            else
+                                            {
+                                                Game1.player.removeItemFromInventory(item);
+                                                somethingWasSorted = true;
+                                                break;
+                                            }
 
                                             somethingWasSorted = true;
                                             continue;

--- a/ChestsAnywhere/ModEntry.cs
+++ b/ChestsAnywhere/ModEntry.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Force.DeepCloner;
 using Microsoft.Xna.Framework;
@@ -363,14 +364,18 @@ namespace Pathoschild.Stardew.ChestsAnywhere
             if (this.Config.EnableAutoSort)
             {
                 bool somethingWasSorted = false;
+                bool stopLookingForThisItem;
+                IEnumerable<ManagedChest> managedChests = this.ChestFactory.GetChests(this.GetAutoSortCurrentRange(), true);
 
                 // For each item in the player inventory
                 foreach(var item in Game1.player.Items)
                 {
+                    stopLookingForThisItem = false;
+
                     if (item != null)
                     {
                         // For each chest in the range
-                        foreach(var managedChest in this.ChestFactory.GetChests(this.GetAutoSortCurrentRange(), true))
+                        foreach(var managedChest in managedChests)
                         {
                             // TODO - Maybe let the player configure where to auto sort
                             if (managedChest.MapEntity is Chest)
@@ -409,11 +414,15 @@ namespace Pathoschild.Stardew.ChestsAnywhere
                                             chest.addItem(item);
                                             Game1.player.removeItemFromInventory(item);
                                             somethingWasSorted = true;
+                                            stopLookingForThisItem = true;
                                             break;
                                         }
                                     }
                                 }
-                            } 
+                            }
+
+                            if (stopLookingForThisItem)
+                                break;
                         }
                     }
                 }

--- a/ChestsAnywhere/ModEntry.cs
+++ b/ChestsAnywhere/ModEntry.cs
@@ -365,6 +365,8 @@ namespace Pathoschild.Stardew.ChestsAnywhere
             {
                 bool somethingWasSorted = false;
                 bool stopLookingForThisItem;
+                
+                // All chests in the farm
                 IEnumerable<ManagedChest> managedChests = this.ChestFactory.GetChests(this.GetAutoSortCurrentRange(), true);
 
                 // For each item in the player inventory
@@ -414,6 +416,7 @@ namespace Pathoschild.Stardew.ChestsAnywhere
                                             chest.addItem(item);
                                             Game1.player.removeItemFromInventory(item);
                                             somethingWasSorted = true;
+                                            // If we sorted the entire stack, we can stop look into the chests
                                             stopLookingForThisItem = true;
                                             break;
                                         }
@@ -421,6 +424,7 @@ namespace Pathoschild.Stardew.ChestsAnywhere
                                 }
                             }
 
+                            // Stop the search into the chests
                             if (stopLookingForThisItem)
                                 break;
                         }

--- a/ChestsAnywhere/ModEntry.cs
+++ b/ChestsAnywhere/ModEntry.cs
@@ -366,8 +366,8 @@ namespace Pathoschild.Stardew.ChestsAnywhere
                 bool somethingWasSorted = false;
                 bool stopLookingForThisItem;
                 
-                // All chests in the farm
-                IEnumerable<ManagedChest> managedChests = this.ChestFactory.GetChests(this.GetAutoSortCurrentRange(), true);
+                RangeHandler range = this.GetAutoSortCurrentRange();
+                ManagedChest[] managedChests = this.ChestFactory.GetChests(range, true).ToArray();
 
                 // For each item in the player inventory
                 foreach(var item in Game1.player.Items)
@@ -383,12 +383,17 @@ namespace Pathoschild.Stardew.ChestsAnywhere
                             if (managedChest.MapEntity is Chest)
                             {
                                 Chest chest = (Chest)managedChest.MapEntity;
+                                Item?[] chestItems = managedChest.Container.Inventory.ToArray();
 
                                 // Check each chest inventory slot 
-                                foreach(var chestItem in managedChest.Container.Inventory)
+                                foreach(var chestItem in chestItems)
                                 {
+                                    // Skip this chest slot if it is empty
+                                    if (chestItem == null)
+                                        continue;
+
                                     // Check for the item match
-                                    if (chestItem != null && chestItem.Name == item.Name && chestItem.Quality == item.Quality)
+                                    if (chestItem.Name == item.Name && chestItem.Quality == item.Quality)
                                     {
                                         // if stack is full, try to search for other stack inside the chest
                                         if (chestItem.Stack == chestItem.maximumStackSize())
@@ -398,7 +403,7 @@ namespace Pathoschild.Stardew.ChestsAnywhere
                                         else if ((chestItem.Stack + item.Stack) >= chestItem.maximumStackSize())
                                         {
                                             int toStore = chestItem.maximumStackSize() - chestItem.Stack;
-                                            Item toAdd = item.DeepClone<Item>();
+                                            Item toAdd = item.DeepClone();
                                             toAdd.Stack = toStore;
                                             chest.addItem(toAdd);
 
@@ -418,6 +423,7 @@ namespace Pathoschild.Stardew.ChestsAnywhere
                                             chest.addItem(item);
                                             Game1.player.removeItemFromInventory(item);
                                             somethingWasSorted = true;
+
                                             // If we sorted the entire stack, we can stop look into the chests
                                             stopLookingForThisItem = true;
                                             break;

--- a/ChestsAnywhere/ModEntry.cs
+++ b/ChestsAnywhere/ModEntry.cs
@@ -395,16 +395,18 @@ namespace Pathoschild.Stardew.ChestsAnywhere
                                             continue;
 
                                         // If stack is half full, fill it and search other stack
-                                        else if((chestItem.Stack + item.Stack) >= chestItem.maximumStackSize())
+                                        else if ((chestItem.Stack + item.Stack) >= chestItem.maximumStackSize())
                                         {
                                             int toStore = chestItem.maximumStackSize() - chestItem.Stack;
                                             Item toAdd = item.DeepClone<Item>();
                                             toAdd.Stack = toStore;
                                             chest.addItem(toAdd);
 
-                                            // Avoid a simple bug where we left a "ghost" stack to the player
-                                            if ((item.Stack -= toStore) == 0)
+                                            // Avoid a bug where we left a "ghost" stack to the player
+                                            if ((item.Stack - toStore) == 0)
                                                 Game1.player.removeItemFromInventory(item);
+                                            else
+                                                item.Stack -= toStore;
 
                                             somethingWasSorted = true;
                                             continue;

--- a/ChestsAnywhere/ModEntry.cs
+++ b/ChestsAnywhere/ModEntry.cs
@@ -380,17 +380,16 @@ namespace Pathoschild.Stardew.ChestsAnywhere
                         foreach(var managedChest in managedChests)
                         {
                             // TODO - Maybe let the player configure where to auto sort
-                            if (managedChest.MapEntity is Chest)
+                            if (managedChest.MapEntity is Chest chest)
                             {
-                                Chest chest = (Chest)managedChest.MapEntity;
-                                Item?[] chestItems = managedChest.Container.Inventory.ToArray();
+                                Item?[] chestItems = [.. managedChest.Container.Inventory];
 
                                 // Check each chest inventory slot 
-                                foreach(var chestItem in chestItems)
+                                foreach (var chestItem in chestItems)
                                 {
-                                    // Skip this chest slot if it is empty
+                                    // Skip this chest if slot is empty
                                     if (chestItem == null)
-                                        continue;
+                                        break;
 
                                     // Check for the item match
                                     if (chestItem.Name == item.Name && chestItem.Quality == item.Quality)

--- a/ChestsAnywhere/ModEntry.cs
+++ b/ChestsAnywhere/ModEntry.cs
@@ -187,8 +187,11 @@ namespace Pathoschild.Stardew.ChestsAnywhere
 
                 // Auto sorter
                 if (keys.AutoSortItems.JustPressed())
-                    this.AutoSorter();
-
+                {   
+                    // Only do it if the player doesnt have a open menu
+                    if (Game1.activeClickableMenu == null)
+                        this.AutoSorter();
+                }
             }
             catch (Exception ex)
             {

--- a/ChestsAnywhere/i18n/default.json
+++ b/ChestsAnywhere/i18n/default.json
@@ -72,6 +72,16 @@
     "config.range.currentLocation": "Chests within the current location",
     "config.range.none": "None (can't access chests remotely)",
 
+    "config.auto-sorter.name": "Enable auto sort",
+    "config.auto-sorter.desc": "Whether to enable the auto item sorter from anywhere feature.",
+
+    "config.auto-sorter-range.name": "Auto sort range",
+    "config.auto-sorter-range.desc": "The range at which chests are accessible to the auto sorter.",
+    "config.auto-sorter-range.unlimited": "All chests",
+    "config.auto-sorter-range.currentWorldArea": "Chests within the current world area",
+    "config.auto-sorter-range.currentLocation": "Chests within the current location",
+    "config.auto-sorter-range.none": "None (can't access chests remotely)",
+
     /****
     ** general controls
     ****/
@@ -79,6 +89,9 @@
 
     "config.toggle-ui-key.name": "Toggle UI",
     "config.toggle-ui-key.desc": "The keys which show or hide the chest UI.",
+
+    "config.auto-sorter-key.name": "Auto sort items",
+    "config.auto-sorter-key.desc": "The keys which will automatically sort player items into chests.",
 
     /****
     ** controls when chest UI is open
@@ -118,5 +131,11 @@
     "config.disable-mines.desc": "Whether to disable accessing chests while in the mines or Skull Cavern.",
 
     "config.disable-custom-names.name": "Custom location names",
-    "config.disable-custom-names.desc": "The internal names (as shown by the Debug Mode mod) for locations from which to disable accessing chests. You can list multiple with commas."
+    "config.disable-custom-names.desc": "The internal names (as shown by the Debug Mode mod) for locations from which to disable accessing chests. You can list multiple with commas.",
+
+    /**********
+    ** Ingame alerts
+    **********/
+    "alert.auto-sorter.sorted": "Items sorted!",
+    "alert.auto-sorter.not-sorted": "No items sorted."
 }

--- a/ChestsAnywhere/i18n/pt.json
+++ b/ChestsAnywhere/i18n/pt.json
@@ -72,6 +72,16 @@
     "config.range.currentLocation": "Baús dentro da localização atual",
     "config.range.none": "Nenhum (não é possível acessar os baús remotamente)",
 
+    "config.auto-sorter.name": "Habilitar organizador automático",
+    "config.auto-sorter.desc": "Habilitar a funcionalidade de organziar item de qualquer lugar.",
+
+    "config.auto-sorter-range.name": "Alcance do organizador automático",
+    "config.auto-sorter-range.desc": "O alcance em que os baús são acessíveis ao organizador automático.",
+    "config.auto-sorter-range.unlimited": "Todos os baús",
+    "config.auto-sorter-range.currentWorldArea": "Baús dentro da área atual do mundo",
+    "config.auto-sorter-range.currentLocation": "Baús dentro da localização atual",
+    "config.auto-sorter-range.none": "Nenhum (não é possível acessar os baús remotamente)",
+
     /****
     ** general controls
     ****/
@@ -79,6 +89,9 @@
 
     "config.toggle-ui-key.name": "Alternar interface",
     "config.toggle-ui-key.desc": "As teclas que mostram ou ocultam a interface do baú.",
+
+    "config.auto-sorter-key.name": "Organizador automático",
+    "config.auto-sorter-key.desc": "As teclas que organizaram automaticamente o inventário do jogador em baús.",
 
     /****
     ** controls when chest UI is open
@@ -118,5 +131,11 @@
     "config.disable-mines.desc": "Se deve desabilitar o acesso aos baús enquanto estiver nas Minas ou na Caverna da Caveira.",
 
     "config.disable-custom-names.name": "Nomes de locais personalizados",
-    "config.disable-custom-names.desc": "Os nomes internos (como mostrado pelo mod Debug Mode) para locais onde desabilitar o acesso aos baús. Você pode listar vários nomes separando-os por vírgulas."
+    "config.disable-custom-names.desc": "Os nomes internos (como mostrado pelo mod Debug Mode) para locais onde desabilitar o acesso aos baús. Você pode listar vários nomes separando-os por vírgulas.",
+
+    /**********
+    ** Ingame alerts
+    **********/
+    "alert.auto-sorter.sorted": "Itens organizados!",
+    "alert.auto-sorter.not-sorted": "Nenhum item foi organizado."
 }


### PR DESCRIPTION
This is a new **optional** feature that allows the player to automatically sort all items from their inventory into chests from anywhere.

### How it works
Basically, we look into the player inventory and for each item, we try to find a **chest** that have a similar item stored. For now, I think that this feature only make sense to store items into **chests**, but this could be easily configurable.

After looking for a chest, we check the item stacks in order to try to store the item, the conditions to store an item are the following:

- If a chest have an item with the same name and quality, proceeds with the checking stage;
- If the chest item stack is full, search for other stack;
- If the chest item stack is half-full, store X items until the stack is full and search for other stack;
- If the stack can accept all the player items, stores than and stop checking for other stacks;

By the end of the process, we show a simple message to the player using `Game1.addHUDMessage` to any item was sorted or not.

### How it would be shipped
This feature could be quite "op", so it's shipped as disabled by default.

The player can also change the range of the item sorter, as well as the key to sort the items if they so desire.

### Regarding translations
As I only speak Portuguese and English, I only did the translations for those languages, so any help with the other languages would be great!

### Final words
That's my first time trying to add a feature to a mod, so any feedback is welcome :P
