### PR TITLE
[LookupAnything] Add integration with Extra Machine Config's multiple output items feature

### DIFF
--- a/Common/Integrations/ExtraMachineConfig/IExtraMachineConfigApi.cs
+++ b/Common/Integrations/ExtraMachineConfig/IExtraMachineConfigApi.cs
@@ -16,5 +16,6 @@ public interface IExtraMachineConfigApi
 
     /// <summary>Retrieves the extra output items produced by this recipe.</summary>
     /// <param name="outputData">The output rule to check.</param>
+    /// <param name="machine">The machine data which contains the <paramref name="outputData"/>.</param>
     IList<MachineItemOutput> GetExtraOutputs(MachineItemOutput outputData, MachineData? machine);
 }

--- a/Common/Integrations/ExtraMachineConfig/IExtraMachineConfigApi.cs
+++ b/Common/Integrations/ExtraMachineConfig/IExtraMachineConfigApi.cs
@@ -16,5 +16,5 @@ public interface IExtraMachineConfigApi
 
     /// <summary>Retrieves the extra output items produced by this recipe.</summary>
     /// <param name="outputData">The output rule to check.</param>
-    IList<MachineItemOutput> GetExtraOutputs(MachineItemOutput outputData);
+    IList<MachineItemOutput> GetExtraOutputs(MachineItemOutput outputData, MachineData? machine);
 }

--- a/Common/Integrations/ExtraMachineConfig/IExtraMachineConfigApi.cs
+++ b/Common/Integrations/ExtraMachineConfig/IExtraMachineConfigApi.cs
@@ -13,4 +13,8 @@ public interface IExtraMachineConfigApi
     /// <summary>Retrieves the extra tag-defined fuels consumed by this recipe.</summary>
     /// <param name="outputData">The output rule to check.</param>
     IList<(string, int)> GetExtraTagsRequirements(MachineItemOutput outputData);
+
+    /// <summary>Retrieves the extra output items produced by this recipe.</summary>
+    /// <param name="outputData">The output rule to check.</param>
+    IList<MachineItemOutput> GetExtraOutputs(MachineItemOutput outputData);
 }

--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -497,67 +497,83 @@ internal class DataParser
                         continue;
 
                     // build output list
-                    foreach (MachineItemOutput? outputItem in outputRule.OutputItem)
+                    foreach (MachineItemOutput? mainOutputItem in outputRule.OutputItem)
                     {
-                        if (outputItem is null)
+                        if (mainOutputItem is null)
                             continue;
 
-                        // get conditions
-                        List<string>? conditions = null;
-                        {
-                            // extract raw conditions
-                            string? rawConditions = null;
-                            if (!string.IsNullOrWhiteSpace(trigger.Condition))
-                                rawConditions = trigger.Condition;
-                            if (!string.IsNullOrWhiteSpace(outputItem.Condition))
-                            {
-                                rawConditions = rawConditions != null
-                                    ? rawConditions + ", " + outputItem.Condition
-                                    : outputItem.Condition;
-                            }
+                        // if there are extra outputs added by the Extra Machine Config mod, add them here
+                        List<MachineItemOutput> allOutputItems = [mainOutputItem];
 
-                            // parse
-                            if (rawConditions != null)
-                                conditions = GameStateQuery.SplitRaw(rawConditions).Distinct().ToList();
-                        }
-
-                        // get ingredient
-                        if (!this.TryGetMostSpecificIngredientIds(trigger.RequiredItemId, trigger.RequiredTags, ref conditions, out string? inputId, out string[] inputContextTags))
-                            continue;
-
-                        // track whether some recipes are too complex to fully display
-                        if (outputItem.OutputMethod != null)
-                            someRulesTooComplex = true;
-
-                        // add ingredients
-                        List<RecipeIngredientModel> ingredients = [
-                            new RecipeIngredientModel(RecipeType.MachineInput, inputId, trigger.RequiredCount, inputContextTags)
-                        ];
-                        ingredients.AddRange(additionalConsumedItems);
-
-                        List<MachineItemOutput> allOutputItems = [outputItem];
-
-                        // if there are extra fuels or outputs added by the Extra Machine Config mod, add them here
                         if (extraMachineConfig.IsLoaded)
                         {
-                            foreach ((string extraItemId, int extraCount) in extraMachineConfig.ModApi.GetExtraRequirements(outputItem))
-                                ingredients.Add(new RecipeIngredientModel(RecipeType.MachineInput, extraItemId, extraCount));
-
-                            foreach ((string extraContextTags, int extraCount) in extraMachineConfig.ModApi.GetExtraTagsRequirements(outputItem))
-                                ingredients.Add(new RecipeIngredientModel(RecipeType.MachineInput, null, extraCount, extraContextTags.Split(",")));
-
-                            allOutputItems.AddRange(extraMachineConfig.ModApi.GetExtraOutputs(outputItem));
+                            allOutputItems.AddRange(extraMachineConfig.ModApi.GetExtraOutputs(mainOutputItem));
                         }
 
-                        // add produced items
-                        foreach (var outputItemData in allOutputItems)
+                        foreach (var outputItem in allOutputItems)
                         {
+                            // get conditions
+                            List<string>? conditions = null;
+                            {
+                                // extract raw conditions
+                                string? rawConditions = null;
+                                if (!string.IsNullOrWhiteSpace(trigger.Condition))
+                                    rawConditions = trigger.Condition;
+
+                                // add condition of primary output
+                                if (!string.IsNullOrWhiteSpace(mainOutputItem.Condition))
+                                {
+                                    rawConditions = rawConditions != null
+                                        ? rawConditions + ", " + mainOutputItem.Condition
+                                        : mainOutputItem.Condition;
+                                }
+
+                                // add condition of secondary outputs from EMC if any
+                                if (outputItem != mainOutputItem && !string.IsNullOrWhiteSpace(outputItem.Condition))
+                                {
+                                    rawConditions = rawConditions != null
+                                        ? rawConditions + ", " + outputItem.Condition
+                                        : outputItem.Condition;
+                                }
+
+                                // parse
+                                if (rawConditions != null)
+                                    conditions = GameStateQuery.SplitRaw(rawConditions).Distinct().ToList();
+                            }
+
+                            // get ingredient
+                            if (!this.TryGetMostSpecificIngredientIds(trigger.RequiredItemId, trigger.RequiredTags, ref conditions, out string? inputId, out string[] inputContextTags))
+                                continue;
+
+                            // track whether some recipes are too complex to fully display
+                            if (outputItem.OutputMethod != null)
+                                someRulesTooComplex = true;
+
+                            // add ingredients
+                            List<RecipeIngredientModel> ingredients = [
+                                new RecipeIngredientModel(RecipeType.MachineInput, inputId, trigger.RequiredCount, inputContextTags)
+                            ];
+                            ingredients.AddRange(additionalConsumedItems);
+
+                            // if there are extra fuels added by the Extra Machine Config mod, add them here
+                            if (extraMachineConfig.IsLoaded)
+                            {
+                                foreach ((string extraItemId, int extraCount) in extraMachineConfig.ModApi.GetExtraRequirements(outputItem))
+                                    ingredients.Add(new RecipeIngredientModel(RecipeType.MachineInput, extraItemId, extraCount));
+
+                                foreach ((string extraContextTags, int extraCount) in extraMachineConfig.ModApi.GetExtraTagsRequirements(outputItem))
+                                    ingredients.Add(new RecipeIngredientModel(RecipeType.MachineInput, null, extraCount, extraContextTags.Split(",")));
+
+                                allOutputItems.AddRange(extraMachineConfig.ModApi.GetExtraOutputs(outputItem));
+                            }
+
+                            // add produced item
                             IList<ItemQueryResult> itemQueryResults;
-                            if (outputItemData.ItemId != null || outputItemData.RandomItemId != null)
+                            if (outputItem.ItemId != null || outputItem.RandomItemId != null)
                             {
                                 ItemQueryContext itemQueryContext = new();
                                 itemQueryResults = ItemQueryResolver.TryResolve(
-                                    outputItemData,
+                                    outputItem,
                                     itemQueryContext,
                                     formatItemId: id => id?.Replace("DROP_IN_ID", "0").Replace("DROP_IN_PRESERVE", "0").Replace("NEARBY_FLOWER_ID", "0")
                                 );
@@ -583,9 +599,9 @@ internal class DataParser
                                     //exceptIngredients: recipe.ExceptIngredients.Select(id => new RecipeIngredientModel(id!.Value, 1)),
                                     exceptIngredients: null,
                                     outputQualifiedItemId: result.Item.QualifiedItemId,
-                                    minOutput: outputItemData.MinStack > 0 ? outputItemData.MinStack : 1,
-                                    maxOutput: outputItemData.MaxStack > 0 ? outputItemData.MaxStack : null, // TODO: Calculate this better
-                                    quality: outputItemData.Quality,
+                                    minOutput: outputItem.MinStack > 0 ? outputItem.MinStack : 1,
+                                    maxOutput: outputItem.MaxStack > 0 ? outputItem.MaxStack : null, // TODO: Calculate this better
+                                    quality: outputItem.Quality,
                                     outputChance: 100 / outputRule.OutputItem.Count / itemQueryResults.Count,
                                     conditions: conditions?.ToArray()
                                 )

--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -504,7 +504,6 @@ internal class DataParser
 
                         // if there are extra outputs added by the Extra Machine Config mod, add them here
                         List<MachineItemOutput> allOutputItems = [mainOutputItem];
-
                         if (extraMachineConfig.IsLoaded)
                         {
                             allOutputItems.AddRange(extraMachineConfig.ModApi.GetExtraOutputs(mainOutputItem));
@@ -563,8 +562,6 @@ internal class DataParser
 
                                 foreach ((string extraContextTags, int extraCount) in extraMachineConfig.ModApi.GetExtraTagsRequirements(outputItem))
                                     ingredients.Add(new RecipeIngredientModel(RecipeType.MachineInput, null, extraCount, extraContextTags.Split(",")));
-
-                                allOutputItems.AddRange(extraMachineConfig.ModApi.GetExtraOutputs(outputItem));
                             }
 
                             // add produced item

--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -535,7 +535,9 @@ internal class DataParser
                         ];
                         ingredients.AddRange(additionalConsumedItems);
 
-                        // if there are extra fuels added by the Extra Machine Config mod, add them here
+                        List<MachineItemOutput> allOutputItems = [outputItem];
+
+                        // if there are extra fuels or outputs added by the Extra Machine Config mod, add them here
                         if (extraMachineConfig.IsLoaded)
                         {
                             foreach ((string extraItemId, int extraCount) in extraMachineConfig.ModApi.GetExtraRequirements(outputItem))
@@ -543,47 +545,52 @@ internal class DataParser
 
                             foreach ((string extraContextTags, int extraCount) in extraMachineConfig.ModApi.GetExtraTagsRequirements(outputItem))
                                 ingredients.Add(new RecipeIngredientModel(RecipeType.MachineInput, null, extraCount, extraContextTags.Split(",")));
+
+                            allOutputItems.AddRange(extraMachineConfig.ModApi.GetExtraOutputs(outputItem));
                         }
 
-                        // add produced item
-                        IList<ItemQueryResult> itemQueryResults;
-                        if (outputItem.ItemId != null || outputItem.RandomItemId != null)
+                        // add produced items
+                        foreach (var outputItemData in allOutputItems)
                         {
-                            ItemQueryContext itemQueryContext = new();
-                            itemQueryResults = ItemQueryResolver.TryResolve(
-                                outputItem,
-                                itemQueryContext,
-                                formatItemId: id => id?.Replace("DROP_IN_ID", "0").Replace("DROP_IN_PRESERVE", "0").Replace("NEARBY_FLOWER_ID", "0")
+                            IList<ItemQueryResult> itemQueryResults;
+                            if (outputItemData.ItemId != null || outputItemData.RandomItemId != null)
+                            {
+                                ItemQueryContext itemQueryContext = new();
+                                itemQueryResults = ItemQueryResolver.TryResolve(
+                                    outputItemData,
+                                    itemQueryContext,
+                                    formatItemId: id => id?.Replace("DROP_IN_ID", "0").Replace("DROP_IN_PRESERVE", "0").Replace("NEARBY_FLOWER_ID", "0")
+                                );
+                            }
+                            else
+                            {
+                                itemQueryResults = [];
+                                someRulesTooComplex = true;
+                            }
+
+                            // add to list
+                            recipes.AddRange(
+                                from result in itemQueryResults
+                                select new RecipeModel(
+                                    key: null,
+                                    type: RecipeType.MachineInput,
+                                    displayType: ItemRegistry.GetDataOrErrorItem(qualifiedMachineId).DisplayName,
+                                    ingredients,
+                                    goldPrice: 0,
+                                    item: _ => ItemRegistry.Create(result.Item.QualifiedItemId),
+                                    isKnown: () => true,
+                                    machineId: qualifiedMachineId,
+                                    //exceptIngredients: recipe.ExceptIngredients.Select(id => new RecipeIngredientModel(id!.Value, 1)),
+                                    exceptIngredients: null,
+                                    outputQualifiedItemId: result.Item.QualifiedItemId,
+                                    minOutput: outputItemData.MinStack > 0 ? outputItemData.MinStack : 1,
+                                    maxOutput: outputItemData.MaxStack > 0 ? outputItemData.MaxStack : null, // TODO: Calculate this better
+                                    quality: outputItemData.Quality,
+                                    outputChance: 100 / outputRule.OutputItem.Count / itemQueryResults.Count,
+                                    conditions: conditions?.ToArray()
+                                )
                             );
                         }
-                        else
-                        {
-                            itemQueryResults = [];
-                            someRulesTooComplex = true;
-                        }
-
-                        // add to list
-                        recipes.AddRange(
-                            from result in itemQueryResults
-                            select new RecipeModel(
-                                key: null,
-                                type: RecipeType.MachineInput,
-                                displayType: ItemRegistry.GetDataOrErrorItem(qualifiedMachineId).DisplayName,
-                                ingredients,
-                                goldPrice: 0,
-                                item: _ => ItemRegistry.Create(result.Item.QualifiedItemId),
-                                isKnown: () => true,
-                                machineId: qualifiedMachineId,
-                                //exceptIngredients: recipe.ExceptIngredients.Select(id => new RecipeIngredientModel(id!.Value, 1)),
-                                exceptIngredients: null,
-                                outputQualifiedItemId: result.Item.QualifiedItemId,
-                                minOutput: outputItem.MinStack > 0 ? outputItem.MinStack : 1,
-                                maxOutput: outputItem.MaxStack > 0 ? outputItem.MaxStack : null, // TODO: Calculate this better
-                                quality: outputItem.Quality,
-                                outputChance: 100 / outputRule.OutputItem.Count / itemQueryResults.Count,
-                                conditions: conditions?.ToArray()
-                            )
-                        );
                     }
                 }
             }

--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -506,7 +506,7 @@ internal class DataParser
                         List<MachineItemOutput> allOutputItems = [mainOutputItem];
                         if (extraMachineConfig.IsLoaded)
                         {
-                            allOutputItems.AddRange(extraMachineConfig.ModApi.GetExtraOutputs(mainOutputItem));
+                            allOutputItems.AddRange(extraMachineConfig.ModApi.GetExtraOutputs(mainOutputItem, machineData));
                         }
 
                         foreach (var outputItem in allOutputItems)

--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -503,13 +503,11 @@ internal class DataParser
                             continue;
 
                         // if there are extra outputs added by the Extra Machine Config mod, add them here
-                        List<MachineItemOutput> allOutputItems = [mainOutputItem];
-                        if (extraMachineConfig.IsLoaded)
-                        {
-                            allOutputItems.AddRange(extraMachineConfig.ModApi.GetExtraOutputs(mainOutputItem, machineData));
-                        }
+                        MachineItemOutput[] allOutputItems = extraMachineConfig.IsLoaded
+                            ? [mainOutputItem, .. extraMachineConfig.ModApi.GetExtraOutputs(mainOutputItem, machineData)]
+                            : [mainOutputItem];
 
-                        foreach (var outputItem in allOutputItems)
+                        foreach (MachineItemOutput outputItem in allOutputItems)
                         {
                             // get conditions
                             List<string>? conditions = null;

--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -519,7 +519,7 @@ internal class DataParser
                                 if (!string.IsNullOrWhiteSpace(trigger.Condition))
                                     rawConditions = trigger.Condition;
 
-                                // add condition of primary output
+                                // add main output's condition
                                 if (!string.IsNullOrWhiteSpace(mainOutputItem.Condition))
                                 {
                                     rawConditions = rawConditions != null
@@ -527,8 +527,8 @@ internal class DataParser
                                         : mainOutputItem.Condition;
                                 }
 
-                                // add condition of secondary outputs from EMC if any
-                                if (outputItem != mainOutputItem && !string.IsNullOrWhiteSpace(outputItem.Condition))
+                                // add secondary output's condition from Extra Machine Config mod
+                                if (!string.IsNullOrWhiteSpace(outputItem.Condition) && outputItem.Condition != mainOutputItem.Condition)
                                 {
                                     rawConditions = rawConditions != null
                                         ? rawConditions + ", " + outputItem.Condition


### PR DESCRIPTION
[API Reference](https://github.com/zombifier/My_Stardew_Mods/blob/master/ExtraMachineConfig/Api/IExtraMachineConfigApi.cs)

For now basically add new recipes with the same ingredient list but new output items taken from EMC's API. It does mean the lookup can't distinguish between "the recipe can produce one of these items" and "the recipe will produce all of these items", but I don't think it's important to distinguish (and any solutions I can think of to distinguish them leads to combinatorics explosions if there are multiple possible outputs for each 'slots'). Plus, this is also how things currently work with building conversion recipes (e.g. Mill).