### PR TITLE
[Lookup Anything] Add schedule to NPC lookup

### DIFF
--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -324,6 +324,38 @@ internal class DataParser
         return this.GetLocationDisplayName(fishSpawnData.LocationId, locationData, fishSpawnData.Area);
     }
 
+    /// <summary>Get the translated display name for a location and optional fish area.</summary>
+    /// <param name="id">The location's internal name.</param>
+    /// <param name="data">The location data, if available.</param>
+    /// <param name="fishAreaId">The fish area ID within the location, if applicable.</param>
+    public string GetLocationDisplayName(string id, LocationData? data, string? fishAreaId)
+    {
+        // special cases
+        {
+            // skip: no area set
+            if (string.IsNullOrWhiteSpace(fishAreaId))
+                return this.GetLocationDisplayName(id, data);
+
+            // special case: mine level
+            if (string.Equals(id, "UndergroundMine", StringComparison.OrdinalIgnoreCase))
+                return I18n.Location_UndergroundMine_Level(level: fishAreaId);
+        }
+
+        // get base data
+        string locationName = this.GetLocationDisplayName(id, data);
+        string areaName = TokenParser.ParseText(data?.FishAreas?.GetValueOrDefault(fishAreaId)?.DisplayName);
+
+        // build translation
+        string displayName = I18n.GetByKey($"location.{id}.{fishAreaId}", new { locationName }).UsePlaceholder(false); // predefined translation
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            displayName = !string.IsNullOrWhiteSpace(areaName)
+                ? I18n.Location_FishArea(locationName: locationName, areaName: areaName)
+                : I18n.Location_UnknownFishArea(locationName: locationName, id: fishAreaId);
+        }
+        return displayName;
+    }
+
     /// <summary>Parse monster data.</summary>
     /// <remarks>Reverse engineered from <see cref="StardewValley.Monsters.Monster.parseMonsterInfo"/>, <see cref="GameLocation.monsterDrop"/>, and the <see cref="Debris"/> constructor.</remarks>
     public IEnumerable<MonsterData> GetMonsters()
@@ -652,38 +684,6 @@ internal class DataParser
     /*********
     ** Private methods
     *********/
-    /// <summary>Get the translated display name for a location and optional fish area.</summary>
-    /// <param name="id">The location's internal name.</param>
-    /// <param name="data">The location data, if available.</param>
-    /// <param name="fishAreaId">The fish area ID within the location, if applicable.</param>
-    private string GetLocationDisplayName(string id, LocationData? data, string? fishAreaId)
-    {
-        // special cases
-        {
-            // skip: no area set
-            if (string.IsNullOrWhiteSpace(fishAreaId))
-                return this.GetLocationDisplayName(id, data);
-
-            // special case: mine level
-            if (string.Equals(id, "UndergroundMine", StringComparison.OrdinalIgnoreCase))
-                return I18n.Location_UndergroundMine_Level(level: fishAreaId);
-        }
-
-        // get base data
-        string locationName = this.GetLocationDisplayName(id, data);
-        string areaName = TokenParser.ParseText(data?.FishAreas?.GetValueOrDefault(fishAreaId)?.DisplayName);
-
-        // build translation
-        string displayName = I18n.GetByKey($"location.{id}.{fishAreaId}", new { locationName }).UsePlaceholder(false); // predefined translation
-        if (string.IsNullOrWhiteSpace(displayName))
-        {
-            displayName = !string.IsNullOrWhiteSpace(areaName)
-                ? I18n.Location_FishArea(locationName: locationName, areaName: areaName)
-                : I18n.Location_UnknownFishArea(locationName: locationName, id: fishAreaId);
-        }
-        return displayName;
-    }
-
     /// <summary>Get the translated display name for a location.</summary>
     /// <param name="id">The location's internal name.</param>
     /// <param name="data">The location data, if available.</param>

--- a/LookupAnything/Framework/Fields/ScheduleField.cs
+++ b/LookupAnything/Framework/Fields/ScheduleField.cs
@@ -57,7 +57,7 @@ internal class ScheduleField : GenericField
 
                 if (i > 0)
                     yield return new FormattedText(Environment.NewLine);
-                yield return new FormattedText($"{Game1.getTimeOfDayString(time)} - {locationName}", textColor);
+                yield return new FormattedText(I18n.Npc_Schedule_Entry(time: Game1.getTimeOfDayString(time), locationName: locationName, x: entry.targetTile.X, y: entry.targetTile.Y), textColor);
             }
         }
         else

--- a/LookupAnything/Framework/Fields/ScheduleField.cs
+++ b/LookupAnything/Framework/Fields/ScheduleField.cs
@@ -1,7 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using StardewValley;
 using StardewValley.Pathfinding;
 
@@ -12,19 +12,9 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields;
 /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
 internal class ScheduleField(Dictionary<int, SchedulePathDescription> schedule, GameHelper gameHelper) : GenericField(I18n.Npc_Schedule(), GetText(schedule, gameHelper))
 {
-    /// <inheritdoc />
-    public override Vector2? DrawValue(SpriteBatch spriteBatch, SpriteFont font, Vector2 position, float wrapWidth)
-    {
-        float topOffset = 0;
-
-        foreach (IFormattedText text in this.Value)
-        {
-            topOffset += spriteBatch.DrawTextBlock(font, [text], new Vector2(position.X, position.Y + topOffset), wrapWidth).Y;
-        }
-
-        return new Vector2(wrapWidth, topOffset);
-    }
-
+    /*********
+    ** Private methods
+    *********/
     /// <summary>Get the text to display.</summary>
     /// <param name="schedule">An NPC's loaded schedule.</param>
     /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
@@ -37,18 +27,18 @@ internal class ScheduleField(Dictionary<int, SchedulePathDescription> schedule, 
             (int time, SchedulePathDescription entry) = formattedSchedule[i];
 
             string timeString = formattedSchedule.Count == 1 ? I18n.Npc_Schedule_AllDay() : Game1.getTimeOfDayString(time);
-            string locationDisplayName = gameHelper.GetLocationDisplayName(entry.targetLocationName, Game1.getLocationFromName(entry.targetLocationName).GetData());
+            string locationName = gameHelper.GetLocationDisplayName(entry.targetLocationName, Game1.getLocationFromName(entry.targetLocationName).GetData());
 
-            bool didCurrentEventStart = Game1.timeOfDay >= time;
-            bool didNextEventStart = i < formattedSchedule.Count - 1 && Game1.timeOfDay >= formattedSchedule[i + 1].Time;
-            Color textColor;
+            bool isStarted = Game1.timeOfDay >= time;
+            bool isFinished = i < formattedSchedule.Count - 1 && Game1.timeOfDay >= formattedSchedule[i + 1].Time;
 
-            if (didCurrentEventStart)
-                textColor = didNextEventStart ? Color.Gray : Color.Green;
-            else
-                textColor = Color.Black;
+            Color textColor = isStarted
+                ? (isFinished ? Color.Gray : Color.Green)
+                : Color.Black;
 
-            yield return new FormattedText($"{timeString} - {locationDisplayName}", textColor);
+            if (i > 0)
+                yield return new FormattedText(Environment.NewLine);
+            yield return new FormattedText($"{timeString} - {locationName}", textColor);
         }
     }
 

--- a/LookupAnything/Framework/Fields/ScheduleField.cs
+++ b/LookupAnything/Framework/Fields/ScheduleField.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using StardewValley;
+using StardewValley.Pathfinding;
+
+namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
+{
+    /// <summary>A metadata field which shows an NPC's schedule.</summary>
+    /// <param name="schedule">The NPC's loaded schedule.</param>
+    /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
+    internal class ScheduleField(Dictionary<int, SchedulePathDescription> schedule, GameHelper gameHelper) : GenericField(I18n.Npc_Schedule(), GetText(schedule, gameHelper))
+    {
+        /// <inheritdoc />
+        public override Vector2? DrawValue(SpriteBatch spriteBatch, SpriteFont font, Vector2 position, float wrapWidth)
+        {
+            float topOffset = 0;
+
+            foreach (IFormattedText text in this.Value)
+            {
+                topOffset += spriteBatch.DrawTextBlock(font, [text], new Vector2(position.X, position.Y + topOffset), wrapWidth).Y;
+            }
+
+            return new Vector2(wrapWidth, topOffset);
+        }
+
+        /// <summary>Get the text to display.</summary>
+        /// <param name="schedule">An NPC's loaded schedule.</param>
+        /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
+        private static IEnumerable<IFormattedText> GetText(Dictionary<int, SchedulePathDescription> schedule, GameHelper gameHelper)
+        {
+            var formattedSchedule = FormatSchedule(schedule).ToList();
+
+            for (int i = 0; i < formattedSchedule.Count; i++)
+            {
+                (int time, SchedulePathDescription entry) = formattedSchedule[i];
+
+                string timeString = formattedSchedule.Count == 1 ? I18n.Npc_Schedule_AllDay() : Game1.getTimeOfDayString(time);
+                string locationDisplayName = gameHelper.GetLocationDisplayName(entry.targetLocationName, Game1.getLocationFromName(entry.targetLocationName).GetData());
+
+                // check if the current game time is between current and next schedule entry
+                bool isHappeningNow = Game1.timeOfDay >= time && (i >= formattedSchedule.Count - 1 || Game1.timeOfDay < formattedSchedule[i + 1].time);
+                Color textColor = isHappeningNow ? Color.Black : Color.Gray;
+
+                yield return new FormattedText($"{timeString} - {locationDisplayName}", textColor);
+            }
+        }
+
+        /// <summary>Returns a collection of schedule entries sorted by time. Consecutive entries with the same target location are omitted.</summary>
+        /// <param name="schedule">The schedule to format.</param>
+        private static IEnumerable<(int time, SchedulePathDescription entry)> FormatSchedule(Dictionary<int, SchedulePathDescription> schedule)
+        {
+            List<int> sortedKeys = [.. schedule.Keys.OrderBy(key => key)];
+            string prevTargetLocationName = string.Empty;
+
+            foreach (int time in sortedKeys)
+            {
+                // skip if the entry does not exist or the previous entry was for the same location
+                if (!schedule.TryGetValue(time, out SchedulePathDescription? entry) || entry.targetLocationName == prevTargetLocationName)
+                    continue;
+
+                prevTargetLocationName = entry.targetLocationName;
+                yield return (time, entry);
+            }
+        }
+    }
+}

--- a/LookupAnything/Framework/Fields/ScheduleField.cs
+++ b/LookupAnything/Framework/Fields/ScheduleField.cs
@@ -16,28 +16,33 @@ internal class ScheduleField(Dictionary<int, SchedulePathDescription> schedule, 
     ** Private methods
     *********/
     /// <summary>Get the text to display.</summary>
-    /// <param name="schedule">An NPC's loaded schedule.</param>
+    /// <param name="rawSchedule">An NPC's loaded schedule.</param>
     /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
-    private static IEnumerable<IFormattedText> GetText(Dictionary<int, SchedulePathDescription> schedule, GameHelper gameHelper)
+    private static IEnumerable<IFormattedText> GetText(Dictionary<int, SchedulePathDescription> rawSchedule, GameHelper gameHelper)
     {
-        List<ScheduleEntry> formattedSchedule = FormatSchedule(schedule).ToList();
+        ScheduleEntry[] schedule = ScheduleField.FormatSchedule(rawSchedule).ToArray();
 
-        for (int i = 0; i < formattedSchedule.Count; i++)
+        if (schedule.Length > 0)
         {
-            (int time, SchedulePathDescription entry) = formattedSchedule[i];
+            for (int i = 0; i < schedule.Length; i++)
+            {
+                (int time, SchedulePathDescription entry) = schedule[i];
 
-            string locationName = gameHelper.GetLocationDisplayName(entry.targetLocationName, Game1.getLocationFromName(entry.targetLocationName).GetData());
-            bool isStarted = Game1.timeOfDay >= time;
-            bool isFinished = i < formattedSchedule.Count - 1 && Game1.timeOfDay >= formattedSchedule[i + 1].Time;
+                string locationName = gameHelper.GetLocationDisplayName(entry.targetLocationName, Game1.getLocationFromName(entry.targetLocationName).GetData());
+                bool isStarted = Game1.timeOfDay >= time;
+                bool isFinished = i < schedule.Length - 1 && Game1.timeOfDay >= schedule[i + 1].Time;
 
-            Color textColor = isStarted
-                ? (isFinished ? Color.Gray : Color.Green)
-                : Color.Black;
+                Color textColor = isStarted
+                    ? (isFinished ? Color.Gray : Color.Green)
+                    : Color.Black;
 
-            if (i > 0)
-                yield return new FormattedText(Environment.NewLine);
-            yield return new FormattedText($"{Game1.getTimeOfDayString(time)} - {locationName}", textColor);
+                if (i > 0)
+                    yield return new FormattedText(Environment.NewLine);
+                yield return new FormattedText($"{Game1.getTimeOfDayString(time)} - {locationName}", textColor);
+            }
         }
+        else
+            yield return new FormattedText(I18n.Npc_Schedule_NoEntries());
     }
 
     /// <summary>Returns a collection of schedule entries sorted by time. Consecutive entries with the same target location are omitted.</summary>

--- a/LookupAnything/Framework/Fields/ScheduleField.cs
+++ b/LookupAnything/Framework/Fields/ScheduleField.cs
@@ -39,9 +39,14 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                 string timeString = formattedSchedule.Count == 1 ? I18n.Npc_Schedule_AllDay() : Game1.getTimeOfDayString(time);
                 string locationDisplayName = gameHelper.GetLocationDisplayName(entry.targetLocationName, Game1.getLocationFromName(entry.targetLocationName).GetData());
 
-                // check if the current game time is between current and next schedule entry
-                bool isHappeningNow = Game1.timeOfDay >= time && (i >= formattedSchedule.Count - 1 || Game1.timeOfDay < formattedSchedule[i + 1].time);
-                Color textColor = isHappeningNow ? Color.Black : Color.Gray;
+                bool didCurrentEventStart = Game1.timeOfDay >= time;
+                bool didNextEventStart = i < formattedSchedule.Count - 1 && Game1.timeOfDay >= formattedSchedule[i + 1].time;
+                Color textColor;
+
+                if (didCurrentEventStart)
+                    textColor = didNextEventStart ? Color.Gray : Color.Green;
+                else
+                    textColor = Color.Black;
 
                 yield return new FormattedText($"{timeString} - {locationDisplayName}", textColor);
             }

--- a/LookupAnything/Framework/Fields/ScheduleField.cs
+++ b/LookupAnything/Framework/Fields/ScheduleField.cs
@@ -5,74 +5,73 @@ using Microsoft.Xna.Framework.Graphics;
 using StardewValley;
 using StardewValley.Pathfinding;
 
-namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
+namespace Pathoschild.Stardew.LookupAnything.Framework.Fields;
+
+/// <summary>A metadata field which shows an NPC's schedule.</summary>
+/// <param name="schedule">The NPC's loaded schedule.</param>
+/// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
+internal class ScheduleField(Dictionary<int, SchedulePathDescription> schedule, GameHelper gameHelper) : GenericField(I18n.Npc_Schedule(), GetText(schedule, gameHelper))
 {
-    /// <summary>A metadata field which shows an NPC's schedule.</summary>
-    /// <param name="schedule">The NPC's loaded schedule.</param>
-    /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
-    internal class ScheduleField(Dictionary<int, SchedulePathDescription> schedule, GameHelper gameHelper) : GenericField(I18n.Npc_Schedule(), GetText(schedule, gameHelper))
+    /// <inheritdoc />
+    public override Vector2? DrawValue(SpriteBatch spriteBatch, SpriteFont font, Vector2 position, float wrapWidth)
     {
-        /// <inheritdoc />
-        public override Vector2? DrawValue(SpriteBatch spriteBatch, SpriteFont font, Vector2 position, float wrapWidth)
+        float topOffset = 0;
+
+        foreach (IFormattedText text in this.Value)
         {
-            float topOffset = 0;
-
-            foreach (IFormattedText text in this.Value)
-            {
-                topOffset += spriteBatch.DrawTextBlock(font, [text], new Vector2(position.X, position.Y + topOffset), wrapWidth).Y;
-            }
-
-            return new Vector2(wrapWidth, topOffset);
+            topOffset += spriteBatch.DrawTextBlock(font, [text], new Vector2(position.X, position.Y + topOffset), wrapWidth).Y;
         }
 
-        /// <summary>Get the text to display.</summary>
-        /// <param name="schedule">An NPC's loaded schedule.</param>
-        /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
-        private static IEnumerable<IFormattedText> GetText(Dictionary<int, SchedulePathDescription> schedule, GameHelper gameHelper)
-        {
-            List<ScheduleEntry> formattedSchedule = FormatSchedule(schedule).ToList();
-
-            for (int i = 0; i < formattedSchedule.Count; i++)
-            {
-                (int time, SchedulePathDescription entry) = formattedSchedule[i];
-
-                string timeString = formattedSchedule.Count == 1 ? I18n.Npc_Schedule_AllDay() : Game1.getTimeOfDayString(time);
-                string locationDisplayName = gameHelper.GetLocationDisplayName(entry.targetLocationName, Game1.getLocationFromName(entry.targetLocationName).GetData());
-
-                bool didCurrentEventStart = Game1.timeOfDay >= time;
-                bool didNextEventStart = i < formattedSchedule.Count - 1 && Game1.timeOfDay >= formattedSchedule[i + 1].Time;
-                Color textColor;
-
-                if (didCurrentEventStart)
-                    textColor = didNextEventStart ? Color.Gray : Color.Green;
-                else
-                    textColor = Color.Black;
-
-                yield return new FormattedText($"{timeString} - {locationDisplayName}", textColor);
-            }
-        }
-
-        /// <summary>Returns a collection of schedule entries sorted by time. Consecutive entries with the same target location are omitted.</summary>
-        /// <param name="schedule">The schedule to format.</param>
-        private static IEnumerable<ScheduleEntry> FormatSchedule(Dictionary<int, SchedulePathDescription> schedule)
-        {
-            List<int> sortedKeys = [.. schedule.Keys.OrderBy(key => key)];
-            string prevTargetLocationName = string.Empty;
-
-            foreach (int time in sortedKeys)
-            {
-                // skip if the entry does not exist or the previous entry was for the same location
-                if (!schedule.TryGetValue(time, out SchedulePathDescription? entry) || entry.targetLocationName == prevTargetLocationName)
-                    continue;
-
-                prevTargetLocationName = entry.targetLocationName;
-                yield return new ScheduleEntry(time, entry);
-            }
-        }
-
-        /// <summary>An entry in an NPC's schedule.</summary>
-        /// <param name="Time">The time that the event starts.</param>
-        /// <param name="Description">A description of the event.</param>
-        private record ScheduleEntry(int Time, SchedulePathDescription Description);
+        return new Vector2(wrapWidth, topOffset);
     }
+
+    /// <summary>Get the text to display.</summary>
+    /// <param name="schedule">An NPC's loaded schedule.</param>
+    /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
+    private static IEnumerable<IFormattedText> GetText(Dictionary<int, SchedulePathDescription> schedule, GameHelper gameHelper)
+    {
+        List<ScheduleEntry> formattedSchedule = FormatSchedule(schedule).ToList();
+
+        for (int i = 0; i < formattedSchedule.Count; i++)
+        {
+            (int time, SchedulePathDescription entry) = formattedSchedule[i];
+
+            string timeString = formattedSchedule.Count == 1 ? I18n.Npc_Schedule_AllDay() : Game1.getTimeOfDayString(time);
+            string locationDisplayName = gameHelper.GetLocationDisplayName(entry.targetLocationName, Game1.getLocationFromName(entry.targetLocationName).GetData());
+
+            bool didCurrentEventStart = Game1.timeOfDay >= time;
+            bool didNextEventStart = i < formattedSchedule.Count - 1 && Game1.timeOfDay >= formattedSchedule[i + 1].Time;
+            Color textColor;
+
+            if (didCurrentEventStart)
+                textColor = didNextEventStart ? Color.Gray : Color.Green;
+            else
+                textColor = Color.Black;
+
+            yield return new FormattedText($"{timeString} - {locationDisplayName}", textColor);
+        }
+    }
+
+    /// <summary>Returns a collection of schedule entries sorted by time. Consecutive entries with the same target location are omitted.</summary>
+    /// <param name="schedule">The schedule to format.</param>
+    private static IEnumerable<ScheduleEntry> FormatSchedule(Dictionary<int, SchedulePathDescription> schedule)
+    {
+        List<int> sortedKeys = [.. schedule.Keys.OrderBy(key => key)];
+        string prevTargetLocationName = string.Empty;
+
+        foreach (int time in sortedKeys)
+        {
+            // skip if the entry does not exist or the previous entry was for the same location
+            if (!schedule.TryGetValue(time, out SchedulePathDescription? entry) || entry.targetLocationName == prevTargetLocationName)
+                continue;
+
+            prevTargetLocationName = entry.targetLocationName;
+            yield return new ScheduleEntry(time, entry);
+        }
+    }
+
+    /// <summary>An entry in an NPC's schedule.</summary>
+    /// <param name="Time">The time that the event starts.</param>
+    /// <param name="Description">A description of the event.</param>
+    private record ScheduleEntry(int Time, SchedulePathDescription Description);
 }

--- a/LookupAnything/Framework/Fields/ScheduleField.cs
+++ b/LookupAnything/Framework/Fields/ScheduleField.cs
@@ -30,7 +30,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
         /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
         private static IEnumerable<IFormattedText> GetText(Dictionary<int, SchedulePathDescription> schedule, GameHelper gameHelper)
         {
-            var formattedSchedule = FormatSchedule(schedule).ToList();
+            List<ScheduleEntry> formattedSchedule = FormatSchedule(schedule).ToList();
 
             for (int i = 0; i < formattedSchedule.Count; i++)
             {
@@ -40,7 +40,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                 string locationDisplayName = gameHelper.GetLocationDisplayName(entry.targetLocationName, Game1.getLocationFromName(entry.targetLocationName).GetData());
 
                 bool didCurrentEventStart = Game1.timeOfDay >= time;
-                bool didNextEventStart = i < formattedSchedule.Count - 1 && Game1.timeOfDay >= formattedSchedule[i + 1].time;
+                bool didNextEventStart = i < formattedSchedule.Count - 1 && Game1.timeOfDay >= formattedSchedule[i + 1].Time;
                 Color textColor;
 
                 if (didCurrentEventStart)
@@ -54,7 +54,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
 
         /// <summary>Returns a collection of schedule entries sorted by time. Consecutive entries with the same target location are omitted.</summary>
         /// <param name="schedule">The schedule to format.</param>
-        private static IEnumerable<(int time, SchedulePathDescription entry)> FormatSchedule(Dictionary<int, SchedulePathDescription> schedule)
+        private static IEnumerable<ScheduleEntry> FormatSchedule(Dictionary<int, SchedulePathDescription> schedule)
         {
             List<int> sortedKeys = [.. schedule.Keys.OrderBy(key => key)];
             string prevTargetLocationName = string.Empty;
@@ -66,8 +66,13 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
                     continue;
 
                 prevTargetLocationName = entry.targetLocationName;
-                yield return (time, entry);
+                yield return new ScheduleEntry(time, entry);
             }
         }
+
+        /// <summary>An entry in an NPC's schedule.</summary>
+        /// <param name="Time">The time that the event starts.</param>
+        /// <param name="Description">A description of the event.</param>
+        private record ScheduleEntry(int Time, SchedulePathDescription Description);
     }
 }

--- a/LookupAnything/Framework/Fields/ScheduleField.cs
+++ b/LookupAnything/Framework/Fields/ScheduleField.cs
@@ -26,9 +26,7 @@ internal class ScheduleField(Dictionary<int, SchedulePathDescription> schedule, 
         {
             (int time, SchedulePathDescription entry) = formattedSchedule[i];
 
-            string timeString = formattedSchedule.Count == 1 ? I18n.Npc_Schedule_AllDay() : Game1.getTimeOfDayString(time);
             string locationName = gameHelper.GetLocationDisplayName(entry.targetLocationName, Game1.getLocationFromName(entry.targetLocationName).GetData());
-
             bool isStarted = Game1.timeOfDay >= time;
             bool isFinished = i < formattedSchedule.Count - 1 && Game1.timeOfDay >= formattedSchedule[i + 1].Time;
 
@@ -38,7 +36,7 @@ internal class ScheduleField(Dictionary<int, SchedulePathDescription> schedule, 
 
             if (i > 0)
                 yield return new FormattedText(Environment.NewLine);
-            yield return new FormattedText($"{timeString} - {locationName}", textColor);
+            yield return new FormattedText($"{Game1.getTimeOfDayString(time)} - {locationName}", textColor);
         }
     }
 

--- a/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
+++ b/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
@@ -400,6 +400,12 @@ internal class CharacterSubject : BaseSubject
                 if (this.ShowGiftTastes.Hated)
                     yield return this.GetGiftTasteField(I18n.Npc_HatesGifts(), giftTastes, ownedItems, GiftTaste.Hate);
             }
+
+            // schedule
+            if (npc.TryLoadSchedule())
+            {
+                yield return new ScheduleField(npc.Schedule, this.GameHelper);
+            }
         }
     }
 

--- a/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
+++ b/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
@@ -403,7 +403,7 @@ internal class CharacterSubject : BaseSubject
 
             // schedule
             if (npc is { Schedule: not null, ignoreScheduleToday: false, followSchedule: true })
-                yield return new ScheduleField(npc.Schedule, this.GameHelper);
+                yield return new ScheduleField(npc, this.GameHelper);
         }
     }
 

--- a/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
+++ b/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
@@ -402,10 +402,8 @@ internal class CharacterSubject : BaseSubject
             }
 
             // schedule
-            if (npc.TryLoadSchedule())
-            {
+            if (npc is { Schedule: not null, ignoreScheduleToday: false, followSchedule: true })
                 yield return new ScheduleField(npc.Schedule, this.GameHelper);
-            }
         }
     }
 

--- a/LookupAnything/GameHelper.cs
+++ b/LookupAnything/GameHelper.cs
@@ -28,6 +28,7 @@ using StardewValley.Extensions;
 using StardewValley.GameData.Crafting;
 using StardewValley.GameData.Crops;
 using StardewValley.GameData.FishPonds;
+using StardewValley.GameData.Locations;
 using StardewValley.ItemTypeDefinitions;
 using StardewValley.Locations;
 using StardewValley.Menus;
@@ -373,6 +374,15 @@ internal class GameHelper
     public string GetLocationDisplayName(FishSpawnLocationData fishSpawnData)
     {
         return this.DataParser.GetLocationDisplayName(fishSpawnData);
+    }
+
+    /// <summary>Get the translated display name for a location and optional fish area.</summary>
+    /// <param name="id">The location's internal name.</param>
+    /// <param name="data">The location data.</param>
+    /// <param name="fishAreaId">The fish area ID within the location, if applicable.</param>
+    public string GetLocationDisplayName(string id, LocationData data, string? fishAreaId = null)
+    {
+        return this.DataParser.GetLocationDisplayName(id, data, fishAreaId);
     }
 
     /// <summary>Parse monster data.</summary>

--- a/LookupAnything/GameHelper.cs
+++ b/LookupAnything/GameHelper.cs
@@ -376,13 +376,12 @@ internal class GameHelper
         return this.DataParser.GetLocationDisplayName(fishSpawnData);
     }
 
-    /// <summary>Get the translated display name for a location and optional fish area.</summary>
+    /// <summary>Get the translated display name for a location.</summary>
     /// <param name="id">The location's internal name.</param>
     /// <param name="data">The location data.</param>
-    /// <param name="fishAreaId">The fish area ID within the location, if applicable.</param>
-    public string GetLocationDisplayName(string id, LocationData data, string? fishAreaId = null)
+    public string GetLocationDisplayName(string id, LocationData? data)
     {
-        return this.DataParser.GetLocationDisplayName(id, data, fishAreaId);
+        return this.DataParser.GetLocationDisplayName(id, data);
     }
 
     /// <summary>Parse monster data.</summary>

--- a/LookupAnything/i18n/de.json
+++ b/LookupAnything/i18n/de.json
@@ -507,6 +507,7 @@
     "npc.unowned-gift-taste": "{{count}} nicht bessesene Gegenstände",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
+    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/de.json
+++ b/LookupAnything/i18n/de.json
@@ -505,7 +505,6 @@
     "npc.friendship.need-points": "nächstes in {{count}} Punkten",
     "npc.undiscovered-gift-taste": "{{count}} unaufgedeckte Gegenstände",
     "npc.unowned-gift-taste": "{{count}} nicht bessesene Gegenstände",
-    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/de.json
+++ b/LookupAnything/i18n/de.json
@@ -505,6 +505,7 @@
     "npc.friendship.need-points": "nächstes in {{count}} Punkten",
     "npc.undiscovered-gift-taste": "{{count}} unaufgedeckte Gegenstände",
     "npc.unowned-gift-taste": "{{count}} nicht bessesene Gegenstände",
+    "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/de.json
+++ b/LookupAnything/i18n/de.json
@@ -113,6 +113,10 @@
     "location.forest.island-tip": "Waldfluss (Südspitze der großen Insel)",
     "location.forest.lake": "Waldteich",
     "location.forest.river": "Waldfluss",
+    "location.HarveyRoom": "Harvey's Room", // TODO
+    "location.LeoTreeHouse": "Treehouse", // TODO
+    "location.SandyHouse": "Oasis", // TODO
+    "location.SebastianRoom": "Sebastian's Room", // TODO
     "location.submarine": "Nachtmarkt Tiefsee-U-Boot",
     "location.town.northmost-bridge": "Stadt (Nord-östliche Brücke)",
     "location.undergroundMine": "Mine",
@@ -491,6 +495,7 @@
     "npc.neutral-gifts": "Neutrale Geschenke",
     "npc.dislikes-gifts": "Nicht gemochte Geschenke",
     "npc.hates-gifts": "Gehasste Geschenke",
+    "npc.schedule": "Today's schedule", // TODO
 
     // values
     "npc.can-romance.married": "Du bist verheiratet! <", // < turns into a heart
@@ -500,6 +505,7 @@
     "npc.friendship.need-points": "nächstes in {{count}} Punkten",
     "npc.undiscovered-gift-taste": "{{count}} unaufgedeckte Gegenstände",
     "npc.unowned-gift-taste": "{{count}} nicht bessesene Gegenstände",
+    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/de.json
+++ b/LookupAnything/i18n/de.json
@@ -505,6 +505,7 @@
     "npc.friendship.need-points": "nächstes in {{count}} Punkten",
     "npc.undiscovered-gift-taste": "{{count}} unaufgedeckte Gegenstände",
     "npc.unowned-gift-taste": "{{count}} nicht bessesene Gegenstände",
+    "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 

--- a/LookupAnything/i18n/de.json
+++ b/LookupAnything/i18n/de.json
@@ -507,7 +507,7 @@
     "npc.unowned-gift-taste": "{{count}} nicht bessesene Gegenstände",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
-    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
+    "npc.schedule.entry": "{{time}}: walk to {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/default.json
+++ b/LookupAnything/i18n/default.json
@@ -113,6 +113,10 @@
     "location.forest.island-tip": "{{locationName}} (river near south tip of large island)",
     "location.forest.lake": "{{locationName}} (pond)",
     "location.forest.river": "{{locationName}} (river)",
+    "location.HarveyRoom":  "Harvey's Room",
+    "location.LeoTreeHouse": "Treehouse",
+    "location.SandyHouse": "Oasis",
+    "location.SebastianRoom": "Sebastian's Room",
     "location.submarine": "Night Market Submarine",
     "location.town.northmost-bridge": "{{locationName}} (northmost bridge)",
     "location.undergroundMine": "Mines",
@@ -491,6 +495,7 @@
     "npc.neutral-gifts": "Neutral gifts",
     "npc.dislikes-gifts": "Dislikes gifts",
     "npc.hates-gifts": "Hates gifts",
+    "npc.schedule": "Today's schedule",
 
     // values
     "npc.can-romance.married": "You're married! <", // < turns into a heart
@@ -500,6 +505,7 @@
     "npc.friendship.need-points": "next in {{count}} pts",
     "npc.undiscovered-gift-taste": "{{count}} unrevealed items",
     "npc.unowned-gift-taste": "{{count}} unowned items",
+    "npc.schedule.all-day": "All day",
 
 
     /*********

--- a/LookupAnything/i18n/default.json
+++ b/LookupAnything/i18n/default.json
@@ -507,6 +507,7 @@
     "npc.unowned-gift-taste": "{{count}} unowned items",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).",
     "npc.schedule.no-entries": "No schedule loaded.",
+    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).",
 
 
     /*********

--- a/LookupAnything/i18n/default.json
+++ b/LookupAnything/i18n/default.json
@@ -507,7 +507,7 @@
     "npc.unowned-gift-taste": "{{count}} unowned items",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).",
     "npc.schedule.no-entries": "No schedule loaded.",
-    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).",
+    "npc.schedule.entry": "{{time}}: walk to {{locationName}} ({{x}}, {{y}}).",
 
 
     /*********

--- a/LookupAnything/i18n/default.json
+++ b/LookupAnything/i18n/default.json
@@ -113,7 +113,7 @@
     "location.forest.island-tip": "{{locationName}} (river near south tip of large island)",
     "location.forest.lake": "{{locationName}} (pond)",
     "location.forest.river": "{{locationName}} (river)",
-    "location.HarveyRoom":  "Harvey's Room",
+    "location.HarveyRoom": "Harvey's Room",
     "location.LeoTreeHouse": "Treehouse",
     "location.SandyHouse": "Oasis",
     "location.SebastianRoom": "Sebastian's Room",
@@ -505,7 +505,6 @@
     "npc.friendship.need-points": "next in {{count}} pts",
     "npc.undiscovered-gift-taste": "{{count}} unrevealed items",
     "npc.unowned-gift-taste": "{{count}} unowned items",
-    "npc.schedule.all-day": "All day",
 
 
     /*********

--- a/LookupAnything/i18n/default.json
+++ b/LookupAnything/i18n/default.json
@@ -505,6 +505,7 @@
     "npc.friendship.need-points": "next in {{count}} pts",
     "npc.undiscovered-gift-taste": "{{count}} unrevealed items",
     "npc.unowned-gift-taste": "{{count}} unowned items",
+    "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).",
     "npc.schedule.no-entries": "No schedule loaded.",
 
 

--- a/LookupAnything/i18n/default.json
+++ b/LookupAnything/i18n/default.json
@@ -505,6 +505,7 @@
     "npc.friendship.need-points": "next in {{count}} pts",
     "npc.undiscovered-gift-taste": "{{count}} unrevealed items",
     "npc.unowned-gift-taste": "{{count}} unowned items",
+    "npc.schedule.no-entries": "No schedule loaded.",
 
 
     /*********

--- a/LookupAnything/i18n/es.json
+++ b/LookupAnything/i18n/es.json
@@ -506,6 +506,7 @@
     "npc.friendship.need-points": "siguiente en {{count}} puntos",
     "npc.undiscovered-gift-taste": "{{count}} items sin revelar",
     "npc.unowned-gift-taste": "{{count}} objetos no obtenidos",
+    "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 

--- a/LookupAnything/i18n/es.json
+++ b/LookupAnything/i18n/es.json
@@ -508,6 +508,7 @@
     "npc.unowned-gift-taste": "{{count}} objetos no obtenidos",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
+    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/es.json
+++ b/LookupAnything/i18n/es.json
@@ -506,7 +506,6 @@
     "npc.friendship.need-points": "siguiente en {{count}} puntos",
     "npc.undiscovered-gift-taste": "{{count}} items sin revelar",
     "npc.unowned-gift-taste": "{{count}} objetos no obtenidos",
-    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/es.json
+++ b/LookupAnything/i18n/es.json
@@ -506,6 +506,7 @@
     "npc.friendship.need-points": "siguiente en {{count}} puntos",
     "npc.undiscovered-gift-taste": "{{count}} items sin revelar",
     "npc.unowned-gift-taste": "{{count}} objetos no obtenidos",
+    "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/es.json
+++ b/LookupAnything/i18n/es.json
@@ -508,7 +508,7 @@
     "npc.unowned-gift-taste": "{{count}} objetos no obtenidos",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
-    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
+    "npc.schedule.entry": "{{time}}: walk to {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/es.json
+++ b/LookupAnything/i18n/es.json
@@ -113,6 +113,10 @@
     "location.forest.island-tip": "río de bosque (en la punta sureña de la gran isla)",
     "location.forest.lake": "estanque de bosque",
     "location.forest.river": "río de bosque",
+    "location.HarveyRoom": "Harvey's Room", // TODO
+    "location.LeoTreeHouse": "Treehouse", // TODO
+    "location.SandyHouse": "Oasis", // TODO
+    "location.SebastianRoom": "Sebastian's Room", // TODO
     "location.submarine": "submarino del Mercado de Noche",
     "location.town.northmost-bridge": "pueblo (en el puente más al norte)",
     "location.undergroundMine": "minas",
@@ -492,6 +496,7 @@
     "npc.neutral-gifts": "Regalos neutrales",
     "npc.dislikes-gifts": "Regalos que no le gustaron",
     "npc.hates-gifts": "Regalos odiados",
+    "npc.schedule": "Today's schedule", // TODO
 
     // values
     "npc.can-romance.married": "¡Estás casado! <", // < turns into a heart
@@ -501,6 +506,7 @@
     "npc.friendship.need-points": "siguiente en {{count}} puntos",
     "npc.undiscovered-gift-taste": "{{count}} items sin revelar",
     "npc.unowned-gift-taste": "{{count}} objetos no obtenidos",
+    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/fr.json
+++ b/LookupAnything/i18n/fr.json
@@ -508,6 +508,7 @@
     "npc.friendship.need-points": "manque {{count}} pts",
     "npc.undiscovered-gift-taste": "{{count}} goût(s) non révelé(s)",
     "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
+    "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/fr.json
+++ b/LookupAnything/i18n/fr.json
@@ -508,6 +508,7 @@
     "npc.friendship.need-points": "manque {{count}} pts",
     "npc.undiscovered-gift-taste": "{{count}} goût(s) non révelé(s)",
     "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
+    "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 

--- a/LookupAnything/i18n/fr.json
+++ b/LookupAnything/i18n/fr.json
@@ -510,7 +510,7 @@
     "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
-    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
+    "npc.schedule.entry": "{{time}}: walk to {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/fr.json
+++ b/LookupAnything/i18n/fr.json
@@ -115,6 +115,10 @@
     "location.forest.island-tip": "rivière de la forêt (pointe sud de la grande île)",
     "location.forest.lake": "étang de la forêt",
     "location.forest.river": "rivère de la forêt",
+    "location.HarveyRoom": "Harvey's Room", // TODO
+    "location.LeoTreeHouse": "Treehouse", // TODO
+    "location.SandyHouse": "Oasis", // TODO
+    "location.SebastianRoom": "Sebastian's Room", // TODO
     "location.submarine": "sous-marin du marché de nuit",
     "location.town.northmost-bridge": "ville (pont le plus au nord)",
     "location.undergroundMine": "mines",
@@ -494,6 +498,7 @@
     "npc.neutral-gifts": "Cadeaux neutres",
     "npc.dislikes-gifts": "Cadeaux non appréciés",
     "npc.hates-gifts": "Cadeaux détestés",
+    "npc.schedule": "Today's schedule", // TODO
 
     // values
     "npc.can-romance.married": "Vous êtes mariés ! <", // < turns into a heart
@@ -503,6 +508,7 @@
     "npc.friendship.need-points": "manque {{count}} pts",
     "npc.undiscovered-gift-taste": "{{count}} goût(s) non révelé(s)",
     "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
+    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/fr.json
+++ b/LookupAnything/i18n/fr.json
@@ -510,6 +510,7 @@
     "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
+    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/fr.json
+++ b/LookupAnything/i18n/fr.json
@@ -508,7 +508,6 @@
     "npc.friendship.need-points": "manque {{count}} pts",
     "npc.undiscovered-gift-taste": "{{count}} goût(s) non révelé(s)",
     "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
-    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/hu.json
+++ b/LookupAnything/i18n/hu.json
@@ -508,6 +508,7 @@
     "npc.friendship.need-points": "Következő szint {{count}} pont múlva",
     "npc.undiscovered-gift-taste": "{{count}} fel nem fedezett dolog",
     "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
+    "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 

--- a/LookupAnything/i18n/hu.json
+++ b/LookupAnything/i18n/hu.json
@@ -113,6 +113,10 @@
     "location.forest.island-tip": "erdei folyó (nagy sziget déli csücske)",
     "location.forest.lake": "erdei tó",
     "location.forest.river": "erdei folyó",
+    "location.HarveyRoom": "Harvey's Room", // TODO
+    "location.LeoTreeHouse": "Treehouse", // TODO
+    "location.SandyHouse": "Oasis", // TODO
+    "location.SebastianRoom": "Sebastian's Room", // TODO
     "location.submarine": "Éjszakai Piac tengeralattjáró",
     "location.town.northmost-bridge": "város (legészakibb híd)",
     "location.undergroundMine": "bányák",
@@ -494,6 +498,7 @@
     "npc.neutral-gifts": "Semleges ajándékok",
     "npc.dislikes-gifts": "Ajándékok, melyeket nem szeret",
     "npc.hates-gifts": "Ajándékok, melyeket utál",
+    "npc.schedule": "Today's schedule", // TODO
 
     // values
     "npc.can-romance.married": "Házastársak vagytok! <", // < turns into a heart
@@ -503,6 +508,7 @@
     "npc.friendship.need-points": "Következő szint {{count}} pont múlva",
     "npc.undiscovered-gift-taste": "{{count}} fel nem fedezett dolog",
     "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
+    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/hu.json
+++ b/LookupAnything/i18n/hu.json
@@ -508,6 +508,7 @@
     "npc.friendship.need-points": "Következő szint {{count}} pont múlva",
     "npc.undiscovered-gift-taste": "{{count}} fel nem fedezett dolog",
     "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
+    "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/hu.json
+++ b/LookupAnything/i18n/hu.json
@@ -510,7 +510,7 @@
     "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
-    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
+    "npc.schedule.entry": "{{time}}: walk to {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/hu.json
+++ b/LookupAnything/i18n/hu.json
@@ -508,7 +508,6 @@
     "npc.friendship.need-points": "Következő szint {{count}} pont múlva",
     "npc.undiscovered-gift-taste": "{{count}} fel nem fedezett dolog",
     "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
-    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/hu.json
+++ b/LookupAnything/i18n/hu.json
@@ -510,6 +510,7 @@
     "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
+    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/it.json
+++ b/LookupAnything/i18n/it.json
@@ -506,7 +506,7 @@
     "npc.unowned-gift-taste": "{{count}} oggetti non posseduti",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
-    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
+    "npc.schedule.entry": "{{time}}: walk to {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/it.json
+++ b/LookupAnything/i18n/it.json
@@ -504,7 +504,6 @@
     "npc.friendship.need-points": "prossimo fra {{count}} pti",
     "npc.undiscovered-gift-taste": "{{count}} oggetti non rivelati",
     "npc.unowned-gift-taste": "{{count}} oggetti non posseduti",
-    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/it.json
+++ b/LookupAnything/i18n/it.json
@@ -506,6 +506,7 @@
     "npc.unowned-gift-taste": "{{count}} oggetti non posseduti",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
+    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/it.json
+++ b/LookupAnything/i18n/it.json
@@ -504,6 +504,7 @@
     "npc.friendship.need-points": "prossimo fra {{count}} pti",
     "npc.undiscovered-gift-taste": "{{count}} oggetti non rivelati",
     "npc.unowned-gift-taste": "{{count}} oggetti non posseduti",
+    "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/it.json
+++ b/LookupAnything/i18n/it.json
@@ -112,6 +112,10 @@
     "location.forest.island-tip": "fiume nella foresta (punta Sud dell'isola maggiore)",
     "location.forest.lake": "laghetto nella foresta",
     "location.forest.river": "fiume nella foresta",
+    "location.HarveyRoom": "Harvey's Room", // TODO
+    "location.LeoTreeHouse": "Treehouse", // TODO
+    "location.SandyHouse": "Oasis", // TODO
+    "location.SebastianRoom": "Sebastian's Room", // TODO
     "location.submarine": "sottomarino",
     "location.town.northmost-bridge": "paese (ponte Nord)",
     "location.undergroundMine": "miniera",
@@ -490,6 +494,7 @@
     "npc.neutral-gifts": "Regali neutrali",
     "npc.dislikes-gifts": "Regali che non piacciono",
     "npc.hates-gifts": "Regali che odia",
+    "npc.schedule": "Today's schedule", // TODO
 
     // values
     "npc.can-romance.married": "Siete sposati! <", // < turns into a heart
@@ -499,6 +504,7 @@
     "npc.friendship.need-points": "prossimo fra {{count}} pti",
     "npc.undiscovered-gift-taste": "{{count}} oggetti non rivelati",
     "npc.unowned-gift-taste": "{{count}} oggetti non posseduti",
+    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/it.json
+++ b/LookupAnything/i18n/it.json
@@ -504,6 +504,7 @@
     "npc.friendship.need-points": "prossimo fra {{count}} pti",
     "npc.undiscovered-gift-taste": "{{count}} oggetti non rivelati",
     "npc.unowned-gift-taste": "{{count}} oggetti non posseduti",
+    "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 

--- a/LookupAnything/i18n/ja.json
+++ b/LookupAnything/i18n/ja.json
@@ -505,7 +505,6 @@
     "npc.friendship.need-points": "次のハートまで{{count}}ポイント必要",
     "npc.undiscovered-gift-taste": "{{count}}個の贈った事のないアイテム",
     "npc.unowned-gift-taste": "{{count}}個のアイテムは未所有",
-    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/ja.json
+++ b/LookupAnything/i18n/ja.json
@@ -507,6 +507,7 @@
     "npc.unowned-gift-taste": "{{count}}個のアイテムは未所有",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
+    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/ja.json
+++ b/LookupAnything/i18n/ja.json
@@ -505,6 +505,7 @@
     "npc.friendship.need-points": "次のハートまで{{count}}ポイント必要",
     "npc.undiscovered-gift-taste": "{{count}}個の贈った事のないアイテム",
     "npc.unowned-gift-taste": "{{count}}個のアイテムは未所有",
+    "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/ja.json
+++ b/LookupAnything/i18n/ja.json
@@ -507,7 +507,7 @@
     "npc.unowned-gift-taste": "{{count}}個のアイテムは未所有",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
-    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
+    "npc.schedule.entry": "{{time}}: walk to {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/ja.json
+++ b/LookupAnything/i18n/ja.json
@@ -505,6 +505,7 @@
     "npc.friendship.need-points": "次のハートまで{{count}}ポイント必要",
     "npc.undiscovered-gift-taste": "{{count}}個の贈った事のないアイテム",
     "npc.unowned-gift-taste": "{{count}}個のアイテムは未所有",
+    "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 

--- a/LookupAnything/i18n/ja.json
+++ b/LookupAnything/i18n/ja.json
@@ -113,6 +113,10 @@
     "location.forest.island-tip": "森の川（南の小島の南端）",
     "location.forest.lake": "森の池",
     "location.forest.river": "森の川",
+    "location.HarveyRoom": "Harvey's Room", // TODO
+    "location.LeoTreeHouse": "Treehouse", // TODO
+    "location.SandyHouse": "Oasis", // TODO
+    "location.SebastianRoom": "Sebastian's Room", // TODO
     "location.submarine": "夜の市 潜水艦",
     "location.town.northmost-bridge": "ペリカンタウン（北端の橋）",
     "location.undergroundMine": "鉱山",
@@ -491,6 +495,7 @@
     "npc.neutral-gifts": "普通の贈り物",
     "npc.dislikes-gifts": "嫌いな贈り物",
     "npc.hates-gifts": "大嫌いな贈り物",
+    "npc.schedule": "Today's schedule", // TODO
 
     // values
     "npc.can-romance.married": "あなたと結婚しました！", // < turns into a heart
@@ -500,6 +505,7 @@
     "npc.friendship.need-points": "次のハートまで{{count}}ポイント必要",
     "npc.undiscovered-gift-taste": "{{count}}個の贈った事のないアイテム",
     "npc.unowned-gift-taste": "{{count}}個のアイテムは未所有",
+    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/ko.json
+++ b/LookupAnything/i18n/ko.json
@@ -505,6 +505,7 @@
     "npc.friendship.need-points": "호감도 UP까지 {{count}}점",
     "npc.undiscovered-gift-taste": "공개되지 않은 품목 {{count}}개",
     "npc.unowned-gift-taste": "소유하지 않은 품목 {{count}}개",
+    "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/ko.json
+++ b/LookupAnything/i18n/ko.json
@@ -113,6 +113,10 @@
     "location.forest.island-tip": "섬 (큰 섬의 남쪽 끝)",
     "location.forest.lake": "숲 호수",
     "location.forest.river": "숲 강",
+    "location.HarveyRoom": "Harvey's Room", // TODO
+    "location.LeoTreeHouse": "Treehouse", // TODO
+    "location.SandyHouse": "Oasis", // TODO
+    "location.SebastianRoom": "Sebastian's Room", // TODO
     "location.submarine": "야시장 잠수함",
     "location.town.northmost-bridge": "마을 (최북단의 다리)",
     "location.undergroundMine": "광산",
@@ -491,6 +495,7 @@
     "npc.neutral-gifts": "그저그런 선물",
     "npc.dislikes-gifts": "싫어하는 선물",
     "npc.hates-gifts": "혐오하는 선물",
+    "npc.schedule": "Today's schedule", // TODO
 
     // values
     "npc.can-romance.married": "당신은 이미 결혼했다!", // < turns into a heart (Korean does not support emoji)
@@ -500,6 +505,7 @@
     "npc.friendship.need-points": "호감도 UP까지 {{count}}점",
     "npc.undiscovered-gift-taste": "공개되지 않은 품목 {{count}}개",
     "npc.unowned-gift-taste": "소유하지 않은 품목 {{count}}개",
+    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/ko.json
+++ b/LookupAnything/i18n/ko.json
@@ -507,7 +507,7 @@
     "npc.unowned-gift-taste": "소유하지 않은 품목 {{count}}개",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
-    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
+    "npc.schedule.entry": "{{time}}: walk to {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/ko.json
+++ b/LookupAnything/i18n/ko.json
@@ -505,6 +505,7 @@
     "npc.friendship.need-points": "호감도 UP까지 {{count}}점",
     "npc.undiscovered-gift-taste": "공개되지 않은 품목 {{count}}개",
     "npc.unowned-gift-taste": "소유하지 않은 품목 {{count}}개",
+    "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 

--- a/LookupAnything/i18n/ko.json
+++ b/LookupAnything/i18n/ko.json
@@ -507,6 +507,7 @@
     "npc.unowned-gift-taste": "소유하지 않은 품목 {{count}}개",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
+    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/ko.json
+++ b/LookupAnything/i18n/ko.json
@@ -505,7 +505,6 @@
     "npc.friendship.need-points": "호감도 UP까지 {{count}}점",
     "npc.undiscovered-gift-taste": "공개되지 않은 품목 {{count}}개",
     "npc.unowned-gift-taste": "소유하지 않은 품목 {{count}}개",
-    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/pl.json
+++ b/LookupAnything/i18n/pl.json
@@ -505,6 +505,7 @@
     "npc.friendship.need-points": "następne za {{count}} pkt",
     "npc.undiscovered-gift-taste": "{{count}} nieodkrytych przedmiotów",
     "npc.unowned-gift-taste": "{{count}} nieposiadanych przedmiotów",
+    "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/pl.json
+++ b/LookupAnything/i18n/pl.json
@@ -505,7 +505,6 @@
     "npc.friendship.need-points": "następne za {{count}} pkt",
     "npc.undiscovered-gift-taste": "{{count}} nieodkrytych przedmiotów",
     "npc.unowned-gift-taste": "{{count}} nieposiadanych przedmiotów",
-    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/pl.json
+++ b/LookupAnything/i18n/pl.json
@@ -507,6 +507,7 @@
     "npc.unowned-gift-taste": "{{count}} nieposiadanych przedmiotów",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
+    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/pl.json
+++ b/LookupAnything/i18n/pl.json
@@ -505,6 +505,7 @@
     "npc.friendship.need-points": "następne za {{count}} pkt",
     "npc.undiscovered-gift-taste": "{{count}} nieodkrytych przedmiotów",
     "npc.unowned-gift-taste": "{{count}} nieposiadanych przedmiotów",
+    "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 

--- a/LookupAnything/i18n/pl.json
+++ b/LookupAnything/i18n/pl.json
@@ -507,7 +507,7 @@
     "npc.unowned-gift-taste": "{{count}} nieposiadanych przedmiotów",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
-    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
+    "npc.schedule.entry": "{{time}}: walk to {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/pl.json
+++ b/LookupAnything/i18n/pl.json
@@ -113,6 +113,10 @@
     "location.forest.island-tip": "leśna rzeka (południowy kraniec dużej wyspy)",
     "location.forest.lake": "leśny staw",
     "location.forest.river": "leśna rzeka",
+    "location.HarveyRoom": "Harvey's Room", // TODO
+    "location.LeoTreeHouse": "Treehouse", // TODO
+    "location.SandyHouse": "Oasis", // TODO
+    "location.SebastianRoom": "Sebastian's Room", // TODO
     "location.submarine": "łódź podwodna Nocnego Rynku",
     "location.town.northmost-bridge": "miasto (kładka na północy)",
     "location.undergroundMine": "kopalnia",
@@ -491,6 +495,7 @@
     "npc.neutral-gifts": "Neutralne prezenty",
     "npc.dislikes-gifts": "Nielubiane prezenty",
     "npc.hates-gifts": "Znienawidzone prezenty",
+    "npc.schedule": "Today's schedule", // TODO
 
     // values
     "npc.can-romance.married": "Jesteście małżeństwem! <", // < turns into a heart
@@ -500,6 +505,7 @@
     "npc.friendship.need-points": "następne za {{count}} pkt",
     "npc.undiscovered-gift-taste": "{{count}} nieodkrytych przedmiotów",
     "npc.unowned-gift-taste": "{{count}} nieposiadanych przedmiotów",
+    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/pt.json
+++ b/LookupAnything/i18n/pt.json
@@ -508,6 +508,7 @@
     "npc.unowned-gift-taste": "{{count}} itens não possuídos",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
+    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/pt.json
+++ b/LookupAnything/i18n/pt.json
@@ -508,7 +508,7 @@
     "npc.unowned-gift-taste": "{{count}} itens não possuídos",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
-    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
+    "npc.schedule.entry": "{{time}}: walk to {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/pt.json
+++ b/LookupAnything/i18n/pt.json
@@ -506,6 +506,7 @@
     "npc.friendship.need-points": "Precisa de {{count}} pontos para prosseguir",
     "npc.undiscovered-gift-taste": "{{count}} itens não revelados",
     "npc.unowned-gift-taste": "{{count}} itens não possuídos",
+    "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/pt.json
+++ b/LookupAnything/i18n/pt.json
@@ -506,7 +506,6 @@
     "npc.friendship.need-points": "Precisa de {{count}} pontos para prosseguir",
     "npc.undiscovered-gift-taste": "{{count}} itens não revelados",
     "npc.unowned-gift-taste": "{{count}} itens não possuídos",
-    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/pt.json
+++ b/LookupAnything/i18n/pt.json
@@ -506,6 +506,7 @@
     "npc.friendship.need-points": "Precisa de {{count}} pontos para prosseguir",
     "npc.undiscovered-gift-taste": "{{count}} itens não revelados",
     "npc.unowned-gift-taste": "{{count}} itens não possuídos",
+    "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 

--- a/LookupAnything/i18n/pt.json
+++ b/LookupAnything/i18n/pt.json
@@ -113,6 +113,10 @@
     "location.forest.island-tip": "Rio da Floresta Cinzaseiva (ponta sul da ilha grande)",
     "location.forest.lake": "Lagoa da Floresta Cinzaseiva",
     "location.forest.river": "Rio da Floresta Cinzaseiva",
+    "location.HarveyRoom": "Harvey's Room", // TODO
+    "location.LeoTreeHouse": "Treehouse", // TODO
+    "location.SandyHouse": "Oasis", // TODO
+    "location.SebastianRoom": "Sebastian's Room", // TODO
     "location.submarine": "Submarino de Pesca do Mercado Noturno",
     "location.town.northmost-bridge": "Cidade (ponte mais ao norte)",
     "location.undergroundMine": "Minas",
@@ -492,6 +496,7 @@
     "npc.neutral-gifts": "Presentes neutros",
     "npc.dislikes-gifts": "Presentes que não gosta",
     "npc.hates-gifts": "Presentes que odeia",
+    "npc.schedule": "Today's schedule", // TODO
 
     // values
     "npc.can-romance.married": "Você é casado! <", // < turns into a heart
@@ -501,6 +506,7 @@
     "npc.friendship.need-points": "Precisa de {{count}} pontos para prosseguir",
     "npc.undiscovered-gift-taste": "{{count}} itens não revelados",
     "npc.unowned-gift-taste": "{{count}} itens não possuídos",
+    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/ru.json
+++ b/LookupAnything/i18n/ru.json
@@ -507,6 +507,7 @@
     "npc.unowned-gift-taste": "{{count}} бесхозных предметов",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
+    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/ru.json
+++ b/LookupAnything/i18n/ru.json
@@ -505,6 +505,7 @@
     "npc.friendship.need-points": "след. через {{count}}",
     "npc.undiscovered-gift-taste": "{{count}} нераскрытых предметов",
     "npc.unowned-gift-taste": "{{count}} бесхозных предметов",
+    "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/ru.json
+++ b/LookupAnything/i18n/ru.json
@@ -505,6 +505,7 @@
     "npc.friendship.need-points": "след. через {{count}}",
     "npc.undiscovered-gift-taste": "{{count}} нераскрытых предметов",
     "npc.unowned-gift-taste": "{{count}} бесхозных предметов",
+    "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 

--- a/LookupAnything/i18n/ru.json
+++ b/LookupAnything/i18n/ru.json
@@ -505,7 +505,6 @@
     "npc.friendship.need-points": "след. через {{count}}",
     "npc.undiscovered-gift-taste": "{{count}} нераскрытых предметов",
     "npc.unowned-gift-taste": "{{count}} бесхозных предметов",
-    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/ru.json
+++ b/LookupAnything/i18n/ru.json
@@ -507,7 +507,7 @@
     "npc.unowned-gift-taste": "{{count}} бесхозных предметов",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
-    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
+    "npc.schedule.entry": "{{time}}: walk to {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/ru.json
+++ b/LookupAnything/i18n/ru.json
@@ -113,6 +113,10 @@
     "location.forest.island-tip": "лесная река (южная часть большого острова)",
     "location.forest.lake": "лесное озеро",
     "location.forest.river": "лесная река",
+    "location.HarveyRoom": "Harvey's Room", // TODO
+    "location.LeoTreeHouse": "Treehouse", // TODO
+    "location.SandyHouse": "Oasis", // TODO
+    "location.SebastianRoom": "Sebastian's Room", // TODO
     "location.submarine": "ночной Рынок на подводной лодке",
     "location.town.northmost-bridge": "город (самый северный мост)",
     "location.undergroundMine": "шахты",
@@ -491,6 +495,7 @@
     "npc.neutral-gifts": "Равнодушен к подаркам:",
     "npc.dislikes-gifts": "Не любит подарки",
     "npc.hates-gifts": "Ненавидит подарки",
+    "npc.schedule": "Today's schedule", // TODO
 
     // values
     "npc.can-romance.married": "Вы женаты! <", // < turns into a heart
@@ -500,6 +505,7 @@
     "npc.friendship.need-points": "след. через {{count}}",
     "npc.undiscovered-gift-taste": "{{count}} нераскрытых предметов",
     "npc.unowned-gift-taste": "{{count}} бесхозных предметов",
+    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/th.json
+++ b/LookupAnything/i18n/th.json
@@ -508,6 +508,7 @@
     "npc.friendship.need-points": "เลื่อนขั้นใน {{count}} แต้ม",
     "npc.undiscovered-gift-taste": "{{count}} ชิ้นที่ยังไม่เปิดเผย",
     "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
+    "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/th.json
+++ b/LookupAnything/i18n/th.json
@@ -508,6 +508,7 @@
     "npc.friendship.need-points": "เลื่อนขั้นใน {{count}} แต้ม",
     "npc.undiscovered-gift-taste": "{{count}} ชิ้นที่ยังไม่เปิดเผย",
     "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
+    "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 

--- a/LookupAnything/i18n/th.json
+++ b/LookupAnything/i18n/th.json
@@ -113,6 +113,10 @@
     "location.forest.island-tip": "แม่น้ำในป่า (ปลายทางใต้สุดของเกาะใหญ่กลางแม่น้ำ)",
     "location.forest.lake": "ทะลสาบในป่า",
     "location.forest.river": "แม่น้ำในป่า",
+    "location.HarveyRoom": "Harvey's Room", // TODO
+    "location.LeoTreeHouse": "Treehouse", // TODO
+    "location.SandyHouse": "Oasis", // TODO
+    "location.SebastianRoom": "Sebastian's Room", // TODO
     "location.submarine": "เรือดำน้ำในงานตลาดกลางคืน",
     "location.town.northmost-bridge": "เมือง (สะพานที่อยู่ทิศเหนือสุดของเมือง)",
     "location.undergroundMine": "เหมือง",
@@ -494,6 +498,7 @@
     "npc.neutral-gifts": "ของขวัญที่เฉยๆ",
     "npc.dislikes-gifts": "ของขวัญที่ไม่ชอบ",
     "npc.hates-gifts": "ของขวัญที่เกลียด",
+    "npc.schedule": "Today's schedule", // TODO
 
     // values
     "npc.can-romance.married": "คุณแต่งงานกันแล้ว! <3", // < turns into a heart
@@ -503,6 +508,7 @@
     "npc.friendship.need-points": "เลื่อนขั้นใน {{count}} แต้ม",
     "npc.undiscovered-gift-taste": "{{count}} ชิ้นที่ยังไม่เปิดเผย",
     "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
+    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/th.json
+++ b/LookupAnything/i18n/th.json
@@ -508,7 +508,6 @@
     "npc.friendship.need-points": "เลื่อนขั้นใน {{count}} แต้ม",
     "npc.undiscovered-gift-taste": "{{count}} ชิ้นที่ยังไม่เปิดเผย",
     "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
-    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/th.json
+++ b/LookupAnything/i18n/th.json
@@ -510,7 +510,7 @@
     "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
-    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
+    "npc.schedule.entry": "{{time}}: walk to {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/th.json
+++ b/LookupAnything/i18n/th.json
@@ -510,6 +510,7 @@
     "npc.unowned-gift-taste": "{{count}} unowned items", // TODO
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
+    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/tr.json
+++ b/LookupAnything/i18n/tr.json
@@ -505,7 +505,6 @@
     "npc.friendship.need-points": "{{count}} puana gelişir",
     "npc.undiscovered-gift-taste": "{{count}} gizli nesneler",
     "npc.unowned-gift-taste": "{{count}} sahipsiz öğe",
-    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/tr.json
+++ b/LookupAnything/i18n/tr.json
@@ -507,6 +507,7 @@
     "npc.unowned-gift-taste": "{{count}} sahipsiz öğe",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
+    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/tr.json
+++ b/LookupAnything/i18n/tr.json
@@ -507,7 +507,7 @@
     "npc.unowned-gift-taste": "{{count}} sahipsiz öğe",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
-    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
+    "npc.schedule.entry": "{{time}}: walk to {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/tr.json
+++ b/LookupAnything/i18n/tr.json
@@ -505,6 +505,7 @@
     "npc.friendship.need-points": "{{count}} puana gelişir",
     "npc.undiscovered-gift-taste": "{{count}} gizli nesneler",
     "npc.unowned-gift-taste": "{{count}} sahipsiz öğe",
+    "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/tr.json
+++ b/LookupAnything/i18n/tr.json
@@ -113,6 +113,10 @@
     "location.forest.island-tip": "Orman Nehri (büyük adanın güney ucu)",
     "location.forest.lake": "Orman Göleti",
     "location.forest.river": "Orman Nehri",
+    "location.HarveyRoom": "Harvey's Room", // TODO
+    "location.LeoTreeHouse": "Treehouse", // TODO
+    "location.SandyHouse": "Oasis", // TODO
+    "location.SebastianRoom": "Sebastian's Room", // TODO
     "location.submarine": "Akşam Pazarı Denizaltısı",
     "location.town.northmost-bridge": "Kasaba (en kuzeydeki köprü)",
     "location.undergroundMine": "Maden",
@@ -491,6 +495,7 @@
     "npc.neutral-gifts": "Nötr hediyeler",
     "npc.dislikes-gifts": "Beğenilmeyen hediyeler",
     "npc.hates-gifts": "Nefret edilen hediyeler",
+    "npc.schedule": "Today's schedule", // TODO
 
     // values
     "npc.can-romance.married": "Evlisin! <", // < turns into a heart
@@ -500,6 +505,7 @@
     "npc.friendship.need-points": "{{count}} puana gelişir",
     "npc.undiscovered-gift-taste": "{{count}} gizli nesneler",
     "npc.unowned-gift-taste": "{{count}} sahipsiz öğe",
+    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/tr.json
+++ b/LookupAnything/i18n/tr.json
@@ -505,6 +505,7 @@
     "npc.friendship.need-points": "{{count}} puana gelişir",
     "npc.undiscovered-gift-taste": "{{count}} gizli nesneler",
     "npc.unowned-gift-taste": "{{count}} sahipsiz öğe",
+    "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 

--- a/LookupAnything/i18n/uk.json
+++ b/LookupAnything/i18n/uk.json
@@ -506,7 +506,6 @@
     "npc.friendship.need-points": "Наступн. за {{count}}",
     "npc.undiscovered-gift-taste": "{{count}} незвіданих предметів",
     "npc.unowned-gift-taste": "{{count}} предметів, якими ви ніколи не володіли",
-    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/uk.json
+++ b/LookupAnything/i18n/uk.json
@@ -508,7 +508,7 @@
     "npc.unowned-gift-taste": "{{count}} предметів, якими ви ніколи не володіли",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
-    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
+    "npc.schedule.entry": "{{time}}: walk to {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/uk.json
+++ b/LookupAnything/i18n/uk.json
@@ -113,6 +113,10 @@
     "location.forest.island-tip": "Лісова річка (південна частина великого острова)",
     "location.forest.lake": "Лісове озеро",
     "location.forest.river": "Лісова річка",
+    "location.HarveyRoom": "Harvey's Room", // TODO
+    "location.LeoTreeHouse": "Treehouse", // TODO
+    "location.SandyHouse": "Oasis", // TODO
+    "location.SebastianRoom": "Sebastian's Room", // TODO
     "location.submarine": "Підводний човен Нічного ринку",
     "location.town.northmost-bridge": "Місто (найпівнічніший міст)",
     "location.undergroundMine": "Шахта",
@@ -492,6 +496,7 @@
     "npc.neutral-gifts": "Байдуже ставиться до :",
     "npc.dislikes-gifts": "Не любить подарунки",
     "npc.hates-gifts": "Ненавидить подарунки",
+    "npc.schedule": "Today's schedule", // TODO
 
     // values
     "npc.can-romance.married": "Ви одружені! <", // < turns into a heart
@@ -501,6 +506,7 @@
     "npc.friendship.need-points": "Наступн. за {{count}}",
     "npc.undiscovered-gift-taste": "{{count}} незвіданих предметів",
     "npc.unowned-gift-taste": "{{count}} предметів, якими ви ніколи не володіли",
+    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/uk.json
+++ b/LookupAnything/i18n/uk.json
@@ -508,6 +508,7 @@
     "npc.unowned-gift-taste": "{{count}} предметів, якими ви ніколи не володіли",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
+    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/uk.json
+++ b/LookupAnything/i18n/uk.json
@@ -506,6 +506,7 @@
     "npc.friendship.need-points": "Наступн. за {{count}}",
     "npc.undiscovered-gift-taste": "{{count}} незвіданих предметів",
     "npc.unowned-gift-taste": "{{count}} предметів, якими ви ніколи не володіли",
+    "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 

--- a/LookupAnything/i18n/uk.json
+++ b/LookupAnything/i18n/uk.json
@@ -506,6 +506,7 @@
     "npc.friendship.need-points": "Наступн. за {{count}}",
     "npc.undiscovered-gift-taste": "{{count}} незвіданих предметів",
     "npc.unowned-gift-taste": "{{count}} предметів, якими ви ніколи не володіли",
+    "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/vi.json
+++ b/LookupAnything/i18n/vi.json
@@ -505,6 +505,7 @@
     "npc.friendship.need-points": "tim tiếp theo cần {{count}} pts",
     "npc.undiscovered-gift-taste": "{{count}} vật phẩm chưa khám phá",
     "npc.unowned-gift-taste": "{{count}} vật phẩm chưa biết",
+    "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 

--- a/LookupAnything/i18n/vi.json
+++ b/LookupAnything/i18n/vi.json
@@ -113,6 +113,10 @@
     "location.forest.island-tip": "{{locationName}} (sông gần ngọn phía nam của hòn đảo lớn)",
     "location.forest.lake": "{{locationName}} (ao)",
     "location.forest.river": "{{locationName}} (sông)",
+    "location.HarveyRoom": "Harvey's Room", // TODO
+    "location.LeoTreeHouse": "Treehouse", // TODO
+    "location.SandyHouse": "Oasis", // TODO
+    "location.SebastianRoom": "Sebastian's Room", // TODO
     "location.submarine": "Tàu Ngầm Chợ Đêm",
     "location.town.northmost-bridge": "{{locationName}} (cây cầu phía bắc)",
     "location.undergroundMine": "Mỏ",
@@ -491,6 +495,7 @@
     "npc.neutral-gifts": "Quà bình thường",
     "npc.dislikes-gifts": "Không thích quà",
     "npc.hates-gifts": "Ghét quà",
+    "npc.schedule": "Today's schedule", // TODO
 
     // values
     "npc.can-romance.married": "Hai người đã kết hôn! <", // < turns into a heart
@@ -500,6 +505,7 @@
     "npc.friendship.need-points": "tim tiếp theo cần {{count}} pts",
     "npc.undiscovered-gift-taste": "{{count}} vật phẩm chưa khám phá",
     "npc.unowned-gift-taste": "{{count}} vật phẩm chưa biết",
+    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/vi.json
+++ b/LookupAnything/i18n/vi.json
@@ -505,7 +505,6 @@
     "npc.friendship.need-points": "tim tiếp theo cần {{count}} pts",
     "npc.undiscovered-gift-taste": "{{count}} vật phẩm chưa khám phá",
     "npc.unowned-gift-taste": "{{count}} vật phẩm chưa biết",
-    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/vi.json
+++ b/LookupAnything/i18n/vi.json
@@ -505,6 +505,7 @@
     "npc.friendship.need-points": "tim tiếp theo cần {{count}} pts",
     "npc.undiscovered-gift-taste": "{{count}} vật phẩm chưa khám phá",
     "npc.unowned-gift-taste": "{{count}} vật phẩm chưa biết",
+    "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/vi.json
+++ b/LookupAnything/i18n/vi.json
@@ -507,6 +507,7 @@
     "npc.unowned-gift-taste": "{{count}} vật phẩm chưa biết",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
+    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/vi.json
+++ b/LookupAnything/i18n/vi.json
@@ -507,7 +507,7 @@
     "npc.unowned-gift-taste": "{{count}} vật phẩm chưa biết",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
-    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
+    "npc.schedule.entry": "{{time}}: walk to {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/zh.json
+++ b/LookupAnything/i18n/zh.json
@@ -508,7 +508,7 @@
     "npc.unowned-gift-taste": "{{count}} 个未拥有的物品",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
-    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
+    "npc.schedule.entry": "{{time}}: walk to {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/zh.json
+++ b/LookupAnything/i18n/zh.json
@@ -506,7 +506,6 @@
     "npc.friendship.need-points": "下一等级需要{{count}}点好感度",
     "npc.undiscovered-gift-taste": "{{count}} 个未揭露的物品",
     "npc.unowned-gift-taste": "{{count}} 个未拥有的物品",
-    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/zh.json
+++ b/LookupAnything/i18n/zh.json
@@ -506,6 +506,7 @@
     "npc.friendship.need-points": "下一等级需要{{count}}点好感度",
     "npc.undiscovered-gift-taste": "{{count}} 个未揭露的物品",
     "npc.unowned-gift-taste": "{{count}} 个未拥有的物品",
+    "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 

--- a/LookupAnything/i18n/zh.json
+++ b/LookupAnything/i18n/zh.json
@@ -508,6 +508,7 @@
     "npc.unowned-gift-taste": "{{count}} 个未拥有的物品",
     "npc.schedule.current-position": "Currently at {{locationName}} ({{x}}, {{y}}).", // TODO
     "npc.schedule.no-entries": "No schedule loaded.", // TODO
+    "npc.schedule.entry": "{{time}}: {{locationName}} ({{x}}, {{y}}).", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/zh.json
+++ b/LookupAnything/i18n/zh.json
@@ -113,6 +113,10 @@
     "location.forest.island-tip": "煤矿森林（河流小岛南端）",
     "location.forest.lake": "煤矿森林（湖泊）",
     "location.forest.river": "煤矿森林（河流）",
+    "location.HarveyRoom": "Harvey's Room", // TODO
+    "location.LeoTreeHouse": "Treehouse", // TODO
+    "location.SandyHouse": "Oasis", // TODO
+    "location.SebastianRoom": "Sebastian's Room", // TODO
     "location.submarine": "夜市潜艇",
     "location.town.northmost-bridge": "鹈鹕镇（北部桥区）",
     "location.undergroundMine": "矿井",
@@ -492,6 +496,7 @@
     "npc.neutral-gifts": "无感",
     "npc.dislikes-gifts": "不喜欢",
     "npc.hates-gifts": "讨厌",
+    "npc.schedule": "Today's schedule", // TODO
 
     // values
     "npc.can-romance.married": "你们已结婚! ♡", // < turns into a heart
@@ -501,6 +506,7 @@
     "npc.friendship.need-points": "下一等级需要{{count}}点好感度",
     "npc.undiscovered-gift-taste": "{{count}} 个未揭露的物品",
     "npc.unowned-gift-taste": "{{count}} 个未拥有的物品",
+    "npc.schedule.all-day": "All day", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/zh.json
+++ b/LookupAnything/i18n/zh.json
@@ -506,6 +506,7 @@
     "npc.friendship.need-points": "下一等级需要{{count}}点好感度",
     "npc.undiscovered-gift-taste": "{{count}} 个未揭露的物品",
     "npc.unowned-gift-taste": "{{count}} 个未拥有的物品",
+    "npc.schedule.no-entries": "No schedule loaded.", // TODO
 
 
     /*********


### PR DESCRIPTION
Added a field for schedules in the NPC lookup. Closes https://github.com/Pathoschild/StardewMods/issues/4.

Schedule items display the time they occur and the NPC's destination location. The schedule item that is currently occurring is written in green, upcoming items are in black, and past items are in gray. For schedules that contain only a single item, the string "All day" is shown instead of the time.

Some locations do not have built-in display names, like `LeoTreeHouse` and `HarveyRoom`. To fix this, I made `DataParser`'s `GetLocationDisplayName` method public and added resource strings for locations without built-in display names.

Screenshots:
<img width="628" alt="image" src="https://github.com/user-attachments/assets/f02f1d2e-fe19-47dd-bb8a-5f730cbcea4e">
<img width="626" alt="image" src="https://github.com/user-attachments/assets/2160e5d3-d58c-4411-9d68-b9a7e11b097f">
<img width="629" alt="image" src="https://github.com/user-attachments/assets/fe3c70b0-d3ea-4e93-a4da-c8336ba0f092">
