### PR TITLE
[Content Patcher] Add ReplaceDelimited text operation

### DIFF
--- a/ContentPatcher/Framework/ConfigModels/TextOperationConfig.cs
+++ b/ContentPatcher/Framework/ConfigModels/TextOperationConfig.cs
@@ -24,16 +24,16 @@ namespace ContentPatcher.Framework.ConfigModels
         /****
         ** Append/Prepend/ReplaceDelimited
         ****/
-        /// <summary>The value to append, prepend, or replace with.</summary>
+        /// <summary>The operation value (e.g. the value to append or replace with).</summary>
         public string? Value { get; }
 
         /****
         ** RemoveDelimited/ReplaceDelimited
         ****/
-        /// <summary>The value to remove from or replace in the text.</summary>
+        /// <summary>The value to match in the text.</summary>
         public string? Search { get; }
 
-        /// <summary>Which delimited values should be removed or replaced.</summary>
+        /// <summary>Which delimited values should be matched.</summary>
         public string? ReplaceMode { get; }
 
 
@@ -43,10 +43,10 @@ namespace ContentPatcher.Framework.ConfigModels
         /// <summary>Construct an instance.</summary>
         /// <param name="operation">The text operation to perform.</param>
         /// <param name="target">The specific text field to change as a breadcrumb path. Each value in the list represents a field to navigate into.</param>
-        /// <param name="value">The value to append, prepend, or replace with.</param>
+        /// <param name="value">The operation value (e.g. the value to append or replace with).</param>
         /// <param name="delimiter">If the target field already has a value, text to add between the previous and inserted values, if any.</param>
-        /// <param name="search">The value to remove from or replace in the text.</param>
-        /// <param name="replaceMode">Which delimited values should be removed or replaced.</param>
+        /// <param name="search">The value to match in the text.</param>
+        /// <param name="replaceMode">Which delimited values should be matched.</param>
         [JsonConstructor]
         public TextOperationConfig(string? operation, string?[]? target, string? value, string? delimiter, string? search, string? replaceMode)
         {

--- a/ContentPatcher/Framework/ConfigModels/TextOperationConfig.cs
+++ b/ContentPatcher/Framework/ConfigModels/TextOperationConfig.cs
@@ -22,18 +22,18 @@ namespace ContentPatcher.Framework.ConfigModels
         public string? Delimiter { get; }
 
         /****
-        ** Append/Prepend
+        ** Append/Prepend/ReplaceDelimited
         ****/
-        /// <summary>The value to append or prepend.</summary>
+        /// <summary>The value to append, prepend, or replace with.</summary>
         public string? Value { get; }
 
         /****
-        ** RemoveDelimited
+        ** RemoveDelimited/ReplaceDelimited
         ****/
-        /// <summary>The value to remove from the text.</summary>
+        /// <summary>The value to remove from or replace in the text.</summary>
         public string? Search { get; }
 
-        /// <summary>Which delimited values should be removed.</summary>
+        /// <summary>Which delimited values should be removed or replaced.</summary>
         public string? ReplaceMode { get; }
 
 
@@ -43,10 +43,10 @@ namespace ContentPatcher.Framework.ConfigModels
         /// <summary>Construct an instance.</summary>
         /// <param name="operation">The text operation to perform.</param>
         /// <param name="target">The specific text field to change as a breadcrumb path. Each value in the list represents a field to navigate into.</param>
-        /// <param name="value">The value to append or prepend.</param>
+        /// <param name="value">The value to append, prepend, or replace with.</param>
         /// <param name="delimiter">If the target field already has a value, text to add between the previous and inserted values, if any.</param>
-        /// <param name="search">The value to remove from the text.</param>
-        /// <param name="replaceMode">Which delimited values should be removed.</param>
+        /// <param name="search">The value to remove from or replace in the text.</param>
+        /// <param name="replaceMode">Which delimited values should be removed or replaced.</param>
         [JsonConstructor]
         public TextOperationConfig(string? operation, string?[]? target, string? value, string? delimiter, string? search, string? replaceMode)
         {

--- a/ContentPatcher/Framework/Constants/TextOperationType.cs
+++ b/ContentPatcher/Framework/Constants/TextOperationType.cs
@@ -10,6 +10,9 @@ namespace ContentPatcher.Framework.Constants
         Prepend,
 
         /// <summary>Parse the target text into a list of delimited values, and remove the values matching the search.</summary>
-        RemoveDelimited
+        RemoveDelimited,
+
+        /// <summary>Parse the target text into a list of delimited values, and replace the values matching the search with a new value.</summary>
+        ReplaceDelimited
     }
 }

--- a/ContentPatcher/Framework/PatchLoader.cs
+++ b/ContentPatcher/Framework/PatchLoader.cs
@@ -932,34 +932,26 @@ namespace ContentPatcher.Framework
                         break;
 
                     case TextOperationType.RemoveDelimited:
-                        if (string.IsNullOrEmpty(operation.Delimiter))
-                            return Fail($"{errorPrefix}: the {nameof(operation.Delimiter)} value must be set for a {operationType} text operation.", out error);
-                        if (string.IsNullOrWhiteSpace(search.Raw))
-                            return Fail($"{errorPrefix}: the {nameof(operation.Search)} value must be set for a {operationType} text operation.", out error);
-
-                        parsedOperation = new RemoveDelimitedTextOperation(
-                            operation: operationType,
-                            target: target,
-                            search: search,
-                            delimiter: operation.Delimiter,
-                            replaceMode: replaceMode
-                        );
-                        break;
-
                     case TextOperationType.ReplaceDelimited:
                         if (string.IsNullOrEmpty(operation.Delimiter))
                             return Fail($"{errorPrefix}: the {nameof(operation.Delimiter)} value must be set for a {operationType} text operation.", out error);
                         if (string.IsNullOrWhiteSpace(search.Raw))
                             return Fail($"{errorPrefix}: the {nameof(operation.Search)} value must be set for a {operationType} text operation.", out error);
 
-                        parsedOperation = new ReplaceDelimitedTextOperation(
-                            operation: operationType,
-                            target: target,
-                            search: search,
-                            value: value,
-                            delimiter: operation.Delimiter,
-                            replaceMode: replaceMode
-                        );
+                        parsedOperation = operationType is TextOperationType.RemoveDelimited
+                            ? new RemoveDelimitedTextOperation(
+                                target: target,
+                                search: search,
+                                delimiter: operation.Delimiter,
+                                replaceMode: replaceMode
+                            )
+                            : new ReplaceDelimitedTextOperation(
+                                target: target,
+                                search: search,
+                                replaceWith: value,
+                                delimiter: operation.Delimiter,
+                                replaceMode: replaceMode
+                            );
                         break;
 
                     default:

--- a/ContentPatcher/Framework/PatchLoader.cs
+++ b/ContentPatcher/Framework/PatchLoader.cs
@@ -946,6 +946,22 @@ namespace ContentPatcher.Framework
                         );
                         break;
 
+                    case TextOperationType.ReplaceDelimited:
+                        if (string.IsNullOrEmpty(operation.Delimiter))
+                            return Fail($"{errorPrefix}: the {nameof(operation.Delimiter)} value must be set for a {operationType} text operation.", out error);
+                        if (string.IsNullOrWhiteSpace(search.Raw))
+                            return Fail($"{errorPrefix}: the {nameof(operation.Search)} value must be set for a {operationType} text operation.", out error);
+
+                        parsedOperation = new ReplaceDelimitedTextOperation(
+                            operation: operationType,
+                            target: target,
+                            search: search,
+                            value: value,
+                            delimiter: operation.Delimiter,
+                            replaceMode: replaceMode
+                        );
+                        break;
+
                     default:
                         return Fail($"{errorPrefix}: unsupported text operation type '{operationType}'", out error);
                 }

--- a/ContentPatcher/Framework/TextOperations/BaseDelimitedTextOperation.cs
+++ b/ContentPatcher/Framework/TextOperations/BaseDelimitedTextOperation.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using ContentPatcher.Framework.Constants;
+
+namespace ContentPatcher.Framework.TextOperations
+{
+    /// <summary>A text operation which parses a field's current value as a delimited list of values, and performs an action for those matching a search value.</summary>
+    internal abstract class BaseDelimitedTextOperation : BaseTextOperation
+    {
+        /*********
+        ** Accessors
+        *********/
+        /// <summary>The value to match.</summary>
+        public ITokenString Search { get; }
+
+        /// <summary>The text between values in a delimited string.</summary>
+        public string Delimiter { get; }
+
+        /// <summary>Which delimited values the action should be applied to.</summary>
+        public TextOperationReplaceMode ReplaceMode { get; }
+
+
+        /*********
+        ** Public methods
+        *********/
+        /// <inheritdoc />
+        [return: NotNullIfNotNull(nameof(text))]
+        public override string? Apply(string? text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return text;
+
+            // get search
+            string? search = this.Search.Value;
+            if (search is null)
+                return text;
+
+            // apply
+            IReadOnlyList<string> values = text.Split(this.Delimiter);
+            var mutableValues = new Lazy<IList<string>>(() => new List<string>(values));
+            {
+                int prevCount = values.Count;
+                switch (this.ReplaceMode)
+                {
+                    case TextOperationReplaceMode.First:
+                        for (int i = 0; i < prevCount; i++)
+                        {
+                            if (values[i] == search)
+                            {
+                                this.ApplyToValue(values, mutableValues, i);
+                                break;
+                            }
+                        }
+                        break;
+
+                    case TextOperationReplaceMode.Last:
+                        for (int i = prevCount - 1; i >= 0; i--)
+                        {
+                            if (values[i] == search)
+                            {
+                                this.ApplyToValue(values, mutableValues, i);
+                                break;
+                            }
+                        }
+                        break;
+
+                    case TextOperationReplaceMode.All:
+                        for (int i = prevCount - 1; i >= 0; i--)
+                        {
+                            if (values[i] == search)
+                                this.ApplyToValue(values, mutableValues, i);
+                        }
+                        break;
+                }
+            }
+
+            // update field
+            return mutableValues.IsValueCreated
+                ? string.Join(this.Delimiter, mutableValues.Value)
+                : text;
+        }
+
+
+        /*********
+        ** Protected methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="operation">The text operation to perform.</param>
+        /// <param name="target">The specific text field to change as a breadcrumb path. Each value in the list represents a field to navigate into.</param>
+        /// <param name="search">The value to match.</param>
+        /// <param name="delimiter">The text between values in a delimited string.</param>
+        /// <param name="replaceMode">Which delimited values the action should be applied to.</param>
+        protected BaseDelimitedTextOperation(TextOperationType operation, ICollection<IManagedTokenString> target, IManagedTokenString search, string delimiter, TextOperationReplaceMode replaceMode)
+            : base(operation, target)
+        {
+            this.Search = search;
+            this.Delimiter = delimiter;
+            this.ReplaceMode = replaceMode;
+
+            this.Contextuals.Add(search);
+        }
+
+        /// <summary>Apply the operation to a matched delimited value.</summary>
+        /// <param name="values">The original values before this operation was applied.</param>
+        /// <param name="mutableValues">The modified values. Accessing the value will mark it modified.</param>
+        /// <param name="index">The index of the delimited value that was matched in <paramref name="values"/>. When applying a <see cref="TextOperationReplaceMode.All"/> operation, the list is iterated in reverse order, so you can safely remove values without offsetting the index.</param>
+        protected abstract void ApplyToValue(IReadOnlyList<string> values, Lazy<IList<string>> mutableValues, int index);
+    }
+}

--- a/ContentPatcher/Framework/TextOperations/RemoveDelimitedTextOperation.cs
+++ b/ContentPatcher/Framework/TextOperations/RemoveDelimitedTextOperation.cs
@@ -1,119 +1,31 @@
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using ContentPatcher.Framework.Constants;
 
 namespace ContentPatcher.Framework.TextOperations
 {
     /// <summary>A text operation which parses a field's current value as a delimited list of values, and removes those matching a search value.</summary>
-    internal class RemoveDelimitedTextOperation : BaseTextOperation
+    internal class RemoveDelimitedTextOperation : BaseDelimitedTextOperation
     {
-        /*********
-        ** Accessors
-        *********/
-        /// <summary>The value to remove from the text.</summary>
-        public ITokenString Search { get; }
-
-        /// <summary>The text between values in a delimited string.</summary>
-        public string Delimiter { get; }
-
-        /// <summary>Which delimited values should be removed.</summary>
-        public TextOperationReplaceMode ReplaceMode { get; }
-
-
         /*********
         ** Public methods
         *********/
         /// <summary>Construct an instance.</summary>
-        /// <param name="operation">The text operation to perform.</param>
         /// <param name="target">The specific text field to change as a breadcrumb path. Each value in the list represents a field to navigate into.</param>
         /// <param name="search">The value to remove from the text.</param>
         /// <param name="delimiter">The text between values in a delimited string.</param>
         /// <param name="replaceMode">Which delimited values should be removed.</param>
-        public RemoveDelimitedTextOperation(TextOperationType operation, ICollection<IManagedTokenString> target, IManagedTokenString search, string delimiter, TextOperationReplaceMode replaceMode)
-            : base(operation, target)
-        {
-            this.Search = search;
-            this.Delimiter = delimiter;
-            this.ReplaceMode = replaceMode;
+        public RemoveDelimitedTextOperation(ICollection<IManagedTokenString> target, IManagedTokenString search, string delimiter, TextOperationReplaceMode replaceMode)
+            : base(TextOperationType.RemoveDelimited, target, search, delimiter, replaceMode) { }
 
-            this.Contextuals.Add(search);
-        }
 
+        /*********
+        ** Protected methods
+        *********/
         /// <inheritdoc />
-        [return: NotNullIfNotNull(nameof(text))]
-        public override string? Apply(string? text)
+        protected override void ApplyToValue(IReadOnlyList<string> values, Lazy<IList<string>> mutableValues, int index)
         {
-            if (string.IsNullOrEmpty(text))
-                return text;
-
-            // get search
-            string? search = this.Search.Value;
-            if (search is null)
-                return text;
-
-            // apply
-            IReadOnlyList<string> values = text.Split(this.Delimiter);
-            bool replaced = false;
-            {
-                int prevCount = values.Count;
-                switch (this.ReplaceMode)
-                {
-                    case TextOperationReplaceMode.First:
-                        for (int i = 0; i < prevCount; i++)
-                        {
-                            if (values[i] == search)
-                            {
-                                List<string> modified = [..values];
-                                modified.RemoveAt(i);
-                                values = modified;
-
-                                replaced = true;
-                                break;
-                            }
-                        }
-                        break;
-
-                    case TextOperationReplaceMode.Last:
-                        for (int i = prevCount - 1; i >= 0; i--)
-                        {
-                            if (values[i] == search)
-                            {
-                                List<string> modified = [..values];
-                                modified.RemoveAt(i);
-                                values = modified;
-
-                                replaced = true;
-                                break;
-                            }
-                        }
-                        break;
-
-                    case TextOperationReplaceMode.All:
-                        {
-                            List<string>? modified = null;
-
-                            for (int i = prevCount - 1; i >= 0; i--)
-                            {
-                                if (values[i] == search)
-                                {
-                                    modified ??= [..values];
-                                    modified.RemoveAt(i);
-
-                                    replaced = true;
-                                }
-                            }
-
-                            if (modified is not null)
-                                values = modified;
-                        }
-                        break;
-                }
-            }
-
-            // update field
-            return replaced
-                ? string.Join(this.Delimiter, values)
-                : text;
+            mutableValues.Value.RemoveAt(index);
         }
     }
 }

--- a/ContentPatcher/Framework/TextOperations/ReplaceDelimitedTextOperation.cs
+++ b/ContentPatcher/Framework/TextOperations/ReplaceDelimitedTextOperation.cs
@@ -1,0 +1,124 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using ContentPatcher.Framework.Constants;
+
+namespace ContentPatcher.Framework.TextOperations
+{
+    /// <summary>A text operation which parses a field's current value as a delimited list of values, and replaces those matching a search value with a provided value.</summary>
+    internal class ReplaceDelimitedTextOperation : BaseTextOperation
+    {
+        /*********
+        ** Accessors
+        *********/
+        /// <summary>The value to replace with.</summary>
+        public ITokenString Value { get; }
+
+        /// <summary>The value to remove from the text.</summary>
+        public ITokenString Search { get; }
+
+        /// <summary>The text between values in a delimited string.</summary>
+        public string Delimiter { get; }
+
+        /// <summary>Which delimited values should be removed.</summary>
+        public TextOperationReplaceMode ReplaceMode { get; }
+
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="operation">The text operation to perform.</param>
+        /// <param name="target">The specific text field to change as a breadcrumb path. Each value in the list represents a field to navigate into.</param>
+        /// <param name="search">The value to remove from the text.</param>
+        /// <param name="value">The value to replace with.</param>
+        /// <param name="delimiter">The text between values in a delimited string.</param>
+        /// <param name="replaceMode">Which delimited values should be removed.</param>
+        public ReplaceDelimitedTextOperation(TextOperationType operation, ICollection<IManagedTokenString> target, IManagedTokenString search, IManagedTokenString value, string delimiter, TextOperationReplaceMode replaceMode)
+            : base(operation, target)
+        {
+            this.Search = search;
+            this.Value = value;
+            this.Delimiter = delimiter;
+            this.ReplaceMode = replaceMode;
+
+            this.Contextuals.Add(search);
+        }
+
+        /// <inheritdoc />
+        [return: NotNullIfNotNull(nameof(text))]
+        public override string? Apply(string? text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return text;
+
+            // get search
+            string? search = this.Search.Value;
+            if (search is null)
+                return text;
+
+            // apply
+            IReadOnlyList<string> values = text.Split(this.Delimiter);
+            bool replaced = false;
+            {
+                int prevCount = values.Count;
+                switch (this.ReplaceMode)
+                {
+                    case TextOperationReplaceMode.First:
+                        for (int i = 0; i < prevCount; i++)
+                        {
+                            if (values[i] == search)
+                            {
+                                List<string> modified = [..values];
+                                modified[i] = this.Value.Value ?? "";
+                                values = modified;
+
+                                replaced = true;
+                                break;
+                            }
+                        }
+                        break;
+
+                    case TextOperationReplaceMode.Last:
+                        for (int i = prevCount - 1; i >= 0; i--)
+                        {
+                            if (values[i] == search)
+                            {
+                                List<string> modified = [..values];
+                                modified[i] = this.Value.Value ?? "";
+                                values = modified;
+
+                                replaced = true;
+                                break;
+                            }
+                        }
+                        break;
+
+                    case TextOperationReplaceMode.All:
+                        {
+                            List<string>? modified = null;
+
+                            for (int i = prevCount - 1; i >= 0; i--)
+                            {
+                                if (values[i] == search)
+                                {
+                                    modified ??= [..values];
+                                    modified[i] = this.Value.Value ?? "";
+
+                                    replaced = true;
+                                }
+                            }
+
+                            if (modified is not null)
+                                values = modified;
+                        }
+                        break;
+                }
+            }
+
+            // update field
+            return replaced
+                ? string.Join(this.Delimiter, values)
+                : text;
+        }
+    }
+}

--- a/ContentPatcher/Framework/TextOperations/ReplaceDelimitedTextOperation.cs
+++ b/ContentPatcher/Framework/TextOperations/ReplaceDelimitedTextOperation.cs
@@ -1,126 +1,44 @@
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using ContentPatcher.Framework.Constants;
 
 namespace ContentPatcher.Framework.TextOperations
 {
     /// <summary>A text operation which parses a field's current value as a delimited list of values, and replaces those matching a search value with a provided value.</summary>
-    internal class ReplaceDelimitedTextOperation : BaseTextOperation
+    internal class ReplaceDelimitedTextOperation : BaseDelimitedTextOperation
     {
         /*********
         ** Accessors
         *********/
-        /// <summary>The value to replace with.</summary>
-        public ITokenString Value { get; }
-
-        /// <summary>The value to remove from the text.</summary>
-        public ITokenString Search { get; }
-
-        /// <summary>The text between values in a delimited string.</summary>
-        public string Delimiter { get; }
-
-        /// <summary>Which delimited values should be removed.</summary>
-        public TextOperationReplaceMode ReplaceMode { get; }
+        /// <summary>The text with which to replace the matched value.</summary>
+        public ITokenString ReplaceWith { get; }
 
 
         /*********
         ** Public methods
         *********/
         /// <summary>Construct an instance.</summary>
-        /// <param name="operation">The text operation to perform.</param>
         /// <param name="target">The specific text field to change as a breadcrumb path. Each value in the list represents a field to navigate into.</param>
-        /// <param name="search">The value to remove from the text.</param>
-        /// <param name="value">The value to replace with.</param>
+        /// <param name="search">The value to match.</param>
+        /// <param name="replaceWith">The text with which to replace the matched value.</param>
         /// <param name="delimiter">The text between values in a delimited string.</param>
         /// <param name="replaceMode">Which delimited values should be removed.</param>
-        public ReplaceDelimitedTextOperation(TextOperationType operation, ICollection<IManagedTokenString> target, IManagedTokenString search, IManagedTokenString value, string delimiter, TextOperationReplaceMode replaceMode)
-            : base(operation, target)
+        public ReplaceDelimitedTextOperation(ICollection<IManagedTokenString> target, IManagedTokenString search, IManagedTokenString replaceWith, string delimiter, TextOperationReplaceMode replaceMode)
+            : base(TextOperationType.ReplaceDelimited, target, search, delimiter, replaceMode)
         {
-            this.Search = search;
-            this.Value = value;
-            this.Delimiter = delimiter;
-            this.ReplaceMode = replaceMode;
+            this.ReplaceWith = replaceWith;
 
-            this.Contextuals
-                .Add(search)
-                .Add(value);
+            this.Contextuals.Add(replaceWith);
         }
 
+
+        /*********
+        ** Protected methods
+        *********/
         /// <inheritdoc />
-        [return: NotNullIfNotNull(nameof(text))]
-        public override string? Apply(string? text)
+        protected override void ApplyToValue(IReadOnlyList<string> values, Lazy<IList<string>> mutableValues, int index)
         {
-            if (string.IsNullOrEmpty(text))
-                return text;
-
-            // get search
-            string? search = this.Search.Value;
-            if (search is null)
-                return text;
-
-            // apply
-            IReadOnlyList<string> values = text.Split(this.Delimiter);
-            bool replaced = false;
-            {
-                int prevCount = values.Count;
-                switch (this.ReplaceMode)
-                {
-                    case TextOperationReplaceMode.First:
-                        for (int i = 0; i < prevCount; i++)
-                        {
-                            if (values[i] == search)
-                            {
-                                List<string> modified = [..values];
-                                modified[i] = this.Value.Value ?? "";
-                                values = modified;
-
-                                replaced = true;
-                                break;
-                            }
-                        }
-                        break;
-
-                    case TextOperationReplaceMode.Last:
-                        for (int i = prevCount - 1; i >= 0; i--)
-                        {
-                            if (values[i] == search)
-                            {
-                                List<string> modified = [..values];
-                                modified[i] = this.Value.Value ?? "";
-                                values = modified;
-
-                                replaced = true;
-                                break;
-                            }
-                        }
-                        break;
-
-                    case TextOperationReplaceMode.All:
-                        {
-                            List<string>? modified = null;
-
-                            for (int i = prevCount - 1; i >= 0; i--)
-                            {
-                                if (values[i] == search)
-                                {
-                                    modified ??= [..values];
-                                    modified[i] = this.Value.Value ?? "";
-
-                                    replaced = true;
-                                }
-                            }
-
-                            if (modified is not null)
-                                values = modified;
-                        }
-                        break;
-                }
-            }
-
-            // update field
-            return replaced
-                ? string.Join(this.Delimiter, values)
-                : text;
+            mutableValues.Value[index] = this.ReplaceWith.Value ?? "";
         }
     }
 }

--- a/ContentPatcher/Framework/TextOperations/ReplaceDelimitedTextOperation.cs
+++ b/ContentPatcher/Framework/TextOperations/ReplaceDelimitedTextOperation.cs
@@ -41,7 +41,9 @@ namespace ContentPatcher.Framework.TextOperations
             this.Delimiter = delimiter;
             this.ReplaceMode = replaceMode;
 
-            this.Contextuals.Add(search);
+            this.Contextuals
+                .Add(search)
+                .Add(value);
         }
 
         /// <inheritdoc />

--- a/ContentPatcher/docs/author-guide/text-operations.md
+++ b/ContentPatcher/docs/author-guide/text-operations.md
@@ -13,6 +13,7 @@ They're set using the `TextOperations` field for an [`EditData`](action-editdata
   * [`Append`](#append)
   * [`Prepend`](#prepend)
   * [`RemoveDelimited`](#removedelimited)
+  * [`ReplaceDelimited`](#replacedelimited)
 * [See also](#see-also)
 
 ## Example
@@ -238,6 +239,98 @@ For example, this removes prismatic shard (item 74) from the list of universally
          "Operation": "RemoveDelimited",
          "Target": ["Entries", "Universal_Love"],
          "Search": "74",
+         "Delimiter": " "
+      }
+   ]
+}
+```
+
+### `ReplaceDelimited`
+The `ReplaceDelimited` operation parses the target text into a set of values based on a delimiter,
+then replaces one or more values which match the given search text with a new value.
+
+This expects these fields:
+
+<table>
+<tr>
+<th>field</th>
+<th>purpose</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td>
+
+See _[common fields](#common-fields)_ above.
+
+</td>
+</tr>
+<tr>
+<td><code>Search</code></td>
+<td>
+
+The value to replace in the text. This must match the entire delimited value to remove, it won't
+remove substrings within each delimited value.
+
+This field supports [tokens](../author-guide.md#tokens), and capitalization **does** matter.
+
+</td>
+</tr>
+<tr>
+<td><code>Value</code></td>
+<td>
+
+The text to replace the found `Search` value with. Like most Content Patcher fields, **whitespace is trimmed from the start and end**.
+
+This field supports [tokens](../author-guide.md#tokens), and capitalization doesn't matter.
+
+</td>
+</tr>
+<tr>
+<td><code>Delimiter</code></td>
+<td>
+
+The characters which separate values within the target text.
+
+For example, let's say the target text contains `A a/B/C`. Here's how that would be parsed with
+different delimiters:
+
+delimiter          | value 1 | value 2 | value 3
+------------------ | ------- | ------- | -------
+`"Delimiter": "/"` | `A a`   | `B`     | `C`
+`"Delimiter": " "` | `A`     | `a/B/C` |
+
+</td>
+</tr>
+<tr>
+<td><code>ReplaceMode</code></td>
+<td>
+
+_(Optional)_ Which delimited values should be replaced. The possible options are:
+
+mode    | result
+------- | ------
+`First` | Replace the first value which matches the `Search`, and leave any others as-is.
+`Last`  | Replace the last value which matches the `Search`, and leave any others as-is.
+`All`   | Replace all values which match the `Search`.
+
+Defaults to `All`.
+
+</td>
+</tr>
+</table>
+
+For example, this replaces the first instance of the word "Thank" in Penny's gift taste entry with the word "Bless":
+
+```js
+{
+   "Action": "EditData",
+   "Target": "Data/NPCGiftTastes",
+   "TextOperations": [
+      {
+         "Operation": "RemoveDelimited",
+         "Target": ["Entries", "Penny"],
+         "Search": "Thank",
+         "Value": "Bless",
          "Delimiter": " "
       }
    ]

--- a/ContentPatcher/docs/author-guide/text-operations.md
+++ b/ContentPatcher/docs/author-guide/text-operations.md
@@ -247,7 +247,9 @@ For example, this removes prismatic shard (item 74) from the list of universally
 
 ### `ReplaceDelimited`
 The `ReplaceDelimited` operation parses the target text into a set of values based on a delimiter,
-then replaces one or more values which match the given search text with a new value.
+then replaces one or more values equal to the given search text with a new value.
+
+This replaces delimited values, _not_ substrings within them.
 
 This expects these fields:
 
@@ -279,9 +281,11 @@ This field supports [tokens](../author-guide.md#tokens), and capitalization **do
 <td><code>Value</code></td>
 <td>
 
-The text to replace the found `Search` value with. Like most Content Patcher fields, **whitespace is trimmed from the start and end**.
+The text with which to replace the value.
 
-This field supports [tokens](../author-guide.md#tokens), and capitalization doesn't matter.
+This field supports [tokens](../author-guide.md#tokens), and capitalization doesn't matter. Like
+most Content Patcher fields, whitespace is trimmed from the start and end.
+
 
 </td>
 </tr>
@@ -319,7 +323,8 @@ Defaults to `All`.
 </tr>
 </table>
 
-For example, this replaces the first instance of the word "Thank" in Penny's gift taste entry with the word "Bless":
+For example, this replaces Rabbit's Foot (item #446) in universal love gift tastes with pufferfish
+(item #128):
 
 ```js
 {
@@ -327,10 +332,10 @@ For example, this replaces the first instance of the word "Thank" in Penny's gif
    "Target": "Data/NPCGiftTastes",
    "TextOperations": [
       {
-         "Operation": "RemoveDelimited",
-         "Target": ["Entries", "Penny"],
-         "Search": "Thank",
-         "Value": "Bless",
+         "Operation": "ReplaceDelimited",
+         "Target": ["Entries", "Universal_Love"],
+         "Search": "446",
+         "Value": "128",
          "Delimiter": " "
       }
    ]


### PR DESCRIPTION
This PR adds a new text operation, ReplaceDelimited, that searches delimited strings to find values similar to RemoveDelimited except instead of removing the found values it will replace them with a user-provided value. This can be helpful for replacing specific words or values in the middle of a delimited string where the index of said value is still important and the other text operations won't suffice. The ReplaceMode field is also accepted here just as it is in RemoveDelimited.

It does accept null replacement values, in which case it will replace the found search value with an empty string and be functionally similar to RemoveDelimited, but enforcing non-null replacement values instead would be a simple change to make if accepting null values is not desired.