### PR TITLE
[Lookup Anything] Fix counts for collapsible fields when some results are grouped

### DIFF
--- a/LookupAnything/Framework/Fields/CharacterGiftTastesField.cs
+++ b/LookupAnything/Framework/Fields/CharacterGiftTastesField.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
@@ -11,6 +12,13 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
     internal class CharacterGiftTastesField : GenericField
     {
         /*********
+        ** Accessors
+        *********/
+        /// <summary>The total number of items shown (including the sum of grouped entries like "11 unrevealed tastes").</summary>
+        public int TotalItems { get; }
+
+
+        /*********
         ** Public methods
         *********/
         /// <summary>Construct an instance.</summary>
@@ -22,7 +30,14 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
         /// <param name="onlyOwned">Whether to only show gift tastes for items which the player owns somewhere in the world.</param>
         /// <param name="ownedItemsCache">A lookup cache for owned items, as created by <see cref="GetOwnedItemsCache"/>.</param>
         public CharacterGiftTastesField(string label, IDictionary<GiftTaste, GiftTasteModel[]> giftTastes, GiftTaste showTaste, bool showUnknown, bool highlightUnrevealed, bool onlyOwned, IDictionary<string, bool> ownedItemsCache)
-            : base(label, CharacterGiftTastesField.GetText(giftTastes, showTaste, showUnknown, highlightUnrevealed, onlyOwned, ownedItemsCache)) { }
+            : base(label)
+        {
+            ItemRecord[] allItems = this.GetGiftTasteRecords(giftTastes, showTaste, ownedItemsCache);
+
+            this.TotalItems = allItems.Length;
+            this.Value = this.GetText(allItems, showUnknown, highlightUnrevealed, onlyOwned).ToArray();
+            this.HasValue = this.Value.Length > 0;
+        }
 
         /// <summary>Get a lookup cache for owned items indexed by <see cref="Item.QualifiedItemId"/>.</summary>
         /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
@@ -38,23 +53,19 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
         /*********
         ** Private methods
         *********/
-        /// <summary>Get the text to display.</summary>
+        /// <summary>Get the items that can be listed for the current gift taste, ignoring filter options.</summary>
         /// <param name="giftTastes">The items by how much this NPC likes receiving them.</param>
         /// <param name="showTaste">The gift taste to show.</param>
-        /// <param name="showUnknown">Whether to show gift tastes the player hasn't discovered yet.</param>
-        /// <param name="highlightUnrevealed">Whether to highlight items which haven't been revealed in the NPC profile yet.</param>
-        /// <param name="onlyOwned">Whether to only show gift tastes for items which the player owns somewhere in the world.</param>
         /// <param name="ownedItemsCache">A lookup cache for owned items, as created by <see cref="GetOwnedItemsCache"/>.</param>
-        private static IEnumerable<IFormattedText> GetText(IDictionary<GiftTaste, GiftTasteModel[]> giftTastes, GiftTaste showTaste, bool showUnknown, bool highlightUnrevealed, bool onlyOwned, IDictionary<string, bool> ownedItemsCache)
+        private ItemRecord[] GetGiftTasteRecords(IDictionary<GiftTaste, GiftTasteModel[]> giftTastes, GiftTaste showTaste, IDictionary<string, bool> ownedItemsCache)
         {
-            if (!giftTastes.ContainsKey(showTaste))
-                yield break;
+            if (!giftTastes.TryGetValue(showTaste, out GiftTasteModel[]? entries))
+                return Array.Empty<ItemRecord>();
 
             // get data
-
-            var items =
+            return
                 (
-                    from entry in giftTastes[showTaste]
+                    from entry in entries
                     let item = entry.Item
 
                     let ownership = ownedItemsCache.TryGetValue(item.QualifiedItemId, out bool rawVal) ? rawVal : null as bool? // true = in inventory, false = owned elsewhere, null = none found
@@ -62,10 +73,18 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                     let inInventory = ownership is true
 
                     orderby inInventory descending, isOwned descending, item.DisplayName
-                    select new { Item = item, IsInventory = inInventory, IsOwned = isOwned, entry.IsRevealed }
+                    select new ItemRecord(item, inInventory, isOwned, entry.IsRevealed)
                 )
                 .ToArray();
+        }
 
+        /// <summary>Get the text to display.</summary>
+        /// <param name="items">The items that can be listed for the current gift taste, ignoring filter options.</param>
+        /// <param name="showUnknown">Whether to show gift tastes the player hasn't discovered yet.</param>
+        /// <param name="highlightUnrevealed">Whether to highlight items which haven't been revealed in the NPC profile yet.</param>
+        /// <param name="onlyOwned">Whether to only show gift tastes for items which the player owns somewhere in the world.</param>
+        private IEnumerable<IFormattedText> GetText(ItemRecord[] items, bool showUnknown, bool highlightUnrevealed, bool onlyOwned)
+        {
             // generate text
             if (items.Any())
             {
@@ -108,5 +127,12 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                     yield return new FormattedText(I18n.Npc_UnownedGiftTaste(count: unowned), Color.Gray);
             }
         }
+
+        /// <summary>An item that can be shown in the list.</summary>
+        /// <param name="Item">The item instance.</param>
+        /// <param name="IsInventory">Whether this item is in the player's inventory.</param>
+        /// <param name="IsOwned">Whether the player owns at least one of this item somewhere in the world.</param>
+        /// <param name="IsRevealed">Whether the player has discovered this gift taste in-game.</param>
+        private record ItemRecord(Item Item, bool IsInventory, bool IsOwned, bool IsRevealed);
     }
 }

--- a/LookupAnything/Framework/Fields/GenericField.cs
+++ b/LookupAnything/Framework/Fields/GenericField.cs
@@ -68,13 +68,14 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
             return null;
         }
 
-        /// <summary>Collapse the field by default if it contains at least <c>minResultsForCollapse</c> results.</summary>
-        /// <param name="minResultsForCollapse">The minimum results needed before the field is collapsed by default.</param>
-        public virtual void CollapseIfLengthExceeds(int minResultsForCollapse)
+        /// <summary>Collapse the field content into an expandable link if it contains at least the given number of results.</summary>
+        /// <param name="minResultsForCollapse">The minimum results needed before the field is collapsed.</param>
+        /// <param name="countForLabel">The total number of results represented by the content (including grouped entries like "11 unrevealed items").</param>
+        public virtual void CollapseIfLengthExceeds(int minResultsForCollapse, int countForLabel)
         {
             if (this.Value?.Length >= minResultsForCollapse)
             {
-                this.CollapseByDefault(I18n.Generic_ShowXResults(count: this.Value.Length));
+                this.CollapseByDefault(I18n.Generic_ShowXResults(count: countForLabel));
             }
         }
 

--- a/LookupAnything/Framework/Fields/GenericField.cs
+++ b/LookupAnything/Framework/Fields/GenericField.cs
@@ -68,15 +68,14 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
             return null;
         }
 
-        /// <summary>Collapse the field by default, so the user needs to click a link to expand it.</summary>
-        /// <param name="linkText">The link text to show.</param>
-        public void CollapseByDefault(string linkText)
+        /// <summary>Collapse the field by default if it contains at least <c>minResultsForCollapse</c> results.</summary>
+        /// <param name="minResultsForCollapse">The minimum results needed before the field is collapsed by default.</param>
+        public virtual void CollapseIfLengthExceeds(int minResultsForCollapse)
         {
-            this.ExpandLink = new LinkField(this.Label, linkText, () =>
+            if (this.Value?.Length >= minResultsForCollapse)
             {
-                this.ExpandLink = null;
-                return null;
-            });
+                this.CollapseByDefault(I18n.Generic_ShowXResults(count: this.Value.Length));
+            }
         }
 
 
@@ -96,6 +95,17 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
             return !string.IsNullOrWhiteSpace(value)
                 ? [new FormattedText(value)]
                 : [];
+        }
+
+        /// <summary>Collapse the field by default, so the user needs to click a link to expand it.</summary>
+        /// <param name="linkText">The link text to show.</param>
+        protected void CollapseByDefault(string linkText)
+        {
+            this.ExpandLink = new LinkField(this.Label, linkText, () =>
+            {
+                this.ExpandLink = null;
+                return null;
+            });
         }
 
         /// <summary>Get the display value for sale price data.</summary>

--- a/LookupAnything/Framework/Fields/ItemRecipesField.cs
+++ b/LookupAnything/Framework/Fields/ItemRecipesField.cs
@@ -215,21 +215,19 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
         }
 
         /// <inheritdoc />
-        public override void CollapseIfLengthExceeds(int minResultsForCollapse)
+        public override void CollapseIfLengthExceeds(int minResultsForCollapse, int countForLabel)
         {
             // if recipes are grouped by type, we need to compute the field length
-            if (this.RecipesByType != null && this.RecipesByType.Length > 0)
+            if (this.RecipesByType.Length > 0)
             {
                 // calculate count of recipes that will be shown, in case we're in progression mode and some are hidden
                 int shownRecipesCount = this.RecipesByType.Sum(group => group.Recipes.Count(recipe => this.ShowUnknownRecipes || recipe.IsKnown));
                 if (shownRecipesCount >= minResultsForCollapse)
-                {
                     this.CollapseByDefault(I18n.Generic_ShowXResults(count: shownRecipesCount));
-                }
             }
             else
             {
-                base.CollapseIfLengthExceeds(minResultsForCollapse);
+                base.CollapseIfLengthExceeds(minResultsForCollapse, countForLabel);
             }
         }
 

--- a/LookupAnything/Framework/Fields/ItemRecipesField.cs
+++ b/LookupAnything/Framework/Fields/ItemRecipesField.cs
@@ -214,6 +214,24 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
             return new Vector2(wrapWidth, curPos.Y - position.Y - lineHeight);
         }
 
+        /// <inheritdoc />
+        public override void CollapseIfLengthExceeds(int minResultsForCollapse)
+        {
+            // if recipes are grouped by type, we need to compute the field length
+            if (this.RecipesByType != null && this.RecipesByType.Length > 0)
+            {
+                // calculate count of recipes that will be shown, in case we're in progression mode and some are hidden
+                int shownRecipesCount = this.RecipesByType.Sum(group => group.Recipes.Count(recipe => this.ShowUnknownRecipes || recipe.IsKnown));
+                if (shownRecipesCount >= minResultsForCollapse)
+                {
+                    this.CollapseByDefault(I18n.Generic_ShowXResults(count: shownRecipesCount));
+                }
+            }
+            else
+            {
+                base.CollapseIfLengthExceeds(minResultsForCollapse);
+            }
+        }
 
         /*********
         ** Private methods

--- a/LookupAnything/Framework/Lookups/Buildings/BuildingSubject.cs
+++ b/LookupAnything/Framework/Lookups/Buildings/BuildingSubject.cs
@@ -191,8 +191,8 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Buildings
                         {
                             // return recipes
                             var field = new ItemRecipesField(this.GameHelper, I18n.Item_Recipes(), null, recipes, showUnknownRecipes: true); // building recipes don't need to be learned
-                            if (this.CollapseFieldsConfig.Enabled && recipes.Length >= this.CollapseFieldsConfig.BuildingRecipes)
-                                field.CollapseByDefault(I18n.Generic_ShowXResults(count: recipes.Length));
+                            if (this.CollapseFieldsConfig.Enabled)
+                                field.CollapseIfLengthExceeds(this.CollapseFieldsConfig.BuildingRecipes);
                             yield return field;
 
                             // return items being processed
@@ -232,8 +232,8 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Buildings
                 if (recipes.Length > 0)
                 {
                     var field = new ItemRecipesField(this.GameHelper, I18n.Building_ConstructionCosts(), null, recipes, showUnknownRecipes: true, showLabelForSingleGroup: false, showOutputLabels: false);
-                    if (this.CollapseFieldsConfig.Enabled && recipes.Length >= this.CollapseFieldsConfig.BuildingRecipes)
-                        field.CollapseByDefault(I18n.Generic_ShowXResults(count: recipes.Length));
+                    if (this.CollapseFieldsConfig.Enabled)
+                        field.CollapseIfLengthExceeds(this.CollapseFieldsConfig.BuildingRecipes);
                     yield return field;
                 }
             }

--- a/LookupAnything/Framework/Lookups/Buildings/BuildingSubject.cs
+++ b/LookupAnything/Framework/Lookups/Buildings/BuildingSubject.cs
@@ -192,7 +192,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Buildings
                             // return recipes
                             var field = new ItemRecipesField(this.GameHelper, I18n.Item_Recipes(), null, recipes, showUnknownRecipes: true); // building recipes don't need to be learned
                             if (this.CollapseFieldsConfig.Enabled)
-                                field.CollapseIfLengthExceeds(this.CollapseFieldsConfig.BuildingRecipes);
+                                field.CollapseIfLengthExceeds(this.CollapseFieldsConfig.BuildingRecipes, recipes.Length);
                             yield return field;
 
                             // return items being processed
@@ -233,7 +233,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Buildings
                 {
                     var field = new ItemRecipesField(this.GameHelper, I18n.Building_ConstructionCosts(), null, recipes, showUnknownRecipes: true, showLabelForSingleGroup: false, showOutputLabels: false);
                     if (this.CollapseFieldsConfig.Enabled)
-                        field.CollapseIfLengthExceeds(this.CollapseFieldsConfig.BuildingRecipes);
+                        field.CollapseIfLengthExceeds(this.CollapseFieldsConfig.BuildingRecipes, recipes.Length);
                     yield return field;
                 }
             }

--- a/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
+++ b/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
@@ -416,7 +416,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Characters
         {
             var field = new CharacterGiftTastesField(label, giftTastes, taste, showUnknown: this.ShowUnknownGiftTastes, highlightUnrevealed: this.HighlightUnrevealedGiftTastes, onlyOwned: !this.ShowUnownedGifts, ownedItemsCache);
             if (this.CollapseFieldsConfig.Enabled)
-                field.CollapseIfLengthExceeds(this.CollapseFieldsConfig.NpcGiftTastes);
+                field.CollapseIfLengthExceeds(this.CollapseFieldsConfig.NpcGiftTastes, field.TotalItems);
             return field;
         }
 

--- a/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
+++ b/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
@@ -415,8 +415,8 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Characters
         private ICustomField GetGiftTasteField(string label, IDictionary<GiftTaste, GiftTasteModel[]> giftTastes, IDictionary<string, bool> ownedItemsCache, GiftTaste taste)
         {
             var field = new CharacterGiftTastesField(label, giftTastes, taste, showUnknown: this.ShowUnknownGiftTastes, highlightUnrevealed: this.HighlightUnrevealedGiftTastes, onlyOwned: !this.ShowUnownedGifts, ownedItemsCache);
-            if (this.CollapseFieldsConfig.Enabled && giftTastes.TryGetValue(taste, out GiftTasteModel[]? tastes) && tastes.Length >= this.CollapseFieldsConfig.NpcGiftTastes)
-                field.CollapseByDefault(I18n.Generic_ShowXResults(tastes.Length));
+            if (this.CollapseFieldsConfig.Enabled)
+                field.CollapseIfLengthExceeds(this.CollapseFieldsConfig.NpcGiftTastes);
             return field;
         }
 

--- a/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
+++ b/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
@@ -300,7 +300,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Items
                 {
                     var field = new ItemRecipesField(this.GameHelper, I18n.Item_Recipes(), item, recipes, this.ShowUnknownRecipes);
                     if (this.CollapseFieldsConfig.Enabled)
-                        field.CollapseIfLengthExceeds(this.CollapseFieldsConfig.ItemRecipes);
+                        field.CollapseIfLengthExceeds(this.CollapseFieldsConfig.ItemRecipes, recipes.Length);
                     yield return field;
                 }
             }

--- a/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
+++ b/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
@@ -299,11 +299,8 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Items
                 if (recipes.Length > 0)
                 {
                     var field = new ItemRecipesField(this.GameHelper, I18n.Item_Recipes(), item, recipes, this.ShowUnknownRecipes);
-
-                    // calculate count of recipes that will be shown, in case we're in progression mode and some are hidden
-                    int shownRecipesCount = recipes.Count(recipe => this.ShowUnknownRecipes || recipe.IsKnown());
-                    if (this.CollapseFieldsConfig.Enabled && shownRecipesCount >= this.CollapseFieldsConfig.ItemRecipes)
-                        field.CollapseByDefault(I18n.Generic_ShowXResults(count: shownRecipesCount));
+                    if (this.CollapseFieldsConfig.Enabled)
+                        field.CollapseIfLengthExceeds(this.CollapseFieldsConfig.ItemRecipes);
                     yield return field;
                 }
             }


### PR DESCRIPTION
When deciding whether to collapse a field, instead of using the total number of items / recipes in the field, we now use the length of the field's `Value`. This way, grouped results (e.g., "647 unrevealed items", which might appear when using progression mode) are counted as one result. This closes https://github.com/Pathoschild/StardewMods/issues/1025.

A special case is when displaying recipes grouped by type. In this case, the length of `Value` is always 0, so we instead need to manually sum up all the displayed recipes in each group.

Example:
Collapsed fields, progression mode on (and collapse limit of 1, for the sake of demonstration):
<img width="629" alt="image" src="https://github.com/user-attachments/assets/a99ff9bd-17b4-41d8-89ee-19a582f7da65">

Expanded fields, progression mode on:
<img width="631" alt="image" src="https://github.com/user-attachments/assets/692b44b5-89eb-422e-abfa-a142b728dc74">

Collapsed fields, progression mode off:
<img width="628" alt="image" src="https://github.com/user-attachments/assets/e7a97953-c4d9-4560-bd5c-01c0101d4fce">
