### PR TITLE
[Lookup Anything] Fix empty fish spawn location names

### DIFF
--- a/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
+++ b/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
@@ -96,7 +96,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                 yield return this.GetCondition(
                     label: I18n.Item_FishSpawnRules_Locations(
                         locations: I18n.List(
-                            spawnRules.Locations.Select(p => gameHelper.GetLocationDisplayName(p)).OrderBy(p => p)
+                            spawnRules.Locations.Select(gameHelper.GetLocationDisplayName).OrderBy(p => p)
                         )
                     ),
                     isMet: spawnRules.MatchesLocation(Game1.currentLocation.Name)

--- a/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
+++ b/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
@@ -96,7 +96,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                 yield return this.GetCondition(
                     label: I18n.Item_FishSpawnRules_Locations(
                         locations: I18n.List(
-                            spawnRules.Locations.Select(p => p.DisplayName).OrderBy(p => p)
+                            spawnRules.Locations.Select(p => gameHelper.GetLocationDisplayName(p)).OrderBy(p => p)
                         )
                     ),
                     isMet: spawnRules.MatchesLocation(Game1.currentLocation.Name)
@@ -108,7 +108,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                     (
                         from location in spawnRules.Locations
                         from season in location.Seasons
-                        select new { Season = season, LocationName = location.DisplayName }
+                        select new { Season = season, LocationName = gameHelper.GetLocationDisplayName(location) }
                     )
                     .GroupBy(p => p.Season, p => p.LocationName, StringComparer.OrdinalIgnoreCase)
                     .ToDictionary(p => p.Key, p => p.ToArray(), StringComparer.OrdinalIgnoreCase);

--- a/LookupAnything/Framework/Models/FishData/FishSpawnLocationData.cs
+++ b/LookupAnything/Framework/Models/FishData/FishSpawnLocationData.cs
@@ -4,30 +4,27 @@ using System.Collections.Generic;
 namespace Pathoschild.Stardew.LookupAnything.Framework.Models.FishData
 {
     /// <summary>Location-specific spawn rules for a fish.</summary>
-    /// <param name="DisplayName">The translated name for the location and area.</param>
     /// <param name="LocationId">The location's internal name.</param>
     /// <param name="Area">The area ID within the location, if applicable.</param>
     /// <param name="Seasons">The required seasons.</param>
-    internal record FishSpawnLocationData(string DisplayName, string LocationId, string? Area, HashSet<string> Seasons)
+    internal record FishSpawnLocationData(string LocationId, string? Area, HashSet<string> Seasons)
     {
         /*********
         ** Public methods
         *********/
         /// <summary>Construct an instance.</summary>
-        /// <param name="displayName">The translated name for the location and area.</param>
         /// <param name="locationId">The location's internal name.</param>
         /// <param name="area">The area ID within the location, if applicable.</param>
         /// <param name="seasons">The required seasons.</param>
-        internal FishSpawnLocationData(string displayName, string locationId, int? area, string[] seasons)
-            : this(displayName, locationId, area >= 0 ? area.ToString() : null, seasons) { }
+        internal FishSpawnLocationData(string locationId, int? area, string[] seasons)
+            : this(locationId, area >= 0 ? area.ToString() : null, seasons) { }
 
         /// <summary>Construct an instance.</summary>
-        /// <param name="displayName">The translated name for the location and area.</param>
         /// <param name="locationId">The location's internal name.</param>
         /// <param name="area">The area ID within the location, if applicable.</param>
         /// <param name="seasons">The required seasons.</param>
-        internal FishSpawnLocationData(string displayName, string locationId, string? area, string[] seasons)
-            : this(displayName, locationId, area, new HashSet<string>(seasons, StringComparer.OrdinalIgnoreCase)) { }
+        internal FishSpawnLocationData(string locationId, string? area, string[] seasons)
+            : this(locationId, area, new HashSet<string>(seasons, StringComparer.OrdinalIgnoreCase)) { }
 
         /// <summary>Get whether this matches a given location name.</summary>
         /// <param name="locationId">The location internal name to match.</param>

--- a/LookupAnything/GameHelper.cs
+++ b/LookupAnything/GameHelper.cs
@@ -376,10 +376,10 @@ namespace Pathoschild.Stardew.LookupAnything
         }
 
         /// <summary>Get the translated display name for a fish spawn location.</summary>
-        /// <param name="fishSpawnData">Data for the location whose name to look up.</param>
-        public string GetLocationDisplayName(FishSpawnLocationData locationData)
+        /// <param name="fishSpawnData">The location-specific spawn rules for which to get a location name.</param>
+        public string GetLocationDisplayName(FishSpawnLocationData fishSpawnData)
         {
-            return this.DataParser.GetLocationDisplayName(locationData);
+            return this.DataParser.GetLocationDisplayName(fishSpawnData);
         }
 
         /// <summary>Parse monster data.</summary>

--- a/LookupAnything/GameHelper.cs
+++ b/LookupAnything/GameHelper.cs
@@ -375,6 +375,13 @@ namespace Pathoschild.Stardew.LookupAnything
             return this.DataParser.GetFriendshipForAnimal(player, animal, this.Metadata);
         }
 
+        /// <summary>Get the translated display name for a fish spawn location.</summary>
+        /// <param name="fishSpawnData">Data for the location whose name to look up.</param>
+        public string GetLocationDisplayName(FishSpawnLocationData locationData)
+        {
+            return this.DataParser.GetLocationDisplayName(locationData);
+        }
+
         /// <summary>Parse monster data.</summary>
         public IEnumerable<MonsterData> GetMonsterData()
         {

--- a/LookupAnything/assets/data.json
+++ b/LookupAnything/assets/data.json
@@ -189,7 +189,7 @@ You shouldn't change this file unless you know what you're doing.
         "149": {
             "Locations": [
                 {
-                    "LocationName": "Submarine",
+                    "LocationId": "Submarine",
                     "Seasons": [ "winter" ]
                 }
             ]
@@ -199,7 +199,7 @@ You shouldn't change this file unless you know what you're doing.
         "152": {
             "Locations": [
                 {
-                    "LocationName": "Submarine",
+                    "LocationId": "Submarine",
                     "Seasons": [ "winter" ]
                 }
             ]
@@ -209,7 +209,7 @@ You shouldn't change this file unless you know what you're doing.
         "154": {
             "Locations": [
                 {
-                    "LocationName": "Submarine",
+                    "LocationId": "Submarine",
                     "Seasons": [ "winter" ]
                 }
             ]
@@ -219,7 +219,7 @@ You shouldn't change this file unless you know what you're doing.
         "155": {
             "Locations": [
                 {
-                    "LocationName": "Submarine",
+                    "LocationId": "Submarine",
                     "Seasons": [ "winter" ]
                 }
             ]
@@ -229,7 +229,7 @@ You shouldn't change this file unless you know what you're doing.
         "158": {
             "Locations": [
                 {
-                    "LocationName": "UndergroundMine",
+                    "LocationId": "UndergroundMine",
                     "Area": 20,
                     "Seasons": [ "spring", "summer", "fall", "winter" ]
                 }
@@ -242,7 +242,7 @@ You shouldn't change this file unless you know what you're doing.
             "MinFishingLevel": 5,
             "Locations": [
                 {
-                    "LocationName": "Beach",
+                    "LocationId": "Beach",
                     "Area": "east-pier",
                     "Seasons": [ "summer" ]
                 }
@@ -255,7 +255,7 @@ You shouldn't change this file unless you know what you're doing.
             "MinFishingLevel": 3,
             "Locations": [
                 {
-                    "LocationName": "Town",
+                    "LocationId": "Town",
                     "Area": "northmost-bridge",
                     "Seasons": [ "fall" ]
                 }
@@ -266,7 +266,7 @@ You shouldn't change this file unless you know what you're doing.
         "161": {
             "Locations": [
                 {
-                    "LocationName": "UndergroundMine",
+                    "LocationId": "UndergroundMine",
                     "Area": 60,
                     "Seasons": [ "spring", "summer", "fall", "winter" ]
                 }
@@ -277,7 +277,7 @@ You shouldn't change this file unless you know what you're doing.
         "162": {
             "Locations": [
                 {
-                    "LocationName": "UndergroundMine",
+                    "LocationId": "UndergroundMine",
                     "Area": 100,
                     "Seasons": [ "spring", "summer", "fall", "winter" ]
                 }
@@ -291,7 +291,7 @@ You shouldn't change this file unless you know what you're doing.
             "Weather": "Rainy",
             "Locations": [
                 {
-                    "LocationName": "Mountain",
+                    "LocationId": "Mountain",
                     "Seasons": [ "spring" ]
                 }
             ]
@@ -302,7 +302,7 @@ You shouldn't change this file unless you know what you're doing.
             "IsUnique": true,
             "Locations": [
                 {
-                    "LocationName": "Sewer",
+                    "LocationId": "Sewer",
                     "Seasons": [ "spring", "summer", "fall", "winter" ]
                 }
             ]
@@ -314,7 +314,7 @@ You shouldn't change this file unless you know what you're doing.
             "MinFishingLevel": 6,
             "Locations": [
                 {
-                    "LocationName": "Forest",
+                    "LocationId": "Forest",
                     "Area": "island-tip",
                     "Seasons": [ "winter" ]
                 }
@@ -325,7 +325,7 @@ You shouldn't change this file unless you know what you're doing.
         "798": {
             "Locations": [
                 {
-                    "LocationName": "Submarine",
+                    "LocationId": "Submarine",
                     "Seasons": [ "winter" ]
                 }
             ]
@@ -335,7 +335,7 @@ You shouldn't change this file unless you know what you're doing.
         "799": {
             "Locations": [
                 {
-                    "LocationName": "Submarine",
+                    "LocationId": "Submarine",
                     "Seasons": [ "winter" ]
                 }
             ]
@@ -345,7 +345,7 @@ You shouldn't change this file unless you know what you're doing.
         "800": {
             "Locations": [
                 {
-                    "LocationName": "Submarine",
+                    "LocationId": "Submarine",
                     "Seasons": [ "winter" ]
                 }
             ]


### PR DESCRIPTION
Closes https://github.com/Pathoschild/StardewMods/issues/1034. I found that location names for spawns defined in `data.json` were empty because the `DisplayName` property was never set. To fix this, I removed `DisplayName` from the `FishSpawnLocationData` class. Now, we get the display name using a new method in `DataParser`.

I also renamed `LocationName` to `LocationId` in `data.json` to match the property name in `FishSpawnLocationData`.

Screenshots:

<img width="628" alt="image" src="https://github.com/user-attachments/assets/85e8723d-ae99-4013-9454-9a56d520d8a6">
<img width="624" alt="image" src="https://github.com/user-attachments/assets/de8cd7ab-6e43-4c35-a605-3b9462c8a14a">
<img width="625" alt="image" src="https://github.com/user-attachments/assets/2648c3fa-7ef7-4537-b677-d1421e74f3f7">
<img width="631" alt="image" src="https://github.com/user-attachments/assets/9e7386e9-f184-40f7-a168-19bc34db89ae">

