### PR TITLE
Add the ability to 'patch reload' a specific json in your content pack.

### DIFF
--- a/ContentPatcher/Framework/Commands/CommandHandler.cs
+++ b/ContentPatcher/Framework/Commands/CommandHandler.cs
@@ -56,6 +56,7 @@ namespace ContentPatcher.Framework.Commands
                 new ReloadCommand(
                     monitor: monitor,
                     getPatchLoader: () => screenManager.Value.PatchLoader,
+                    getPatchManager: () => screenManager.Value.PatchManager,
                     contentPacks: contentPacks,
                     updateContext: updateContext
                 ),

--- a/ContentPatcher/Framework/Commands/Commands/ReloadCommand.cs
+++ b/ContentPatcher/Framework/Commands/Commands/ReloadCommand.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Linq;
+using ContentPatcher.Framework.Patches;
 using Pathoschild.Stardew.Common.Commands;
 using StardewModdingAPI;
+using StardewModdingAPI.Utilities;
 
 namespace ContentPatcher.Framework.Commands.Commands
 {
@@ -13,6 +15,9 @@ namespace ContentPatcher.Framework.Commands.Commands
         *********/
         /// <summary>Manages loading and unloading patches.</summary>
         private readonly Func<PatchLoader> GetPatchLoader;
+
+        /// <summary>Manages loaded patches.</summary>
+        private readonly Func<PatchManager> GetPatchManager;
 
         /// <summary>The loaded content packs.</summary>
         private readonly LoadedContentPack[] ContentPacks;
@@ -29,10 +34,11 @@ namespace ContentPatcher.Framework.Commands.Commands
         /// <param name="getPatchLoader">Manages loading and unloading patches.</param>
         /// <param name="contentPacks">The loaded content packs.</param>
         /// <param name="updateContext">A callback which immediately updates the current condition context.</param>
-        public ReloadCommand(IMonitor monitor, Func<PatchLoader> getPatchLoader, LoadedContentPack[] contentPacks, Action updateContext)
+        public ReloadCommand(IMonitor monitor, Func<PatchLoader> getPatchLoader, Func<PatchManager> getPatchManager, LoadedContentPack[] contentPacks, Action updateContext)
             : base(monitor, "reload")
         {
             this.GetPatchLoader = getPatchLoader;
+            this.GetPatchManager = getPatchManager;
             this.ContentPacks = contentPacks;
             this.UpdateContext = updateContext;
         }
@@ -43,8 +49,8 @@ namespace ContentPatcher.Framework.Commands.Commands
             return
                 """
                 patch reload
-                   Usage: patch reload "<content pack ID>"
-                   Reloads the patches of the content.json of a content pack. Config schema changes and dynamic token changes are unsupported.
+                   Usage: patch reload "<content pack ID>" "[optional specific included file to reload]"
+                   Reloads the patches of the content.json (or a specified json loaded by an Include patch) of a content pack. Config schema changes and dynamic token changes are unsupported.
                 """;
         }
 
@@ -52,11 +58,12 @@ namespace ContentPatcher.Framework.Commands.Commands
         public override void Handle(string[] args)
         {
             var patchLoader = this.GetPatchLoader();
+            var patchManager = this.GetPatchManager();
 
             // get pack ID
-            if (args.Length != 1)
+            if (args.Length < 1 || args.Length > 2)
             {
-                this.Monitor.Log("The 'patch reload' command expects a single arguments containing the target content pack ID. See 'patch help' for more info.", LogLevel.Error);
+                this.Monitor.Log("The 'patch reload' command expects a single argument containing the target content pack ID, with an optional additional argument for a specific file. See 'patch help' for more info.", LogLevel.Error);
                 return;
             }
             string packId = args[0];
@@ -69,24 +76,47 @@ namespace ContentPatcher.Framework.Commands.Commands
                 return;
             }
 
-            // unload patches
-            patchLoader.UnloadPatchesLoadedBy(pack);
-
-            // load pack patches
-            if (!pack.TryReloadContent(out string? loadContentError))
+            if (args.Length >= 2)
             {
-                this.Monitor.Log($"Failed to reload content pack '{pack.Manifest.Name}' for configuration changes: {loadContentError}. The content pack may not be in a valid state.", LogLevel.Error); // should never happen
-                return;
-            }
+                string specificFilePath = args[1];
 
-            // reload patches
-            patchLoader.LoadPatches(
-                contentPack: pack,
-                rawPatches: pack.Content.Changes,
-                rootIndexPath: [pack.Index],
-                path: new LogPathBuilder(pack.Manifest.Name),
-                parentPatch: null
-            );
+                IPatch? patch = patchManager.GetPatches().FirstOrDefault(p => p.FromAsset == PathUtilities.NormalizePath(specificFilePath));
+                if (patch == null || patch is not IncludePatch include)
+                {
+                    this.Monitor.Log($"There was no patch including the path \"{specificFilePath}\" (or it was not an Include type patch).", LogLevel.Error);
+                    return;
+                }
+                else if (!include.IsReady || !patch.Conditions.All(p => p.IsMatch))
+                {
+                    this.Monitor.Log($"The specified patch is not currently active.");
+                    return;
+                }
+
+                patchLoader.UnloadPatchesLoadedBy(include);
+
+                include.AttemptLoad();
+            }
+            else
+            {
+                // unload patches
+                patchLoader.UnloadPatchesLoadedBy(pack);
+
+                // load pack patches
+                if (!pack.TryReloadContent(out string? loadContentError))
+                {
+                    this.Monitor.Log($"Failed to reload content pack '{pack.Manifest.Name}' for configuration changes: {loadContentError}. The content pack may not be in a valid state.", LogLevel.Error); // should never happen
+                    return;
+                }
+
+                // reload patches
+                patchLoader.LoadPatches(
+                    contentPack: pack,
+                    rawPatches: pack.Content.Changes,
+                    rootIndexPath: [pack.Index],
+                    path: new LogPathBuilder(pack.Manifest.Name),
+                    parentPatch: null
+                );
+            }
 
             // make the changes apply
             this.UpdateContext();

--- a/ContentPatcher/Framework/Patches/IncludePatch.cs
+++ b/ContentPatcher/Framework/Patches/IncludePatch.cs
@@ -93,15 +93,7 @@ namespace ContentPatcher.Framework.Patches
             return this.MarkUpdated();
         }
 
-        /// <inheritdoc />
-        public override IEnumerable<string> GetChangeLabels()
-        {
-            return [];
-        }
-
-        /// <summary>
-        /// Attempt to load the new patches, if the patch is ready
-        /// </summary>
+        /// <summary>Load the patches in the include file, if the patch is ready.</summary>
         public void AttemptLoad()
         {
             this.AttemptedDataLoad = this.IsReady && this.Conditions.All(p => p.IsMatch);
@@ -169,6 +161,12 @@ namespace ContentPatcher.Framework.Patches
                     return;
                 }
             }
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> GetChangeLabels()
+        {
+            return [];
         }
 
 

--- a/ContentPatcher/Framework/Patches/IncludePatch.cs
+++ b/ContentPatcher/Framework/Patches/IncludePatch.cs
@@ -88,6 +88,22 @@ namespace ContentPatcher.Framework.Patches
                 this.PatchLoader.UnloadPatchesLoadedBy(this);
 
             // load new patches
+            this.AttemptLoad();
+
+            return this.MarkUpdated();
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<string> GetChangeLabels()
+        {
+            return [];
+        }
+
+        /// <summary>
+        /// Attempt to load the new patches, if the patch is ready
+        /// </summary>
+        public void AttemptLoad()
+        {
             this.AttemptedDataLoad = this.IsReady && this.Conditions.All(p => p.IsMatch);
             this.IsApplied = false;
             if (this.AttemptedDataLoad)
@@ -98,7 +114,7 @@ namespace ContentPatcher.Framework.Patches
                     if (!this.FromAssetExists())
                     {
                         this.WarnForPatch($"file '{this.FromAsset}' doesn't exist.");
-                        return this.MarkUpdated();
+                        return;
                     }
 
                     // prevent circular reference
@@ -115,7 +131,7 @@ namespace ContentPatcher.Framework.Patches
                                     loopPaths.Add(this.FromAsset);
 
                                     this.WarnForPatch($"patch skipped because it would cause an infinite loop ({string.Join(" > ", loopPaths)}).");
-                                    return this.MarkUpdated();
+                                    return;
                                 }
                             }
                         }
@@ -126,7 +142,7 @@ namespace ContentPatcher.Framework.Patches
                     if (!content.Changes.Any())
                     {
                         this.WarnForPatch($"file '{this.FromAsset}' doesn't have anything in the {nameof(content.Changes)} field. Is the file formatted correctly?");
-                        return this.MarkUpdated();
+                        return;
                     }
 
                     // validate fields
@@ -134,7 +150,7 @@ namespace ContentPatcher.Framework.Patches
                     if (invalidFields.Any())
                     {
                         this.WarnForPatch($"file contains fields which aren't allowed for a secondary file ({string.Join(", ", invalidFields.OrderByHuman())}).");
-                        return this.MarkUpdated();
+                        return;
                     }
 
                     // load patches
@@ -150,17 +166,9 @@ namespace ContentPatcher.Framework.Patches
                 catch (Exception ex)
                 {
                     this.WarnForPatch($"an error occurred.\n{ex}", LogLevel.Error);
-                    return this.MarkUpdated();
+                    return;
                 }
             }
-
-            return this.MarkUpdated();
-        }
-
-        /// <inheritdoc />
-        public override IEnumerable<string> GetChangeLabels()
-        {
-            return [];
         }
 
 


### PR DESCRIPTION
This would mean you don't have to reload your entire content patch when only wanting to test changes from one file. (Larger content packs take a long time to reload, so this can be helpful for skipping most of that waiting time.)