### PR TITLE
[Automate] Ignore custom CrabPot instances

### DIFF
--- a/Automate/Framework/AutomationFactory.cs
+++ b/Automate/Framework/AutomationFactory.cs
@@ -83,10 +83,6 @@ namespace Pathoschild.Stardew.Automate.Framework
                     return new TapperMachine(obj, location, tile, tree);
             }
 
-            // crab pot
-            if (obj is CrabPot crabPot && obj.QualifiedItemId == "(O)710")
-                return new CrabPotMachine(crabPot, location, tile, this.Monitor);
-
             // machine by item ID
             switch (obj.QualifiedItemId)
             {
@@ -95,6 +91,11 @@ namespace Pathoschild.Stardew.Automate.Framework
 
                 case "(BC)99":
                     return new FeedHopperMachine(location, tile);
+
+                case "(O)710":
+                    if (obj is CrabPot crabPot)
+                        return new CrabPotMachine(crabPot, location, tile, this.Monitor);
+                    break;
             }
 
             // machine in Data/Machines

--- a/Automate/Framework/AutomationFactory.cs
+++ b/Automate/Framework/AutomationFactory.cs
@@ -84,7 +84,7 @@ namespace Pathoschild.Stardew.Automate.Framework
             }
 
             // crab pot
-            if (obj is CrabPot crabPot)
+            if (obj is CrabPot crabPot && obj.QualifiedItemId == "(O)710")
                 return new CrabPotMachine(crabPot, location, tile, this.Monitor);
 
             // machine by item ID


### PR DESCRIPTION
This allows integration with modded machines that inherit from `CrabPot` (like Archaeology Skill's Water Sifters).