### PR TITLE
Add local tokens feature

### DIFF
--- a/ContentPatcher/Framework/Commands/Commands/ReloadCommand.cs
+++ b/ContentPatcher/Framework/Commands/Commands/ReloadCommand.cs
@@ -125,7 +125,7 @@ internal class ReloadCommand : BaseCommand
             patchLoader.LoadPatches(
                 contentPack: pack,
                 rawPatches: pack.Content.Changes,
-                localTokens: null,
+                inheritLocalTokens: null,
                 rootIndexPath: [pack.Index],
                 path: new LogPathBuilder(pack.Manifest.Name),
                 parentPatch: null

--- a/ContentPatcher/Framework/Commands/Commands/ReloadCommand.cs
+++ b/ContentPatcher/Framework/Commands/Commands/ReloadCommand.cs
@@ -125,6 +125,7 @@ internal class ReloadCommand : BaseCommand
             patchLoader.LoadPatches(
                 contentPack: pack,
                 rawPatches: pack.Content.Changes,
+                passthroughTokens: null,
                 rootIndexPath: [pack.Index],
                 path: new LogPathBuilder(pack.Manifest.Name),
                 parentPatch: null

--- a/ContentPatcher/Framework/Commands/Commands/ReloadCommand.cs
+++ b/ContentPatcher/Framework/Commands/Commands/ReloadCommand.cs
@@ -125,7 +125,7 @@ internal class ReloadCommand : BaseCommand
             patchLoader.LoadPatches(
                 contentPack: pack,
                 rawPatches: pack.Content.Changes,
-                passthroughTokens: null,
+                localTokens: null,
                 rootIndexPath: [pack.Index],
                 path: new LogPathBuilder(pack.Manifest.Name),
                 parentPatch: null

--- a/ContentPatcher/Framework/ConfigModels/PatchConfig.cs
+++ b/ContentPatcher/Framework/ConfigModels/PatchConfig.cs
@@ -97,6 +97,13 @@ internal class PatchConfig
     [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Auto)]
     public List<PatchMapTileConfig?> MapTiles { get; } = [];
 
+    /****
+    ** Include
+    *****/
+    /// <summary>Pass through values for includes.</summary>
+    [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Auto)]
+    public InvariantDictionary<string?> PassThroughTokens { get; } = new();
+
 
     /*********
     ** Public methods
@@ -139,5 +146,8 @@ internal class PatchConfig
         this.MapProperties = other.MapProperties.Clone();
         this.AddWarps = other.AddWarps.ToList();
         this.MapTiles = other.MapTiles.Select(p => p != null ? new PatchMapTileConfig(p) : null).ToList();
+
+        // Include
+        this.PassThroughTokens = other.PassThroughTokens.Clone();
     }
 }

--- a/ContentPatcher/Framework/ConfigModels/PatchConfig.cs
+++ b/ContentPatcher/Framework/ConfigModels/PatchConfig.cs
@@ -100,7 +100,7 @@ internal class PatchConfig
     /****
     ** Include
     *****/
-    /// <summary>Pass through values for includes.</summary>
+    /// <summary>The local token values to use for the loaded patches, in addition to the pre-existing tokens.</summary>
     [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Auto)]
     public InvariantDictionary<string?> PassThroughTokens { get; } = new();
 

--- a/ContentPatcher/Framework/ConfigModels/PatchConfig.cs
+++ b/ContentPatcher/Framework/ConfigModels/PatchConfig.cs
@@ -102,7 +102,7 @@ internal class PatchConfig
     *****/
     /// <summary>The local token values to use for the loaded patches, in addition to the pre-existing tokens.</summary>
     [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Auto)]
-    public InvariantDictionary<string?> PassThroughTokens { get; } = new();
+    public InvariantDictionary<string?> LocalTokens { get; } = new();
 
 
     /*********
@@ -148,6 +148,6 @@ internal class PatchConfig
         this.MapTiles = other.MapTiles.Select(p => p != null ? new PatchMapTileConfig(p) : null).ToList();
 
         // Include
-        this.PassThroughTokens = other.PassThroughTokens.Clone();
+        this.LocalTokens = other.LocalTokens.Clone();
     }
 }

--- a/ContentPatcher/Framework/ConfigModels/PatchConfig.cs
+++ b/ContentPatcher/Framework/ConfigModels/PatchConfig.cs
@@ -44,6 +44,10 @@ internal class PatchConfig
     /// <summary>The priority for this patch when multiple patches apply.</summary>
     public string? Priority { get; set; }
 
+    /// <summary>The local token values to use for this patch, in addition to the pre-existing tokens.</summary>
+    [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Auto)]
+    public InvariantDictionary<string?>? LocalTokens { get; set; }
+
     /****
     ** Multiple actions
     ****/
@@ -97,13 +101,6 @@ internal class PatchConfig
     [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Auto)]
     public List<PatchMapTileConfig?> MapTiles { get; } = [];
 
-    /****
-    ** Include
-    *****/
-    /// <summary>The local token values to use for the loaded patches, in addition to the pre-existing tokens.</summary>
-    [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Auto)]
-    public InvariantDictionary<string?> LocalTokens { get; } = new();
-
 
     /*********
     ** Public methods
@@ -125,6 +122,7 @@ internal class PatchConfig
         this.Enabled = other.Enabled;
         this.When = other.When.Clone();
         this.Priority = other.Priority;
+        this.LocalTokens = other.LocalTokens?.Clone();
 
         // multiple actions
         this.TextOperations = other.TextOperations.Select(p => p != null ? new TextOperationConfig(p) : null).ToList();
@@ -146,8 +144,5 @@ internal class PatchConfig
         this.MapProperties = other.MapProperties.Clone();
         this.AddWarps = other.AddWarps.ToList();
         this.MapTiles = other.MapTiles.Select(p => p != null ? new PatchMapTileConfig(p) : null).ToList();
-
-        // Include
-        this.LocalTokens = other.LocalTokens.Clone();
     }
 }

--- a/ContentPatcher/Framework/LocalContext.cs
+++ b/ContentPatcher/Framework/LocalContext.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using ContentPatcher.Framework.Conditions;
 using ContentPatcher.Framework.Tokens;
 using Pathoschild.Stardew.Common.Utilities;
-using StardewValley.TokenizableStrings;
 
 namespace ContentPatcher.Framework;
 

--- a/ContentPatcher/Framework/LocalContext.cs
+++ b/ContentPatcher/Framework/LocalContext.cs
@@ -117,7 +117,7 @@ internal class LocalContext : IContext
         }
 
         // update values
-        managed.ValueProvider.SetValue(ready ? value : null);
+        managed.ValueProvider.SetValue(value);
         managed.ValueProvider.SetReady(ready);
     }
 }

--- a/ContentPatcher/Framework/LocalContext.cs
+++ b/ContentPatcher/Framework/LocalContext.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using ContentPatcher.Framework.Conditions;
 using ContentPatcher.Framework.Tokens;
 using Pathoschild.Stardew.Common.Utilities;
+using StardewValley.TokenizableStrings;
 
 namespace ContentPatcher.Framework;
 
@@ -117,7 +118,7 @@ internal class LocalContext : IContext
         }
 
         // update values
-        managed.ValueProvider.SetValue(value);
+        managed.ValueProvider.SetValue(ready ? value : null);
         managed.ValueProvider.SetReady(ready);
     }
 }

--- a/ContentPatcher/Framework/Migrations/Migration_2_5.cs
+++ b/ContentPatcher/Framework/Migrations/Migration_2_5.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics.CodeAnalysis;
+using ContentPatcher.Framework.ConfigModels;
+using StardewModdingAPI;
+
+namespace ContentPatcher.Framework.Migrations;
+
+/// <summary>Migrates patches to format version 2.5.</summary>
+[SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Named for clarity.")]
+internal class Migration_2_5 : BaseMigration
+{
+    /*********
+    ** Public methods
+    *********/
+    /// <summary>Construct an instance.</summary>
+    public Migration_2_5()
+        : base(new SemanticVersion(2, 5, 0)) { }
+
+    /// <inheritdoc />
+    public override bool TryMigrate(ref PatchConfig[] patches, [NotNullWhen(false)] out string? error)
+    {
+        if (!base.TryMigrate(ref patches, out error))
+            return false;
+
+        // 2.5 adds the LocalTokens feature
+        foreach (PatchConfig patch in patches)
+        {
+            if (patch.LocalTokens?.Count > 0)
+            {
+                error = this.GetNounPhraseError($"using {nameof(patch.LocalTokens)}");
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/ContentPatcher/Framework/PatchLoader.cs
+++ b/ContentPatcher/Framework/PatchLoader.cs
@@ -46,6 +46,14 @@ internal class PatchLoader
     /// <summary>Handles parsing raw strings into tokens.</summary>
     private readonly Lexer Lexer = new();
 
+    /// <summary>The built-in local token names that can't be used for a user-defined local token.</summary>
+    private readonly InvariantSet ReservedLocalTokenNames = new(
+        nameof(ConditionType.FromFile),
+        nameof(ConditionType.Target),
+        nameof(ConditionType.TargetPathOnly),
+        nameof(ConditionType.TargetWithoutPath)
+    );
+
 
     /*********
     ** Public methods
@@ -68,30 +76,23 @@ internal class PatchLoader
     /// <summary>Load patches for a content pack.</summary>
     /// <param name="contentPack">The content pack for which to load patches.</param>
     /// <param name="rawPatches">The raw patches to load.</param>
-    /// <param name="localTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
+    /// <param name="inheritLocalTokens">The local token values to inherit for all loaded patches, in addition to their <see cref="PatchConfig.LocalTokens"/> field.</param>
     /// <param name="rootIndexPath">The path of indexes from the root <c>content.json</c> to the root which is loading patches; see <see cref="IPatch.IndexPath"/>.</param>
     /// <param name="path">The path to the patches from the root content file.</param>
     /// <param name="parentPatch">The parent <see cref="PatchType.Include"/> patch for which the patches are being loaded, if any.</param>
     /// <returns>Returns the patches that were loaded.</returns>
-    public IEnumerable<IPatch> LoadPatches(RawContentPack contentPack, PatchConfig[] rawPatches, InvariantDictionary<IManagedTokenString>? localTokens, int[] rootIndexPath, LogPathBuilder path, Patch? parentPatch)
+    public IEnumerable<IPatch> LoadPatches(RawContentPack contentPack, PatchConfig[] rawPatches, InvariantDictionary<IManagedTokenString>? inheritLocalTokens, int[] rootIndexPath, LogPathBuilder path, Patch? parentPatch)
     {
         bool verbose = this.Monitor.IsVerbose;
 
         // get fake patch context (so patch tokens are available in patch validation)
         ModTokenContext modContext = this.TokenManager.TrackLocalTokens(contentPack.ContentPack);
-        LocalContext fakePatchContext = new LocalContext(contentPack.Manifest.UniqueID, parentContext: modContext);
+        LocalContext validatorPatchContext = new LocalContext(contentPack.Manifest.UniqueID, parentContext: modContext);
         foreach (ConditionType type in InternalConstants.FromFileTokens.Concat(InternalConstants.TargetTokens))
-            fakePatchContext.SetLocalValue(type.ToString(), InternalConstants.TokenPlaceholder);
-
-        // add local tokens
-        if (localTokens != null)
-        {
-            foreach ((string key, IManagedTokenString value) in localTokens)
-                fakePatchContext.SetLocalValue(key, value, value.IsReady);
-        }
+            validatorPatchContext.SetLocalValue(type.ToString(), InternalConstants.TokenPlaceholder);
 
         // get token parser for fake context
-        TokenParser tokenParser = new TokenParser(fakePatchContext, contentPack.Manifest, contentPack.Migrator, this.InstalledMods);
+        TokenParser tokenParser = new TokenParser(validatorPatchContext, contentPack.Manifest, contentPack.Migrator, this.InstalledMods);
 
         // preprocess patches
         PatchConfig[] patches = this.SplitPatches(rawPatches).ToArray();
@@ -116,7 +117,7 @@ internal class PatchLoader
             var localPath = path.With(patch.LogName!);
             if (verbose)
                 this.Monitor.Log($"   loading {localPath}...");
-            IPatch? loaded = this.LoadPatch(contentPack, patch, tokenParser, localTokens, rootIndexPath.Concat([index]).ToArray(), localPath, parentPatch, logSkip: reasonPhrase => this.Monitor.Log($"Ignored {localPath}: {reasonPhrase}", LogLevel.Warn));
+            IPatch? loaded = this.LoadPatch(contentPack, patch, validatorPatchContext, tokenParser, inheritLocalTokens, rootIndexPath.Concat([index]).ToArray(), localPath, parentPatch, logSkip: reasonPhrase => this.Monitor.Log($"Ignored {localPath}: {reasonPhrase}", LogLevel.Warn));
             if (loaded != null)
                 loadedPatches.Add(loaded);
         }
@@ -347,14 +348,15 @@ internal class PatchLoader
     /// <summary>Load one patch from a content pack's <c>content.json</c> file.</summary>
     /// <param name="rawContentPack">The content pack being loaded.</param>
     /// <param name="entry">The change to load.</param>
+    /// <param name="validatorPatchContext">The token context containing patch-specific tokens with placeholder values, so they're available during patch validation.</param>
     /// <param name="tokenParser">Handles low-level parsing and validation for tokens.</param>
-    /// <param name="localTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
+    /// <param name="inheritLocalTokens">The local token values to inherit for all loaded patches, in addition to their <see cref="PatchConfig.LocalTokens"/> field.</param>
     /// <param name="indexPath">The path of indexes from the root <c>content.json</c> to this patch; see <see cref="IPatch.IndexPath"/>.</param>
     /// <param name="path">The path to the patch from the root content file.</param>
     /// <param name="parentPatch">The parent <see cref="PatchType.Include"/> patch for which the patches are being loaded, if any.</param>
     /// <param name="logSkip">The callback to invoke with the error reason if loading it fails.</param>
     /// <returns>The patch that was loaded, or <c>null</c> if it failed to load.</returns>
-    private IPatch? LoadPatch(RawContentPack rawContentPack, PatchConfig entry, TokenParser tokenParser, InvariantDictionary<IManagedTokenString>? localTokens, int[] indexPath, LogPathBuilder path, Patch? parentPatch, Action<string> logSkip)
+    private IPatch? LoadPatch(RawContentPack rawContentPack, PatchConfig entry, LocalContext validatorPatchContext, TokenParser tokenParser, InvariantDictionary<IManagedTokenString>? inheritLocalTokens, int[] indexPath, LogPathBuilder path, Patch? parentPatch, Action<string> logSkip)
     {
         var pack = rawContentPack.ContentPack;
         PatchType? action = null;
@@ -439,6 +441,33 @@ internal class PatchLoader
                     return TrackSkip(error);
             }
 
+            // parse local tokens
+            InvariantDictionary<IManagedTokenString>? localTokens = null;
+            if (inheritLocalTokens?.Count > 0 || entry.LocalTokens?.Count > 0)
+            {
+                // add inherited tokens
+                localTokens = new();
+                localTokens.TryAddMany(inheritLocalTokens);
+
+                // load local tokens
+                if (entry.LocalTokens != null)
+                {
+                    foreach ((string rawKey, string? value) in entry.LocalTokens)
+                    {
+                        string name = rawKey.Trim();
+
+                        if (this.ReservedLocalTokenNames.Contains(name))
+                            return TrackSkip($"the {nameof(entry.LocalTokens)} field can't contain a token named '{name}', which is a reserved token name.");
+
+                        if (!tokenParser.TryParseNullableString(value, immutableRequiredModIDs, path.With(nameof(entry.LocalTokens), name), out string? error, out IManagedTokenString? parsed))
+                            return TrackSkip(error);
+
+                        if (parsed != null)
+                            localTokens.Add(name, parsed);
+                    }
+                }
+            }
+
             // validate field reference tokens
             if (targetAsset != null)
             {
@@ -451,6 +480,13 @@ internal class PatchLoader
                     return TrackSkip($"circular field reference: {nameof(entry.FromFile)} field can't use the '{string.Join("', '", InternalConstants.FromFileTokens)}' tokens.");
                 if (fromAsset.UsesTokens(InternalConstants.TargetTokens) && targetAsset?.UsesTokens(InternalConstants.FromFileTokens) == true)
                     return TrackSkip($"circular field reference: {nameof(entry.Target)} field can't use the '{string.Join("', '", InternalConstants.FromFileTokens)}' tokens if the {nameof(entry.FromFile)} field uses '{string.Join("', '", InternalConstants.TargetTokens)}' tokens.");
+            }
+
+            // add local tokens to validator context
+            if (localTokens != null)
+            {
+                foreach (var pair in localTokens)
+                    validatorPatchContext.SetLocalValue(pair.Key, pair.Value, pair.Value.IsReady);
             }
 
             // get patch instance
@@ -466,27 +502,6 @@ internal class PatchLoader
                         if (targetAsset != null)
                             return TrackSkip($"can't use the {nameof(PatchConfig.Target)} field with an {PatchType.Include} patch.");
 
-                        // local tokens
-                        string[] localTokenBlacklist = // disallow built-in local tokens
-                        [
-                            nameof(ConditionType.Target),
-                                nameof(ConditionType.TargetPathOnly),
-                                nameof(ConditionType.TargetWithoutPath),
-                                nameof(ConditionType.FromFile)
-                        ];
-                        InvariantDictionary<IManagedTokenString> localTokensForInclude = new();
-                        foreach (var value in entry.LocalTokens)
-                        {
-                            if (localTokenBlacklist.Contains(value.Key))
-                                return TrackSkip($"the {nameof(entry.LocalTokens)} field can't contain a token named '{value.Key}', which is a reserved token name.");
-
-                            if (!tokenParser.TryParseNullableString(value.Value, immutableRequiredModIDs, path.With(nameof(entry.LocalTokens), value.Key), out string? error, out IManagedTokenString? parsed))
-                                return TrackSkip(error);
-
-                            if (parsed != null)
-                                localTokensForInclude.Add(value.Key, parsed);
-                        }
-
                         // save
                         patch = new IncludePatch(
                             indexPath: indexPath,
@@ -495,7 +510,6 @@ internal class PatchLoader
                             fromFile: fromAsset,
                             updateRate: updateRate,
                             localTokens: localTokens,
-                            localTokensForInclude: localTokensForInclude,
                             contentPack: rawContentPack,
                             parentPatch: parentPatch,
                             parseAssetName: this.ParseAssetName,

--- a/ContentPatcher/Framework/Patches/EditDataPatch.cs
+++ b/ContentPatcher/Framework/Patches/EditDataPatch.cs
@@ -83,7 +83,6 @@ internal class EditDataPatch : Patch
     /// <param name="assetName">The normalized asset name to intercept.</param>
     /// <param name="assetLocale">The locale code in the target asset's name to match. See <see cref="IPatch.TargetAsset"/> for more info.</param>
     /// <param name="priority">The priority for this patch when multiple patches apply.</param>
-    /// <param name="passthroughTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
     /// <param name="conditions">The conditions which determine whether this patch should be applied.</param>
     /// <param name="fromFile">The normalized asset key from which to load entries (if applicable), including tokens.</param>
     /// <param name="records">The data records to edit.</param>
@@ -92,13 +91,14 @@ internal class EditDataPatch : Patch
     /// <param name="textOperations">The text operations to apply to existing values.</param>
     /// <param name="targetField">The field within the data asset to which edits should be applied, or empty to apply to the root asset.</param>
     /// <param name="updateRate">When the patch should be updated.</param>
+    /// <param name="passthroughTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
     /// <param name="contentPack">The content pack which requested the patch.</param>
     /// <param name="migrator">The aggregate migration which applies for this patch.</param>
     /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
     /// <param name="monitor">Encapsulates monitoring and logging.</param>
     /// <param name="parseAssetName">Parse an asset name.</param>
     /// <param name="tryParseFields">Parse the data change fields for an <see cref="PatchType.EditData"/> patch.</param>
-    public EditDataPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, InvariantDictionary<IManagedTokenString>? passthroughTokens, IEnumerable<Condition> conditions, IManagedTokenString? fromFile, IEnumerable<EditDataPatchRecord>? records, IEnumerable<EditDataPatchField>? fields, IEnumerable<EditDataPatchMoveRecord>? moveRecords, IEnumerable<ITextOperation>? textOperations, IEnumerable<IManagedTokenString>? targetField, UpdateRate updateRate, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName, TryParseFieldsDelegate tryParseFields)
+    public EditDataPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString? fromFile, IEnumerable<EditDataPatchRecord>? records, IEnumerable<EditDataPatchField>? fields, IEnumerable<EditDataPatchMoveRecord>? moveRecords, IEnumerable<ITextOperation>? textOperations, IEnumerable<IManagedTokenString>? targetField, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? passthroughTokens, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName, TryParseFieldsDelegate tryParseFields)
         : base(
             indexPath: indexPath,
             path: path,

--- a/ContentPatcher/Framework/Patches/EditDataPatch.cs
+++ b/ContentPatcher/Framework/Patches/EditDataPatch.cs
@@ -91,7 +91,7 @@ internal class EditDataPatch : Patch
     /// <param name="textOperations">The text operations to apply to existing values.</param>
     /// <param name="targetField">The field within the data asset to which edits should be applied, or empty to apply to the root asset.</param>
     /// <param name="updateRate">When the patch should be updated.</param>
-    /// <param name="localTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
+    /// <param name="localTokens">The local token values to use for this patch, in addition to the pre-existing tokens.</param>
     /// <param name="contentPack">The content pack which requested the patch.</param>
     /// <param name="migrator">The aggregate migration which applies for this patch.</param>
     /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>

--- a/ContentPatcher/Framework/Patches/EditDataPatch.cs
+++ b/ContentPatcher/Framework/Patches/EditDataPatch.cs
@@ -91,14 +91,14 @@ internal class EditDataPatch : Patch
     /// <param name="textOperations">The text operations to apply to existing values.</param>
     /// <param name="targetField">The field within the data asset to which edits should be applied, or empty to apply to the root asset.</param>
     /// <param name="updateRate">When the patch should be updated.</param>
-    /// <param name="passthroughTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
+    /// <param name="localTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
     /// <param name="contentPack">The content pack which requested the patch.</param>
     /// <param name="migrator">The aggregate migration which applies for this patch.</param>
     /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
     /// <param name="monitor">Encapsulates monitoring and logging.</param>
     /// <param name="parseAssetName">Parse an asset name.</param>
     /// <param name="tryParseFields">Parse the data change fields for an <see cref="PatchType.EditData"/> patch.</param>
-    public EditDataPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString? fromFile, IEnumerable<EditDataPatchRecord>? records, IEnumerable<EditDataPatchField>? fields, IEnumerable<EditDataPatchMoveRecord>? moveRecords, IEnumerable<ITextOperation>? textOperations, IEnumerable<IManagedTokenString>? targetField, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? passthroughTokens, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName, TryParseFieldsDelegate tryParseFields)
+    public EditDataPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString? fromFile, IEnumerable<EditDataPatchRecord>? records, IEnumerable<EditDataPatchField>? fields, IEnumerable<EditDataPatchMoveRecord>? moveRecords, IEnumerable<ITextOperation>? textOperations, IEnumerable<IManagedTokenString>? targetField, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? localTokens, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName, TryParseFieldsDelegate tryParseFields)
         : base(
             indexPath: indexPath,
             path: path,
@@ -107,7 +107,7 @@ internal class EditDataPatch : Patch
             assetLocale: assetLocale,
             priority: (int)priority,
             updateRate: updateRate,
-            passthroughTokens: passthroughTokens,
+            localTokens: localTokens,
             conditions: conditions,
             contentPack: contentPack,
             migrator: migrator,

--- a/ContentPatcher/Framework/Patches/EditDataPatch.cs
+++ b/ContentPatcher/Framework/Patches/EditDataPatch.cs
@@ -12,6 +12,7 @@ using ContentPatcher.Framework.Tokens;
 using Microsoft.Xna.Framework.Graphics;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Pathoschild.Stardew.Common.Utilities;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using xTile;
@@ -96,7 +97,7 @@ internal class EditDataPatch : Patch
     /// <param name="monitor">Encapsulates monitoring and logging.</param>
     /// <param name="parseAssetName">Parse an asset name.</param>
     /// <param name="tryParseFields">Parse the data change fields for an <see cref="PatchType.EditData"/> patch.</param>
-    public EditDataPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString? fromFile, IEnumerable<EditDataPatchRecord>? records, IEnumerable<EditDataPatchField>? fields, IEnumerable<EditDataPatchMoveRecord>? moveRecords, IEnumerable<ITextOperation>? textOperations, IEnumerable<IManagedTokenString>? targetField, UpdateRate updateRate, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName, TryParseFieldsDelegate tryParseFields)
+    public EditDataPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, InvariantDictionary<IManagedTokenString> passthroughTokens, IEnumerable<Condition> conditions, IManagedTokenString? fromFile, IEnumerable<EditDataPatchRecord>? records, IEnumerable<EditDataPatchField>? fields, IEnumerable<EditDataPatchMoveRecord>? moveRecords, IEnumerable<ITextOperation>? textOperations, IEnumerable<IManagedTokenString>? targetField, UpdateRate updateRate, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName, TryParseFieldsDelegate tryParseFields)
         : base(
             indexPath: indexPath,
             path: path,
@@ -105,6 +106,7 @@ internal class EditDataPatch : Patch
             assetLocale: assetLocale,
             priority: (int)priority,
             updateRate: updateRate,
+            passthroughTokens: passthroughTokens,
             conditions: conditions,
             contentPack: contentPack,
             migrator: migrator,

--- a/ContentPatcher/Framework/Patches/EditDataPatch.cs
+++ b/ContentPatcher/Framework/Patches/EditDataPatch.cs
@@ -83,6 +83,7 @@ internal class EditDataPatch : Patch
     /// <param name="assetName">The normalized asset name to intercept.</param>
     /// <param name="assetLocale">The locale code in the target asset's name to match. See <see cref="IPatch.TargetAsset"/> for more info.</param>
     /// <param name="priority">The priority for this patch when multiple patches apply.</param>
+    /// <param name="passthroughTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
     /// <param name="conditions">The conditions which determine whether this patch should be applied.</param>
     /// <param name="fromFile">The normalized asset key from which to load entries (if applicable), including tokens.</param>
     /// <param name="records">The data records to edit.</param>
@@ -97,7 +98,7 @@ internal class EditDataPatch : Patch
     /// <param name="monitor">Encapsulates monitoring and logging.</param>
     /// <param name="parseAssetName">Parse an asset name.</param>
     /// <param name="tryParseFields">Parse the data change fields for an <see cref="PatchType.EditData"/> patch.</param>
-    public EditDataPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, InvariantDictionary<IManagedTokenString> passthroughTokens, IEnumerable<Condition> conditions, IManagedTokenString? fromFile, IEnumerable<EditDataPatchRecord>? records, IEnumerable<EditDataPatchField>? fields, IEnumerable<EditDataPatchMoveRecord>? moveRecords, IEnumerable<ITextOperation>? textOperations, IEnumerable<IManagedTokenString>? targetField, UpdateRate updateRate, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName, TryParseFieldsDelegate tryParseFields)
+    public EditDataPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, InvariantDictionary<IManagedTokenString>? passthroughTokens, IEnumerable<Condition> conditions, IManagedTokenString? fromFile, IEnumerable<EditDataPatchRecord>? records, IEnumerable<EditDataPatchField>? fields, IEnumerable<EditDataPatchMoveRecord>? moveRecords, IEnumerable<ITextOperation>? textOperations, IEnumerable<IManagedTokenString>? targetField, UpdateRate updateRate, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName, TryParseFieldsDelegate tryParseFields)
         : base(
             indexPath: indexPath,
             path: path,

--- a/ContentPatcher/Framework/Patches/EditImagePatch.cs
+++ b/ContentPatcher/Framework/Patches/EditImagePatch.cs
@@ -58,7 +58,7 @@ internal class EditImagePatch : Patch
     /// <param name="toArea">The sprite area to overwrite.</param>
     /// <param name="patchMode">Indicates how the image should be patched.</param>
     /// <param name="updateRate">When the patch should be updated.</param>
-    /// <param name="localTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
+    /// <param name="localTokens">The local token values to use for this patch, in addition to the pre-existing tokens.</param>
     /// <param name="contentPack">The content pack which requested the patch.</param>
     /// <param name="migrator">The aggregate migration which applies for this patch.</param>
     /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>

--- a/ContentPatcher/Framework/Patches/EditImagePatch.cs
+++ b/ContentPatcher/Framework/Patches/EditImagePatch.cs
@@ -6,6 +6,7 @@ using ContentPatcher.Framework.Migrations;
 using ContentPatcher.Framework.Tokens;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Pathoschild.Stardew.Common.Utilities;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewModdingAPI.Internal;
@@ -57,12 +58,13 @@ internal class EditImagePatch : Patch
     /// <param name="toArea">The sprite area to overwrite.</param>
     /// <param name="patchMode">Indicates how the image should be patched.</param>
     /// <param name="updateRate">When the patch should be updated.</param>
+    /// <param name="passthroughTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
     /// <param name="contentPack">The content pack which requested the patch.</param>
     /// <param name="migrator">The aggregate migration which applies for this patch.</param>
     /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
     /// <param name="monitor">Encapsulates monitoring and logging.</param>
     /// <param name="parseAssetName">Parse an asset name.</param>
-    public EditImagePatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString fromAsset, TokenRectangle? fromArea, TokenRectangle? toArea, PatchImageMode patchMode, UpdateRate updateRate, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName)
+    public EditImagePatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString fromAsset, TokenRectangle? fromArea, TokenRectangle? toArea, PatchImageMode patchMode, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? passthroughTokens, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName)
         : base(
             indexPath: indexPath,
             path: path,
@@ -71,12 +73,13 @@ internal class EditImagePatch : Patch
             assetLocale: assetLocale,
             priority: (int)priority,
             updateRate: updateRate,
+            passthroughTokens: passthroughTokens,
             conditions: conditions,
-            parseAssetName: parseAssetName,
-            fromAsset: fromAsset,
             contentPack: contentPack,
             migrator: migrator,
-            parentPatch: parentPatch
+            parentPatch: parentPatch,
+            parseAssetName: parseAssetName,
+            fromAsset: fromAsset
         )
     {
         this.FromArea = fromArea;

--- a/ContentPatcher/Framework/Patches/EditImagePatch.cs
+++ b/ContentPatcher/Framework/Patches/EditImagePatch.cs
@@ -58,13 +58,13 @@ internal class EditImagePatch : Patch
     /// <param name="toArea">The sprite area to overwrite.</param>
     /// <param name="patchMode">Indicates how the image should be patched.</param>
     /// <param name="updateRate">When the patch should be updated.</param>
-    /// <param name="passthroughTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
+    /// <param name="localTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
     /// <param name="contentPack">The content pack which requested the patch.</param>
     /// <param name="migrator">The aggregate migration which applies for this patch.</param>
     /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
     /// <param name="monitor">Encapsulates monitoring and logging.</param>
     /// <param name="parseAssetName">Parse an asset name.</param>
-    public EditImagePatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString fromAsset, TokenRectangle? fromArea, TokenRectangle? toArea, PatchImageMode patchMode, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? passthroughTokens, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName)
+    public EditImagePatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString fromAsset, TokenRectangle? fromArea, TokenRectangle? toArea, PatchImageMode patchMode, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? localTokens, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName)
         : base(
             indexPath: indexPath,
             path: path,
@@ -73,7 +73,7 @@ internal class EditImagePatch : Patch
             assetLocale: assetLocale,
             priority: (int)priority,
             updateRate: updateRate,
-            passthroughTokens: passthroughTokens,
+            localTokens: localTokens,
             conditions: conditions,
             contentPack: contentPack,
             migrator: migrator,

--- a/ContentPatcher/Framework/Patches/EditMapPatch.cs
+++ b/ContentPatcher/Framework/Patches/EditMapPatch.cs
@@ -78,13 +78,13 @@ internal class EditMapPatch : Patch
     /// <param name="addWarps">The warps to add to the location.</param>
     /// <param name="textOperations">The text operations to apply to existing values.</param>
     /// <param name="updateRate">When the patch should be updated.</param>
-    /// <param name="passthroughTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
+    /// <param name="localTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
     /// <param name="contentPack">The content pack which requested the patch.</param>
     /// <param name="migrator">The aggregate migration which applies for this patch.</param>
     /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
     /// <param name="monitor">Encapsulates monitoring and logging.</param>
     /// <param name="parseAssetName">Parse an asset name.</param>
-    public EditMapPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString? fromAsset, TokenRectangle? fromArea, TokenRectangle? toArea, PatchMapMode patchMode, IEnumerable<EditMapPatchProperty>? mapProperties, IEnumerable<EditMapPatchTile>? mapTiles, IEnumerable<IManagedTokenString>? addWarps, IEnumerable<ITextOperation>? textOperations, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? passthroughTokens, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName)
+    public EditMapPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString? fromAsset, TokenRectangle? fromArea, TokenRectangle? toArea, PatchMapMode patchMode, IEnumerable<EditMapPatchProperty>? mapProperties, IEnumerable<EditMapPatchTile>? mapTiles, IEnumerable<IManagedTokenString>? addWarps, IEnumerable<ITextOperation>? textOperations, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? localTokens, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName)
         : base(
             indexPath: indexPath,
             path: path,
@@ -93,7 +93,7 @@ internal class EditMapPatch : Patch
             assetLocale: assetLocale,
             priority: (int)priority,
             updateRate: updateRate,
-            passthroughTokens: passthroughTokens,
+            localTokens: localTokens,
             conditions: conditions,
             contentPack: contentPack,
             migrator: migrator,

--- a/ContentPatcher/Framework/Patches/EditMapPatch.cs
+++ b/ContentPatcher/Framework/Patches/EditMapPatch.cs
@@ -68,23 +68,23 @@ internal class EditMapPatch : Patch
     /// <param name="assetName">The normalized asset name to intercept.</param>
     /// <param name="assetLocale">The locale code in the target asset's name to match. See <see cref="IPatch.TargetAsset"/> for more info.</param>
     /// <param name="priority">The priority for this patch when multiple patches apply.</param>
-    /// <param name="passthroughTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
     /// <param name="conditions">The conditions which determine whether this patch should be applied.</param>
     /// <param name="fromAsset">The asset key to load from the content pack instead.</param>
     /// <param name="fromArea">The map area from which to read tiles.</param>
-    /// <param name="patchMode">Indicates how the map should be patched.</param>
     /// <param name="toArea">The map area to overwrite.</param>
+    /// <param name="patchMode">Indicates how the map should be patched.</param>
     /// <param name="mapProperties">The map properties to change when editing a map, if any.</param>
     /// <param name="mapTiles">The map tiles to change when editing a map.</param>
     /// <param name="addWarps">The warps to add to the location.</param>
     /// <param name="textOperations">The text operations to apply to existing values.</param>
     /// <param name="updateRate">When the patch should be updated.</param>
+    /// <param name="passthroughTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
     /// <param name="contentPack">The content pack which requested the patch.</param>
     /// <param name="migrator">The aggregate migration which applies for this patch.</param>
     /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
     /// <param name="monitor">Encapsulates monitoring and logging.</param>
     /// <param name="parseAssetName">Parse an asset name.</param>
-    public EditMapPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, InvariantDictionary<IManagedTokenString>? passthroughTokens, IEnumerable<Condition> conditions, IManagedTokenString? fromAsset, TokenRectangle? fromArea, TokenRectangle? toArea, PatchMapMode patchMode, IEnumerable<EditMapPatchProperty>? mapProperties, IEnumerable<EditMapPatchTile>? mapTiles, IEnumerable<IManagedTokenString>? addWarps, IEnumerable<ITextOperation>? textOperations, UpdateRate updateRate, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName)
+    public EditMapPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString? fromAsset, TokenRectangle? fromArea, TokenRectangle? toArea, PatchMapMode patchMode, IEnumerable<EditMapPatchProperty>? mapProperties, IEnumerable<EditMapPatchTile>? mapTiles, IEnumerable<IManagedTokenString>? addWarps, IEnumerable<ITextOperation>? textOperations, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? passthroughTokens, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName)
         : base(
             indexPath: indexPath,
             path: path,
@@ -95,11 +95,11 @@ internal class EditMapPatch : Patch
             updateRate: updateRate,
             passthroughTokens: passthroughTokens,
             conditions: conditions,
-            fromAsset: fromAsset,
             contentPack: contentPack,
             migrator: migrator,
             parentPatch: parentPatch,
-            parseAssetName: parseAssetName
+            parseAssetName: parseAssetName,
+            fromAsset: fromAsset
         )
     {
         this.FromArea = fromArea;

--- a/ContentPatcher/Framework/Patches/EditMapPatch.cs
+++ b/ContentPatcher/Framework/Patches/EditMapPatch.cs
@@ -83,7 +83,7 @@ internal class EditMapPatch : Patch
     /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
     /// <param name="monitor">Encapsulates monitoring and logging.</param>
     /// <param name="parseAssetName">Parse an asset name.</param>
-    public EditMapPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString? fromAsset, TokenRectangle? fromArea, TokenRectangle? toArea, PatchMapMode patchMode, IEnumerable<EditMapPatchProperty>? mapProperties, IEnumerable<EditMapPatchTile>? mapTiles, IEnumerable<IManagedTokenString>? addWarps, IEnumerable<ITextOperation>? textOperations, UpdateRate updateRate, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName)
+    public EditMapPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, InvariantDictionary<IManagedTokenString> passthroughTokens, IEnumerable<Condition> conditions, IManagedTokenString? fromAsset, TokenRectangle? fromArea, TokenRectangle? toArea, PatchMapMode patchMode, IEnumerable<EditMapPatchProperty>? mapProperties, IEnumerable<EditMapPatchTile>? mapTiles, IEnumerable<IManagedTokenString>? addWarps, IEnumerable<ITextOperation>? textOperations, UpdateRate updateRate, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName)
         : base(
             indexPath: indexPath,
             path: path,
@@ -92,6 +92,7 @@ internal class EditMapPatch : Patch
             assetLocale: assetLocale,
             priority: (int)priority,
             updateRate: updateRate,
+            passthroughTokens: passthroughTokens,
             conditions: conditions,
             fromAsset: fromAsset,
             contentPack: contentPack,

--- a/ContentPatcher/Framework/Patches/EditMapPatch.cs
+++ b/ContentPatcher/Framework/Patches/EditMapPatch.cs
@@ -78,7 +78,7 @@ internal class EditMapPatch : Patch
     /// <param name="addWarps">The warps to add to the location.</param>
     /// <param name="textOperations">The text operations to apply to existing values.</param>
     /// <param name="updateRate">When the patch should be updated.</param>
-    /// <param name="localTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
+    /// <param name="localTokens">The local token values to use for this patch, in addition to the pre-existing tokens.</param>
     /// <param name="contentPack">The content pack which requested the patch.</param>
     /// <param name="migrator">The aggregate migration which applies for this patch.</param>
     /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>

--- a/ContentPatcher/Framework/Patches/EditMapPatch.cs
+++ b/ContentPatcher/Framework/Patches/EditMapPatch.cs
@@ -68,6 +68,7 @@ internal class EditMapPatch : Patch
     /// <param name="assetName">The normalized asset name to intercept.</param>
     /// <param name="assetLocale">The locale code in the target asset's name to match. See <see cref="IPatch.TargetAsset"/> for more info.</param>
     /// <param name="priority">The priority for this patch when multiple patches apply.</param>
+    /// <param name="passthroughTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
     /// <param name="conditions">The conditions which determine whether this patch should be applied.</param>
     /// <param name="fromAsset">The asset key to load from the content pack instead.</param>
     /// <param name="fromArea">The map area from which to read tiles.</param>
@@ -83,7 +84,7 @@ internal class EditMapPatch : Patch
     /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
     /// <param name="monitor">Encapsulates monitoring and logging.</param>
     /// <param name="parseAssetName">Parse an asset name.</param>
-    public EditMapPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, InvariantDictionary<IManagedTokenString> passthroughTokens, IEnumerable<Condition> conditions, IManagedTokenString? fromAsset, TokenRectangle? fromArea, TokenRectangle? toArea, PatchMapMode patchMode, IEnumerable<EditMapPatchProperty>? mapProperties, IEnumerable<EditMapPatchTile>? mapTiles, IEnumerable<IManagedTokenString>? addWarps, IEnumerable<ITextOperation>? textOperations, UpdateRate updateRate, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName)
+    public EditMapPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, InvariantDictionary<IManagedTokenString>? passthroughTokens, IEnumerable<Condition> conditions, IManagedTokenString? fromAsset, TokenRectangle? fromArea, TokenRectangle? toArea, PatchMapMode patchMode, IEnumerable<EditMapPatchProperty>? mapProperties, IEnumerable<EditMapPatchTile>? mapTiles, IEnumerable<IManagedTokenString>? addWarps, IEnumerable<ITextOperation>? textOperations, UpdateRate updateRate, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName)
         : base(
             indexPath: indexPath,
             path: path,

--- a/ContentPatcher/Framework/Patches/IncludePatch.cs
+++ b/ContentPatcher/Framework/Patches/IncludePatch.cs
@@ -32,9 +32,6 @@ internal class IncludePatch : Patch
     /// <summary>Whether the patch already tried loading the <see cref="Patch.FromAsset"/> asset for the current context. This doesn't necessarily means it succeeded (e.g. the file may not have existed).</summary>
     private bool AttemptedDataLoad;
 
-    /// <summary>The local token values to use for the loaded patches, in addition to the pre-existing tokens.</summary>
-    private readonly InvariantDictionary<IManagedTokenString> LocalTokens;
-
 
     /*********
     ** Accessors
@@ -52,14 +49,13 @@ internal class IncludePatch : Patch
     /// <param name="conditions">The conditions which determine whether this patch should be applied.</param>
     /// <param name="fromFile">The normalized asset key from which to load entries (if applicable), including tokens.</param>
     /// <param name="updateRate">When the patch should be updated.</param>
-    /// <param name="localTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
-    /// <param name="localTokensForInclude">The local token values to use for the loaded patches, in addition to the pre-existing tokens. This is a filtered version of <paramref name="localTokens"/>.</param>
+    /// <param name="localTokens">The local token values to use for this and loaded patches, in addition to the pre-existing tokens.</param>
     /// <param name="contentPack">The content pack which requested the patch.</param>
     /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
     /// <param name="parseAssetName">Parse an asset name.</param>
     /// <param name="monitor">Encapsulates monitoring and logging.</param>
     /// <param name="patchLoader">Handles loading and unloading patches for content packs.</param>
-    public IncludePatch(int[] indexPath, LogPathBuilder path, IEnumerable<Condition> conditions, IManagedTokenString fromFile, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? localTokens, InvariantDictionary<IManagedTokenString> localTokensForInclude, RawContentPack contentPack, IPatch? parentPatch, Func<string, IAssetName> parseAssetName, IMonitor monitor, PatchLoader patchLoader)
+    public IncludePatch(int[] indexPath, LogPathBuilder path, IEnumerable<Condition> conditions, IManagedTokenString fromFile, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? localTokens, RawContentPack contentPack, IPatch? parentPatch, Func<string, IAssetName> parseAssetName, IMonitor monitor, PatchLoader patchLoader)
         : base(
             indexPath: indexPath,
             path: path,
@@ -80,7 +76,6 @@ internal class IncludePatch : Patch
         this.RawContentPack = contentPack;
         this.Monitor = monitor;
         this.PatchLoader = patchLoader;
-        this.LocalTokens = localTokensForInclude;
     }
 
     /// <inheritdoc />
@@ -158,7 +153,7 @@ internal class IncludePatch : Patch
                 this.PatchesJustLoaded = this.PatchLoader.LoadPatches(
                     contentPack: this.RawContentPack,
                     rawPatches: content.Changes,
-                    localTokens: this.LocalTokens,
+                    inheritLocalTokens: this.LocalTokens,
                     rootIndexPath: this.IndexPath,
                     path: this.GetIncludedLogPath(this.FromAsset),
                     parentPatch: this

--- a/ContentPatcher/Framework/Patches/IncludePatch.cs
+++ b/ContentPatcher/Framework/Patches/IncludePatch.cs
@@ -68,13 +68,13 @@ internal class IncludePatch : Patch
             assetLocale: null,
             priority: (int)AssetEditPriority.Default,
             updateRate: updateRate,
-            conditions: conditions,
-            fromAsset: fromFile,
             passthroughTokens: passthroughTokens,
-            parentPatch: parentPatch,
+            conditions: conditions,
             contentPack: contentPack.ContentPack,
             migrator: contentPack.Migrator,
-            parseAssetName: parseAssetName
+            parentPatch: parentPatch,
+            parseAssetName: parseAssetName,
+            fromAsset: fromFile
         )
     {
         this.RawContentPack = contentPack;
@@ -158,10 +158,10 @@ internal class IncludePatch : Patch
                 this.PatchesJustLoaded = this.PatchLoader.LoadPatches(
                     contentPack: this.RawContentPack,
                     rawPatches: content.Changes,
+                    passthroughTokens: this.PassthroughTokens,
                     rootIndexPath: this.IndexPath,
                     path: this.GetIncludedLogPath(this.FromAsset),
-                    parentPatch: this,
-                    passthroughTokens: this.PassthroughTokens
+                    parentPatch: this
                 );
                 this.IsApplied = true;
             }

--- a/ContentPatcher/Framework/Patches/IncludePatch.cs
+++ b/ContentPatcher/Framework/Patches/IncludePatch.cs
@@ -52,12 +52,14 @@ internal class IncludePatch : Patch
     /// <param name="conditions">The conditions which determine whether this patch should be applied.</param>
     /// <param name="fromFile">The normalized asset key from which to load entries (if applicable), including tokens.</param>
     /// <param name="updateRate">When the patch should be updated.</param>
+    /// <param name="passthroughTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
+    /// <param name="passthroughTokensForInclude">The local token values to use for the loaded patches, in addition to the pre-existing tokens. This is a filtered version of <paramref name="passthroughTokens"/>.</param>
     /// <param name="contentPack">The content pack which requested the patch.</param>
     /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
     /// <param name="parseAssetName">Parse an asset name.</param>
     /// <param name="monitor">Encapsulates monitoring and logging.</param>
     /// <param name="patchLoader">Handles loading and unloading patches for content packs.</param>
-    public IncludePatch(int[] indexPath, LogPathBuilder path, IEnumerable<Condition> conditions, IManagedTokenString fromFile, UpdateRate updateRate, InvariantDictionary<IManagedTokenString> passthroughTokens, InvariantDictionary<IManagedTokenString> passthroughTokensForInclude, RawContentPack contentPack, IPatch? parentPatch, Func<string, IAssetName> parseAssetName, IMonitor monitor, PatchLoader patchLoader)
+    public IncludePatch(int[] indexPath, LogPathBuilder path, IEnumerable<Condition> conditions, IManagedTokenString fromFile, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? passthroughTokens, InvariantDictionary<IManagedTokenString> passthroughTokensForInclude, RawContentPack contentPack, IPatch? parentPatch, Func<string, IAssetName> parseAssetName, IMonitor monitor, PatchLoader patchLoader)
         : base(
             indexPath: indexPath,
             path: path,

--- a/ContentPatcher/Framework/Patches/IncludePatch.cs
+++ b/ContentPatcher/Framework/Patches/IncludePatch.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using ContentPatcher.Framework.Conditions;
 using ContentPatcher.Framework.ConfigModels;
 using ContentPatcher.Framework.Tokens;
+using Pathoschild.Stardew.Common.Utilities;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewModdingAPI.Utilities;
@@ -31,6 +32,9 @@ internal class IncludePatch : Patch
     /// <summary>Whether the patch already tried loading the <see cref="Patch.FromAsset"/> asset for the current context. This doesn't necessarily means it succeeded (e.g. the file may not have existed).</summary>
     private bool AttemptedDataLoad;
 
+    /// <summary>The passthrough tokens provided.</summary>
+    private InvariantDictionary<IManagedTokenString> PassthroughTokens;
+
 
     /*********
     ** Accessors
@@ -53,7 +57,7 @@ internal class IncludePatch : Patch
     /// <param name="parseAssetName">Parse an asset name.</param>
     /// <param name="monitor">Encapsulates monitoring and logging.</param>
     /// <param name="patchLoader">Handles loading and unloading patches for content packs.</param>
-    public IncludePatch(int[] indexPath, LogPathBuilder path, IEnumerable<Condition> conditions, IManagedTokenString fromFile, UpdateRate updateRate, RawContentPack contentPack, IPatch? parentPatch, Func<string, IAssetName> parseAssetName, IMonitor monitor, PatchLoader patchLoader)
+    public IncludePatch(int[] indexPath, LogPathBuilder path, IEnumerable<Condition> conditions, IManagedTokenString fromFile, UpdateRate updateRate, InvariantDictionary<IManagedTokenString> passthroughTokens, InvariantDictionary<IManagedTokenString> passthroughTokensForInclude, RawContentPack contentPack, IPatch? parentPatch, Func<string, IAssetName> parseAssetName, IMonitor monitor, PatchLoader patchLoader)
         : base(
             indexPath: indexPath,
             path: path,
@@ -64,6 +68,7 @@ internal class IncludePatch : Patch
             updateRate: updateRate,
             conditions: conditions,
             fromAsset: fromFile,
+            passthroughTokens: passthroughTokens,
             parentPatch: parentPatch,
             contentPack: contentPack.ContentPack,
             migrator: contentPack.Migrator,
@@ -73,6 +78,7 @@ internal class IncludePatch : Patch
         this.RawContentPack = contentPack;
         this.Monitor = monitor;
         this.PatchLoader = patchLoader;
+        this.PassthroughTokens = passthroughTokensForInclude;
     }
 
     /// <inheritdoc />
@@ -152,7 +158,8 @@ internal class IncludePatch : Patch
                     rawPatches: content.Changes,
                     rootIndexPath: this.IndexPath,
                     path: this.GetIncludedLogPath(this.FromAsset),
-                    parentPatch: this
+                    parentPatch: this,
+                    passthroughTokens: this.PassthroughTokens
                 );
                 this.IsApplied = true;
             }

--- a/ContentPatcher/Framework/Patches/IncludePatch.cs
+++ b/ContentPatcher/Framework/Patches/IncludePatch.cs
@@ -32,8 +32,8 @@ internal class IncludePatch : Patch
     /// <summary>Whether the patch already tried loading the <see cref="Patch.FromAsset"/> asset for the current context. This doesn't necessarily means it succeeded (e.g. the file may not have existed).</summary>
     private bool AttemptedDataLoad;
 
-    /// <summary>The passthrough tokens provided.</summary>
-    private InvariantDictionary<IManagedTokenString> PassthroughTokens;
+    /// <summary>The local token values to use for the loaded patches, in addition to the pre-existing tokens.</summary>
+    private readonly InvariantDictionary<IManagedTokenString> LocalTokens;
 
 
     /*********
@@ -52,14 +52,14 @@ internal class IncludePatch : Patch
     /// <param name="conditions">The conditions which determine whether this patch should be applied.</param>
     /// <param name="fromFile">The normalized asset key from which to load entries (if applicable), including tokens.</param>
     /// <param name="updateRate">When the patch should be updated.</param>
-    /// <param name="passthroughTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
-    /// <param name="passthroughTokensForInclude">The local token values to use for the loaded patches, in addition to the pre-existing tokens. This is a filtered version of <paramref name="passthroughTokens"/>.</param>
+    /// <param name="localTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
+    /// <param name="localTokensForInclude">The local token values to use for the loaded patches, in addition to the pre-existing tokens. This is a filtered version of <paramref name="localTokens"/>.</param>
     /// <param name="contentPack">The content pack which requested the patch.</param>
     /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
     /// <param name="parseAssetName">Parse an asset name.</param>
     /// <param name="monitor">Encapsulates monitoring and logging.</param>
     /// <param name="patchLoader">Handles loading and unloading patches for content packs.</param>
-    public IncludePatch(int[] indexPath, LogPathBuilder path, IEnumerable<Condition> conditions, IManagedTokenString fromFile, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? passthroughTokens, InvariantDictionary<IManagedTokenString> passthroughTokensForInclude, RawContentPack contentPack, IPatch? parentPatch, Func<string, IAssetName> parseAssetName, IMonitor monitor, PatchLoader patchLoader)
+    public IncludePatch(int[] indexPath, LogPathBuilder path, IEnumerable<Condition> conditions, IManagedTokenString fromFile, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? localTokens, InvariantDictionary<IManagedTokenString> localTokensForInclude, RawContentPack contentPack, IPatch? parentPatch, Func<string, IAssetName> parseAssetName, IMonitor monitor, PatchLoader patchLoader)
         : base(
             indexPath: indexPath,
             path: path,
@@ -68,7 +68,7 @@ internal class IncludePatch : Patch
             assetLocale: null,
             priority: (int)AssetEditPriority.Default,
             updateRate: updateRate,
-            passthroughTokens: passthroughTokens,
+            localTokens: localTokens,
             conditions: conditions,
             contentPack: contentPack.ContentPack,
             migrator: contentPack.Migrator,
@@ -80,7 +80,7 @@ internal class IncludePatch : Patch
         this.RawContentPack = contentPack;
         this.Monitor = monitor;
         this.PatchLoader = patchLoader;
-        this.PassthroughTokens = passthroughTokensForInclude;
+        this.LocalTokens = localTokensForInclude;
     }
 
     /// <inheritdoc />
@@ -158,7 +158,7 @@ internal class IncludePatch : Patch
                 this.PatchesJustLoaded = this.PatchLoader.LoadPatches(
                     contentPack: this.RawContentPack,
                     rawPatches: content.Changes,
-                    passthroughTokens: this.PassthroughTokens,
+                    localTokens: this.LocalTokens,
                     rootIndexPath: this.IndexPath,
                     path: this.GetIncludedLogPath(this.FromAsset),
                     parentPatch: this

--- a/ContentPatcher/Framework/Patches/LoadPatch.cs
+++ b/ContentPatcher/Framework/Patches/LoadPatch.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using ContentPatcher.Framework.Conditions;
 using ContentPatcher.Framework.Migrations;
+using Pathoschild.Stardew.Common.Utilities;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 
@@ -26,7 +27,7 @@ internal class LoadPatch : Patch
     /// <param name="migrator">The aggregate migration which applies for this patch.</param>
     /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
     /// <param name="parseAssetName">Parse an asset name.</param>
-    public LoadPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, IManagedTokenString localAsset, AssetLoadPriority priority, UpdateRate updateRate, IEnumerable<Condition> conditions, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, Func<string, IAssetName> parseAssetName)
+    public LoadPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, IManagedTokenString localAsset, AssetLoadPriority priority, UpdateRate updateRate, InvariantDictionary<IManagedTokenString> passthroughTokens, IEnumerable<Condition> conditions, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, Func<string, IAssetName> parseAssetName)
         : base(
             indexPath: indexPath,
             path: path,
@@ -35,6 +36,7 @@ internal class LoadPatch : Patch
             assetLocale: assetLocale,
             priority: (int)priority,
             updateRate: updateRate,
+            passthroughTokens: passthroughTokens,
             conditions: conditions,
             contentPack: contentPack,
             migrator: migrator,

--- a/ContentPatcher/Framework/Patches/LoadPatch.cs
+++ b/ContentPatcher/Framework/Patches/LoadPatch.cs
@@ -22,7 +22,7 @@ internal class LoadPatch : Patch
     /// <param name="localAsset">The asset key to load from the content pack instead.</param>
     /// <param name="priority">The priority for this patch when multiple patches apply.</param>
     /// <param name="updateRate">When the patch should be updated.</param>
-    /// <param name="localTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
+    /// <param name="localTokens">The local token values to use for this patch, in addition to the pre-existing tokens.</param>
     /// <param name="conditions">The conditions which determine whether this patch should be applied.</param>
     /// <param name="contentPack">The content pack which requested the patch.</param>
     /// <param name="migrator">The aggregate migration which applies for this patch.</param>

--- a/ContentPatcher/Framework/Patches/LoadPatch.cs
+++ b/ContentPatcher/Framework/Patches/LoadPatch.cs
@@ -22,12 +22,13 @@ internal class LoadPatch : Patch
     /// <param name="localAsset">The asset key to load from the content pack instead.</param>
     /// <param name="priority">The priority for this patch when multiple patches apply.</param>
     /// <param name="updateRate">When the patch should be updated.</param>
+    /// <param name="passthroughTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
     /// <param name="conditions">The conditions which determine whether this patch should be applied.</param>
     /// <param name="contentPack">The content pack which requested the patch.</param>
     /// <param name="migrator">The aggregate migration which applies for this patch.</param>
     /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
     /// <param name="parseAssetName">Parse an asset name.</param>
-    public LoadPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, IManagedTokenString localAsset, AssetLoadPriority priority, UpdateRate updateRate, InvariantDictionary<IManagedTokenString> passthroughTokens, IEnumerable<Condition> conditions, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, Func<string, IAssetName> parseAssetName)
+    public LoadPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, IManagedTokenString localAsset, AssetLoadPriority priority, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? passthroughTokens, IEnumerable<Condition> conditions, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, Func<string, IAssetName> parseAssetName)
         : base(
             indexPath: indexPath,
             path: path,

--- a/ContentPatcher/Framework/Patches/LoadPatch.cs
+++ b/ContentPatcher/Framework/Patches/LoadPatch.cs
@@ -22,13 +22,13 @@ internal class LoadPatch : Patch
     /// <param name="localAsset">The asset key to load from the content pack instead.</param>
     /// <param name="priority">The priority for this patch when multiple patches apply.</param>
     /// <param name="updateRate">When the patch should be updated.</param>
-    /// <param name="passthroughTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
+    /// <param name="localTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
     /// <param name="conditions">The conditions which determine whether this patch should be applied.</param>
     /// <param name="contentPack">The content pack which requested the patch.</param>
     /// <param name="migrator">The aggregate migration which applies for this patch.</param>
     /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
     /// <param name="parseAssetName">Parse an asset name.</param>
-    public LoadPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, IManagedTokenString localAsset, AssetLoadPriority priority, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? passthroughTokens, IEnumerable<Condition> conditions, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, Func<string, IAssetName> parseAssetName)
+    public LoadPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, IManagedTokenString localAsset, AssetLoadPriority priority, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? localTokens, IEnumerable<Condition> conditions, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, Func<string, IAssetName> parseAssetName)
         : base(
             indexPath: indexPath,
             path: path,
@@ -37,7 +37,7 @@ internal class LoadPatch : Patch
             assetLocale: assetLocale,
             priority: (int)priority,
             updateRate: updateRate,
-            passthroughTokens: passthroughTokens,
+            localTokens: localTokens,
             conditions: conditions,
             contentPack: contentPack,
             migrator: migrator,

--- a/ContentPatcher/Framework/Patches/Patch.cs
+++ b/ContentPatcher/Framework/Patches/Patch.cs
@@ -58,8 +58,8 @@ internal abstract class Patch : IPatch
     /// <summary>The cached result for <see cref="GetTokensUsed"/>.</summary>
     protected IInvariantSet? TokensUsedCache;
 
-    /// <summary>The local token values to use for the loaded patches, in addition to the pre-existing tokens.</summary>
-    private InvariantDictionary<IManagedTokenString>? LocalTokens { get; }
+    /// <summary>The local token values to use for this patch, in addition to the pre-existing tokens.</summary>
+    protected InvariantDictionary<IManagedTokenString>? LocalTokens { get; }
 
 
     /*********
@@ -244,7 +244,7 @@ internal abstract class Patch : IPatch
     /// <param name="assetLocale">The locale code in the target asset's name to match. See <see cref="IPatch.TargetAsset"/> for more info.</param>
     /// <param name="priority">The priority for this patch when multiple patches apply.</param>
     /// <param name="updateRate">When the patch should be updated.</param>
-    /// <param name="localTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
+    /// <param name="localTokens">The local token values to use for this patch, in addition to the pre-existing tokens.</param>
     /// <param name="conditions">The conditions which determine whether this patch should be applied.</param>
     /// <param name="contentPack">The content pack which requested the patch.</param>
     /// <param name="migrator">The aggregate migration which applies for this patch.</param>

--- a/ContentPatcher/Framework/Patches/Patch.cs
+++ b/ContentPatcher/Framework/Patches/Patch.cs
@@ -244,14 +244,14 @@ internal abstract class Patch : IPatch
     /// <param name="assetLocale">The locale code in the target asset's name to match. See <see cref="IPatch.TargetAsset"/> for more info.</param>
     /// <param name="priority">The priority for this patch when multiple patches apply.</param>
     /// <param name="updateRate">When the patch should be updated.</param>
+    /// <param name="passthroughTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
     /// <param name="conditions">The conditions which determine whether this patch should be applied.</param>
-    /// <param name="parseAssetName">Parse an asset name.</param>
     /// <param name="contentPack">The content pack which requested the patch.</param>
     /// <param name="migrator">The aggregate migration which applies for this patch.</param>
     /// <param name="parentPatch">The parent <see cref="PatchType.Include"/> patch for which this patch was loaded, if any.</param>
+    /// <param name="parseAssetName">Parse an asset name.</param>
     /// <param name="fromAsset">The normalized asset key from which to load the local asset (if applicable), including tokens.</param>
-    /// <param name="passthroughTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
-    protected Patch(int[] indexPath, LogPathBuilder path, PatchType type, IManagedTokenString? assetName, IManagedTokenString? assetLocale, int priority, UpdateRate updateRate, IEnumerable<Condition> conditions, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, Func<string, IAssetName> parseAssetName, IManagedTokenString? fromAsset = null, InvariantDictionary<IManagedTokenString>? passthroughTokens = null)
+    protected Patch(int[] indexPath, LogPathBuilder path, PatchType type, IManagedTokenString? assetName, IManagedTokenString? assetLocale, int priority, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? passthroughTokens, IEnumerable<Condition> conditions, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, Func<string, IAssetName> parseAssetName, IManagedTokenString? fromAsset = null)
     {
         this.IndexPath = indexPath;
         this.Path = path;

--- a/ContentPatcher/Framework/Patches/Patch.cs
+++ b/ContentPatcher/Framework/Patches/Patch.cs
@@ -32,7 +32,7 @@ internal abstract class Patch : IPatch
     /// <summary>Diagnostic info about the instance.</summary>
     protected readonly ContextualState State = new();
 
-    /// <summary>The context which provides tokens specific to this patch like <see cref="ConditionType.Target"/> and <see cref="PassThroughTokens"/>.</summary>
+    /// <summary>The context which provides tokens specific to this patch like <see cref="ConditionType.Target"/> and <see cref="LocalTokens"/>.</summary>
     private readonly LocalContext PrivateContext;
 
     /// <summary>Whether the <see cref="FromAsset"/> file exists.</summary>
@@ -59,7 +59,7 @@ internal abstract class Patch : IPatch
     protected IInvariantSet? TokensUsedCache;
 
     /// <summary>The local token values to use for the loaded patches, in addition to the pre-existing tokens.</summary>
-    private InvariantDictionary<IManagedTokenString>? PassThroughTokens { get; }
+    private InvariantDictionary<IManagedTokenString>? LocalTokens { get; }
 
 
     /*********
@@ -138,7 +138,7 @@ internal abstract class Patch : IPatch
         this.State.Reset();
         bool isReady = true;
 
-        // update local tokens
+        // update built-in local tokens
         // (FromFile and Target may reference each other, so they need to be updated in a
         // specific order. A circular reference isn't possible since that's checked when the
         // patch is loaded.)
@@ -150,10 +150,10 @@ internal abstract class Patch : IPatch
             changed |= this.UpdateTargetPath(this.PrivateContext) | this.UpdateFromFile(this.PrivateContext);
         isReady &= this.RawTargetAsset?.IsReady != false && this.RawFromAsset?.IsReady != false;
 
-        // update passthroughs
-        if (this.PassThroughTokens != null)
+        // update user-defined local tokens
+        if (this.LocalTokens != null)
         {
-            foreach ((string key, IManagedTokenString value) in this.PassThroughTokens)
+            foreach ((string key, IManagedTokenString value) in this.LocalTokens)
             {
                 value.UpdateContext(context);
                 this.PrivateContext.SetLocalValue(key, value, value.IsReady);
@@ -244,14 +244,14 @@ internal abstract class Patch : IPatch
     /// <param name="assetLocale">The locale code in the target asset's name to match. See <see cref="IPatch.TargetAsset"/> for more info.</param>
     /// <param name="priority">The priority for this patch when multiple patches apply.</param>
     /// <param name="updateRate">When the patch should be updated.</param>
-    /// <param name="passthroughTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
+    /// <param name="localTokens">The local token values to use for the loaded patches, in addition to the pre-existing tokens.</param>
     /// <param name="conditions">The conditions which determine whether this patch should be applied.</param>
     /// <param name="contentPack">The content pack which requested the patch.</param>
     /// <param name="migrator">The aggregate migration which applies for this patch.</param>
     /// <param name="parentPatch">The parent <see cref="PatchType.Include"/> patch for which this patch was loaded, if any.</param>
     /// <param name="parseAssetName">Parse an asset name.</param>
     /// <param name="fromAsset">The normalized asset key from which to load the local asset (if applicable), including tokens.</param>
-    protected Patch(int[] indexPath, LogPathBuilder path, PatchType type, IManagedTokenString? assetName, IManagedTokenString? assetLocale, int priority, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? passthroughTokens, IEnumerable<Condition> conditions, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, Func<string, IAssetName> parseAssetName, IManagedTokenString? fromAsset = null)
+    protected Patch(int[] indexPath, LogPathBuilder path, PatchType type, IManagedTokenString? assetName, IManagedTokenString? assetLocale, int priority, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? localTokens, IEnumerable<Condition> conditions, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, Func<string, IAssetName> parseAssetName, IManagedTokenString? fromAsset = null)
     {
         this.IndexPath = indexPath;
         this.Path = path;
@@ -260,7 +260,7 @@ internal abstract class Patch : IPatch
         this.ManagedRawTargetLocale = assetLocale;
         this.Priority = priority;
         this.UpdateRate = updateRate;
-        this.PassThroughTokens = passthroughTokens;
+        this.LocalTokens = localTokens;
         this.Conditions = conditions.ToArray();
         this.ParseAssetNameImpl = parseAssetName;
         this.PrivateContext = new LocalContext(scope: contentPack.Manifest.UniqueID);
@@ -281,9 +281,9 @@ internal abstract class Patch : IPatch
         if (fromAsset != null)
             this.ManuallyUpdatedTokens.Add(fromAsset);
 
-        if (passthroughTokens != null)
+        if (localTokens != null)
         {
-            foreach ((string key, IManagedTokenString value) in passthroughTokens)
+            foreach ((string key, IManagedTokenString value) in localTokens)
             {
                 this.PrivateContext.SetLocalValue(key, value, value.IsReady);
                 this.Contextuals.Add(value);

--- a/ContentPatcher/Framework/ScreenManager.cs
+++ b/ContentPatcher/Framework/ScreenManager.cs
@@ -344,7 +344,7 @@ internal class ScreenManager
                 this.PatchLoader.LoadPatches(
                     contentPack: current,
                     rawPatches: content.Changes,
-                    localTokens: null,
+                    inheritLocalTokens: null,
                     rootIndexPath: [current.Index],
                     path: current.LogPath,
                     parentPatch: null
@@ -392,7 +392,7 @@ internal class ScreenManager
         this.PatchLoader.LoadPatches(
             contentPack: contentPack,
             rawPatches: contentPack.Content.Changes,
-            localTokens: null,
+            inheritLocalTokens: null,
             rootIndexPath: [contentPack.Index],
             path: contentPack.LogPath,
             parentPatch: null

--- a/ContentPatcher/Framework/ScreenManager.cs
+++ b/ContentPatcher/Framework/ScreenManager.cs
@@ -344,6 +344,7 @@ internal class ScreenManager
                 this.PatchLoader.LoadPatches(
                     contentPack: current,
                     rawPatches: content.Changes,
+                    passthroughTokens: null,
                     rootIndexPath: [current.Index],
                     path: current.LogPath,
                     parentPatch: null
@@ -391,6 +392,7 @@ internal class ScreenManager
         this.PatchLoader.LoadPatches(
             contentPack: contentPack,
             rawPatches: contentPack.Content.Changes,
+            passthroughTokens: null,
             rootIndexPath: [contentPack.Index],
             path: contentPack.LogPath,
             parentPatch: null

--- a/ContentPatcher/Framework/ScreenManager.cs
+++ b/ContentPatcher/Framework/ScreenManager.cs
@@ -344,7 +344,7 @@ internal class ScreenManager
                 this.PatchLoader.LoadPatches(
                     contentPack: current,
                     rawPatches: content.Changes,
-                    passthroughTokens: null,
+                    localTokens: null,
                     rootIndexPath: [current.Index],
                     path: current.LogPath,
                     parentPatch: null
@@ -392,7 +392,7 @@ internal class ScreenManager
         this.PatchLoader.LoadPatches(
             contentPack: contentPack,
             rawPatches: contentPack.Content.Changes,
-            passthroughTokens: null,
+            localTokens: null,
             rootIndexPath: [contentPack.Index],
             path: contentPack.LogPath,
             parentPatch: null

--- a/ContentPatcher/ModEntry.cs
+++ b/ContentPatcher/ModEntry.cs
@@ -75,7 +75,8 @@ internal class ModEntry : Mod
         new Migration_2_1(),
         new Migration_2_2(),
         new EmptyMigration(2, 3),
-        new Migration_2_4()
+        new Migration_2_4(),
+        new Migration_2_5()
     ];
 
     /// <summary>The special validation logic to apply to assets affected by patches.</summary>

--- a/ContentPatcher/docs/author-guide/action-editdata.md
+++ b/ContentPatcher/docs/author-guide/action-editdata.md
@@ -226,6 +226,7 @@ field         | purpose
 `When`        | _(optional)_ Only apply the patch if the given [conditions](../author-guide.md#conditions) match.
 `LogName`     | _(optional)_ A name for this patch to show in log messages. This can be useful for understanding errors. If omitted, it defaults to a name like `EditData Data/Achievements`.
 `Update`      | _(optional)_ How often the patch fields should be updated for token changes. See [update rate](../author-guide.md#update-rate) for more info.
+`LocalTokens` | _(Optional)_ A set of [local tokens](../author-guide.md#local-tokens) which can be used within this patch's field.
 
 </dd>
 <dt>Advanced fields:</dt>

--- a/ContentPatcher/docs/author-guide/action-editimage.md
+++ b/ContentPatcher/docs/author-guide/action-editimage.md
@@ -28,14 +28,15 @@ field     | purpose
 <dt>Optional fields:</dt>
 <dd>
 
-field     | purpose
---------- | -------
-`FromArea` | <p>The part of the source image to copy. Defaults to the whole source image.</p><p>This is specified as an object with the X and Y pixel coordinates of the top-left corner, and the pixel width and height of the area. Its fields may contain tokens.</p>
-`ToArea`   | <p>The part of the target image to replace. Defaults to the same size as `FromArea`, positioned at the top-left corner of the spritesheet.</p><p>This is specified as an object with the X and Y pixel coordinates of the top-left corner, and the pixel width and height of the area. Its fields may contain tokens.</p><p>If you specify an area past the bottom or right edges of the image, the image will be resized automatically to fit.</p>
-`PatchMode`| <p>How to apply `FromArea` to `ToArea`. Defaults to `Replace`.</p> Possible values: <ul><li><code>Replace</code>: replace every pixel in the target area with your source image. If the source image has transparent pixels, the target image will become transparent there.</li><li><code>Overlay</code>: draw your source image over the target area. If the source image has transparent or semi-transparent pixels, the target image will 'show through' those pixels. Opaque pixels will replace the target pixels.</li></ul>For example, let's say your source image is a pufferchick with a transparent background, and the target image is a solid green square. Here's how they'll be combined with different `PatchMode` values:<br />![](../screenshots/patch-mode-examples.png)
-`When`    | _(optional)_ Only apply the patch if the given [conditions](../author-guide.md#conditions) match.
-`LogName` | _(optional)_ A name for this patch to show in log messages. This can be useful for understanding errors. If omitted, it defaults to a name like `EditImage Animals/Dinosaur`.
-`Update`  | _(optional)_ How often the patch fields should be updated for token changes. See [update rate](../author-guide.md#update-rate) for more info.
+field       | purpose
+----------- | -------
+`FromArea`  | <p>The part of the source image to copy. Defaults to the whole source image.</p><p>This is specified as an object with the X and Y pixel coordinates of the top-left corner, and the pixel width and height of the area. Its fields may contain tokens.</p>
+`ToArea`    | <p>The part of the target image to replace. Defaults to the same size as `FromArea`, positioned at the top-left corner of the spritesheet.</p><p>This is specified as an object with the X and Y pixel coordinates of the top-left corner, and the pixel width and height of the area. Its fields may contain tokens.</p><p>If you specify an area past the bottom or right edges of the image, the image will be resized automatically to fit.</p>
+`PatchMode` | <p>How to apply `FromArea` to `ToArea`. Defaults to `Replace`.</p> Possible values: <ul><li><code>Replace</code>: replace every pixel in the target area with your source image. If the source image has transparent pixels, the target image will become transparent there.</li><li><code>Overlay</code>: draw your source image over the target area. If the source image has transparent or semi-transparent pixels, the target image will 'show through' those pixels. Opaque pixels will replace the target pixels.</li></ul>For example, let's say your source image is a pufferchick with a transparent background, and the target image is a solid green square. Here's how they'll be combined with different `PatchMode` values:<br />![](../screenshots/patch-mode-examples.png)
+`When`      | _(optional)_ Only apply the patch if the given [conditions](../author-guide.md#conditions) match.
+`LogName`   | _(optional)_ A name for this patch to show in log messages. This can be useful for understanding errors. If omitted, it defaults to a name like `EditImage Animals/Dinosaur`.
+`Update`    | _(optional)_ How often the patch fields should be updated for token changes. See [update rate](../author-guide.md#update-rate) for more info.
+`LocalTokens` | _(Optional)_ A set of [local tokens](../author-guide.md#local-tokens) which can be used within this patch's field.
 
 </dd>
 <dt>Advanced fields:</dt>

--- a/ContentPatcher/docs/author-guide/action-editmap.md
+++ b/ContentPatcher/docs/author-guide/action-editmap.md
@@ -57,6 +57,7 @@ field     | purpose
 `When`    | _(optional)_ Only apply the patch if the given [conditions](../author-guide.md#conditions) match.
 `LogName` | _(optional)_ A name for this patch to show in log messages. This can be useful for understanding errors. If omitted, it defaults to a name like `EditMap Maps/Town`.
 `Update`  | _(optional)_ How often the patch fields should be updated for token changes. See [update rate](../author-guide.md#update-rate) for more info.
+`LocalTokens` | _(Optional)_ A set of [local tokens](../author-guide.md#local-tokens) which can be used within this patch's field.
 
 </dd>
 <dt>Advanced fields:</dt>

--- a/ContentPatcher/docs/author-guide/action-include.md
+++ b/ContentPatcher/docs/author-guide/action-include.md
@@ -53,6 +53,7 @@ field     | purpose
 `When`    | _(optional)_ Only apply the patch if the given [conditions](../author-guide.md#conditions) match.
 `LogName` | _(optional)_ A name for this patch to show in log messages. This is useful for understanding errors; if not specified, it'll default to a name like `entry #14 (EditImage Animals/Dinosaurs)`.
 `Update`  | _(optional)_ How often the patch fields should be updated for token changes. See [update rate](../author-guide.md#update-rate) for more info.
+`LocalTokens` | _(Optional)_ A set of [local tokens](../author-guide.md#local-tokens) which can be used within this patch's field. These are inherited by all the patches loaded through the `Include` patch.
 
 </dd>
 </dl>

--- a/ContentPatcher/docs/author-guide/action-load.md
+++ b/ContentPatcher/docs/author-guide/action-load.md
@@ -40,6 +40,7 @@ field     | purpose
 `When`    | _(optional)_ Only apply the patch if the given [conditions](../author-guide.md#conditions) match.
 `LogName` | _(optional)_ A name for this patch to show in log messages. This can be useful for understanding errors. If omitted, it defaults to a name like `Load Data/Achievements`.
 `Update`  | _(optional)_ How often the patch fields should be updated for token changes. See [update rate](../author-guide.md#update-rate) for more info.
+`LocalTokens` | _(Optional)_ A set of [local tokens](../author-guide.md#local-tokens) which can be used within this patch's field.
 
 </dd>
 <dt>Advanced fields:</dt>

--- a/ContentPatcher/docs/author-guide/tokens.md
+++ b/ContentPatcher/docs/author-guide/tokens.md
@@ -1431,27 +1431,53 @@ For example:
 When set on an `Include` patch, local tokens are inherited by all patches loaded through it. This
 can be used to implement template behavior, where a set of patches is applied for each set of values.
 
-For example:
+For example, you can do this in `content.json`:
 ```json
 {
    "Action": "Include",
    "FromFile": "assets/add-hat.json",
    "LocalTokens": {
-      "Id": "PufferHat",
+      "IdSuffix": "PufferHat",
       "DisplayName": "Puffer Hat",
       "Description": "A hat that puffs up when you're threatened.",
       "Price": 500
    }
-},
+}
+```
+
+And then add an `assets/add-hat.json` file like this:
+```json
 {
-   "Action": "Include",
-   "FromFile": "assets/add-hat.json",
-   "LocalTokens": {
-      "Id": "ClownHat",
-      "DisplayName": "Clown Hat",
-      "Description": "A hat that jingles as you move.",
-      "Price": 250
-   }
+   /*
+   This file is loaded once per hat, with these tokens:
+      {{IdSuffix}}: the unique portion of the item ID, like "DeerAntlers".
+      {{DisplayName}}: the translated display name for the hat item.
+      {{Description}}: the translated description for the hat item.
+      {{Price}}: the sell price for the hat item.
+   */
+   "Changes": [
+      // add hat data
+      {
+         "Action": "EditData",
+         "Target": "Data/hats",
+         "Entries": {
+            "{{ModId}}_{{IdSuffix}}": "{{ModId}}_{{IdSuffix}}/{{Description}}/true/true//{{DisplayName}}/4/{{TextureNameInData}}"
+         }
+      },
+
+      // add to shop
+      {
+         "Action": "EditData",
+         "Target": "Data/Shops",
+         "TargetField": [ "HatMouse", "Items" ],
+         "Entries": {
+            "{{ModId}}_{{IdSuffix}}": {
+               "ItemId": "{{ModId}}_{{IdSuffix}}",
+               "Price": "{{Price}}"
+            }
+         }
+      }
+   ]
 }
 ```
 

--- a/ContentPatcher/docs/release-notes.md
+++ b/ContentPatcher/docs/release-notes.md
@@ -393,7 +393,7 @@ Released 31 October 2021 for SMAPI 3.12.6 or later. See the [release highlights]
   * [`Merge`](author-guide/tokens.md#Merge) to combine tokens in `When` conditions or perform value fallback.
   * [`PathPart`](author-guide/tokens.md#PathPart) to get part of a file/asset path (e.g. for patches with multiple `Target` or `FromFile` values).
   * [`Roommate`](author-guide/tokens.md#Roommate) to get a player's roommate NPC (similar to `Spouse` for a married NPC).
-* Added support for [translating content pack config options in Generic Mod Config Menu](author-guide/tokens.md#player-config).
+* Added support for [translating content pack config options in Generic Mod Config Menu](author-guide/config.md#config-ui).
 * Improved tokens:
   * Tokens which let you specify a player type now accept player IDs too (like `{{PlayerName: 3864039824286870457}}`).
   * You can now get per-player values for more tokens (specifically `IsMainPlayer`, `IsOutdoors`, `LocationContext`, `LocationName`, `LocationUniqueName`, `PlayerGender`, `PlayerName`, and `Spouse`).

--- a/ContentPatcher/docs/release-notes.md
+++ b/ContentPatcher/docs/release-notes.md
@@ -10,6 +10,7 @@ When releasing a format change, don't forget to update the smapi.io/json schema!
 
 -->
 ## Upcoming release
+* Added [local tokens feature](author-guide/tokens.md#local-tokens) (thanks to collaboration with spacechase0!).
 * Fixed warnings for mods using `Hearts` or `Relationship` conditions with an NPC who's in the data but not added to the world yet.
 * Fixed `patch_summary` error if a patch has a null target.
 


### PR DESCRIPTION
Might be a little rough at the moment.

(This example uses SpaceCore max stack size overrides because I was too lazy to write an example that made a full new item.)

`content.json`
```json
{
    "Format": "2.0.0",
    "Changes":
    [
        {
            "Action": "Include",
            "FromFile": "stacksize.json",
            "PassThroughTokens":
            {
                "ObjectId": "74",
                "Amount": 3
            }
        },
        {
            "Action": "Include",
            "FromFile": "stacksize.json",
            "PassThroughTokens":
            {
                "ObjectId": "206",
                "Amount": "{{Day}}"
            }
        }
    ]
}
```

`stacksize.json`
```json
{
    "Changes":
    [
        {
            "Action": "EditData",
            "Target": "spacechase0.SpaceCore/ObjectExtensionData",
            "Entries": {
                "{{ObjectId}}": {
                    "MaxStackSizeOverride": "{{Amount}}"
                }
            }
        }
    ]
}
```