### PR TITLE
[LookupAnything] Don't sort machine recipe ingredients lists and keep the trigger item as the first item.

### DIFF
--- a/LookupAnything/Framework/Fields/ItemRecipesField.cs
+++ b/LookupAnything/Framework/Fields/ItemRecipesField.cs
@@ -289,7 +289,10 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                     IEnumerable<RecipeItemEntry> inputs = recipe.Ingredients
                         .Select(this.TryCreateItemEntry)
                         .WhereNotNull();
-                    if (recipe.Type != RecipeType.TailorInput) // tailoring is always two ingredients with cloth first
+                    // tailoring is always two ingredients with cloth first
+                    // machine recipes' first ingredient is the 'trigger' item,
+                    // with additional items being the fuel in the player/chest inventory.
+                    if (recipe.Type != RecipeType.TailorInput && recipe.Type != RecipeType.MachineInput)
                         inputs = inputs.OrderBy(entry => entry.DisplayText);
 
                     if (recipe.GoldPrice > 0)

--- a/LookupAnything/Framework/Fields/ItemRecipesField.cs
+++ b/LookupAnything/Framework/Fields/ItemRecipesField.cs
@@ -289,10 +289,8 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                     IEnumerable<RecipeItemEntry> inputs = recipe.Ingredients
                         .Select(this.TryCreateItemEntry)
                         .WhereNotNull();
-                    // tailoring is always two ingredients with cloth first
-                    // machine recipes' first ingredient is the 'trigger' item,
-                    // with additional items being the fuel in the player/chest inventory.
-                    if (recipe.Type != RecipeType.TailorInput && recipe.Type != RecipeType.MachineInput)
+
+                    if (recipe.Type is not (RecipeType.TailorInput or RecipeType.MachineInput)) // tailoring and machine recipes are pre-sorted to show the common requirement last
                         inputs = inputs.OrderBy(entry => entry.DisplayText);
 
                     if (recipe.GoldPrice > 0)


### PR DESCRIPTION
Machine recipes have a primary 'trigger' item and secondary 'fuel' items. We're already putting the trigger item first while building the machine rules; for clarity's sake also keep it as the first item in the lookup model, before the extra fuels.
Before:
![2024-08-23T17:40:03,884328249-04:00](https://github.com/user-attachments/assets/656bf63a-c67a-408b-91a3-bb2045e39c0b)
After:
![2024-08-23T17:41:54,717276229-04:00](https://github.com/user-attachments/assets/caac76d6-8df8-404f-9c63-5ad84edbf265)
