### PR TITLE
[LookupAnything] Fish spawn rule field should use qualified item ID

### DIFF
--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -149,6 +149,9 @@ namespace Pathoschild.Stardew.LookupAnything
         /// <remarks>Derived from <see cref="GameLocation.getFish"/>.</remarks>
         public FishSpawnData? GetFishSpawnRules(string fishID, Metadata metadata)
         {
+            if (ItemRegistry.GetData(fishID) is not ParsedItemData sourceFishItem)
+                return null;
+            string unqualifiedFishId = sourceFishItem.ItemId;
             // parse location data
             var locations = new List<FishSpawnLocationData>();
             foreach ((string locationId, LocationData data) in DataLoader.Locations(Game1.content))
@@ -160,7 +163,7 @@ namespace Pathoschild.Stardew.LookupAnything
                 foreach (SpawnFishData fish in data.Fish)
                 {
                     ParsedItemData? fishItem = ItemRegistry.GetData(fish.ItemId);
-                    if (fishItem?.ObjectType != "Fish" || fishItem.ItemId != fishID)
+                    if (fishItem?.ObjectType != "Fish" || fishItem.QualifiedItemId != fishID)
                         continue;
 
                     string displayName = this.GetLocationDisplayName(locationId, data, fish.FishAreaId);
@@ -207,7 +210,7 @@ namespace Pathoschild.Stardew.LookupAnything
             bool isUnique = false;
             if (locations.Any()) // ignore default spawn criteria if the fish doesn't spawn naturally; in that case it should be specified explicitly in custom data below (if any)
             {
-                if (DataLoader.Fish(Game1.content).TryGetValue(fishID, out string? rawData))
+                if (DataLoader.Fish(Game1.content).TryGetValue(unqualifiedFishId, out string? rawData))
                 {
                     string[] fishFields = rawData.Split('/');
 
@@ -230,7 +233,7 @@ namespace Pathoschild.Stardew.LookupAnything
             }
 
             // read custom data
-            if (metadata.CustomFishSpawnRules.TryGetValue(fishID, out FishSpawnData? customRules))
+            if (metadata.CustomFishSpawnRules.TryGetValue(unqualifiedFishId, out FishSpawnData? customRules))
             {
                 if (customRules.MinFishingLevel > minFishingLevel)
                     minFishingLevel = customRules.MinFishingLevel;

--- a/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
+++ b/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.Xna.Framework;
 using Pathoschild.Stardew.LookupAnything.Framework.Models.FishData;
 using StardewValley;
+using StardewValley.ItemTypeDefinitions;
 
 namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
 {
@@ -23,11 +24,11 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
         /// <summary>Construct an instance.</summary>
         /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
         /// <param name="label">A short field label.</param>
-        /// <param name="fishID">The fish ID.</param>
-        public FishSpawnRulesField(GameHelper gameHelper, string label, string fishID)
+        /// <param name="fish">The fish item data.</param>
+        public FishSpawnRulesField(GameHelper gameHelper, string label, ParsedItemData fish)
             : base(label)
         {
-            this.Checkboxes = this.GetConditions(gameHelper, fishID).ToArray();
+            this.Checkboxes = this.GetConditions(gameHelper, fish).ToArray();
             this.HasValue = this.Checkboxes.Any();
         }
 
@@ -37,17 +38,17 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
         *********/
         /// <summary>Get the formatted checkbox conditions to display.</summary>
         /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
-        /// <param name="fishID">The fish ID.</param>
-        private IEnumerable<KeyValuePair<IFormattedText[], bool>> GetConditions(GameHelper gameHelper, string fishID)
+        /// <param name="fish">The fish item data.</param>
+        private IEnumerable<KeyValuePair<IFormattedText[], bool>> GetConditions(GameHelper gameHelper, ParsedItemData fish)
         {
             // get spawn data
-            FishSpawnData? spawnRules = gameHelper.GetFishSpawnRules(fishID);
+            FishSpawnData? spawnRules = gameHelper.GetFishSpawnRules(fish);
             if (spawnRules?.Locations?.Any() != true)
                 yield break;
 
             // not caught uet
             if (spawnRules.IsUnique)
-                yield return this.GetCondition(I18n.Item_FishSpawnRules_NotCaughtYet(), !Game1.player.fishCaught.ContainsKey(fishID));
+                yield return this.GetCondition(I18n.Item_FishSpawnRules_NotCaughtYet(), !Game1.player.fishCaught.ContainsKey(fish.QualifiedItemId));
 
             // fishing level
             if (spawnRules.MinFishingLevel > 0)

--- a/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
+++ b/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
@@ -309,7 +309,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Items
             }
 
             // fish spawn rules
-            yield return new FishSpawnRulesField(this.GameHelper, I18n.Item_FishSpawnRules(), item.ItemId);
+            yield return new FishSpawnRulesField(this.GameHelper, I18n.Item_FishSpawnRules(), item.QualifiedItemId);
 
             // fish pond data
             // derived from FishPond::doAction

--- a/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
+++ b/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
@@ -21,6 +21,7 @@ using StardewValley.Extensions;
 using StardewValley.GameData.Crops;
 using StardewValley.GameData.FishPonds;
 using StardewValley.GameData.Movies;
+using StardewValley.ItemTypeDefinitions;
 using StardewValley.Locations;
 using StardewValley.Objects;
 using StardewValley.TerrainFeatures;
@@ -126,6 +127,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Items
         {
             // get data
             Item item = this.Target;
+            ParsedItemData itemData = ItemRegistry.GetDataOrErrorItem(item.QualifiedItemId);
             SObject? obj = item as SObject;
             bool isCrop = this.FromCrop != null;
             bool isSeed = this.SeedForCrop != null;
@@ -309,7 +311,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Items
             }
 
             // fish spawn rules
-            yield return new FishSpawnRulesField(this.GameHelper, I18n.Item_FishSpawnRules(), item.QualifiedItemId);
+            yield return new FishSpawnRulesField(this.GameHelper, I18n.Item_FishSpawnRules(), itemData);
 
             // fish pond data
             // derived from FishPond::doAction

--- a/LookupAnything/Framework/Models/FishData/FishSpawnData.cs
+++ b/LookupAnything/Framework/Models/FishData/FishSpawnData.cs
@@ -1,15 +1,16 @@
 using System.Linq;
+using StardewValley.ItemTypeDefinitions;
 
 namespace Pathoschild.Stardew.LookupAnything.Framework.Models.FishData
 {
     /// <summary>Spawning rules for a fish.</summary>
-    /// <param name="FishID">The fish ID.</param>
+    /// <param name="FishItem">The fish item data.</param>
     /// <param name="Locations">Where the fish will spawn.</param>
     /// <param name="TimesOfDay">When the fish will spawn.</param>
     /// <param name="Weather">The weather in which the fish will spawn.</param>
     /// <param name="MinFishingLevel">The minimum fishing level.</param>
     /// <param name="IsUnique">Whether the fish can only be caught once.</param>
-    internal record FishSpawnData(string FishID, FishSpawnLocationData[]? Locations, FishSpawnTimeOfDayData[]? TimesOfDay, FishSpawnWeather Weather, int MinFishingLevel, bool IsUnique)
+    internal record FishSpawnData(ParsedItemData FishItem, FishSpawnLocationData[]? Locations, FishSpawnTimeOfDayData[]? TimesOfDay, FishSpawnWeather Weather, int MinFishingLevel, bool IsUnique)
     {
         /*********
         ** Public methods

--- a/LookupAnything/GameHelper.cs
+++ b/LookupAnything/GameHelper.cs
@@ -28,6 +28,7 @@ using StardewValley.Extensions;
 using StardewValley.GameData.Crafting;
 using StardewValley.GameData.Crops;
 using StardewValley.GameData.FishPonds;
+using StardewValley.ItemTypeDefinitions;
 using StardewValley.Locations;
 using StardewValley.Menus;
 using StardewValley.Objects;
@@ -343,11 +344,11 @@ namespace Pathoschild.Stardew.LookupAnything
         }
 
         /// <summary>Read parsed data about the spawn rules for a specific fish.</summary>
-        /// <param name="fishID">The fish ID.</param>
+        /// <param name="fish">The fish item.</param>
         /// <remarks>Derived from <see cref="GameLocation.getFish"/>.</remarks>
-        public FishSpawnData? GetFishSpawnRules(string fishID)
+        public FishSpawnData? GetFishSpawnRules(ParsedItemData fish)
         {
-            return this.DataParser.GetFishSpawnRules(fishID, this.Metadata);
+            return this.DataParser.GetFishSpawnRules(fish, this.Metadata);
         }
 
         /// <summary>Get parsed data about the friendship between a player and NPC.</summary>

--- a/LookupAnything/assets/data.json
+++ b/LookupAnything/assets/data.json
@@ -186,7 +186,7 @@ You shouldn't change this file unless you know what you're doing.
      */
     "CustomFishSpawnRules": {
         // Octopus
-        "149": {
+        "(O)149": {
             "Locations": [
                 {
                     "LocationName": "Submarine",
@@ -196,7 +196,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Seaweed
-        "152": {
+        "(O)152": {
             "Locations": [
                 {
                     "LocationName": "Submarine",
@@ -206,7 +206,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Sea Cucumber
-        "154": {
+        "(O)154": {
             "Locations": [
                 {
                     "LocationName": "Submarine",
@@ -216,7 +216,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Super Cucumber
-        "155": {
+        "(O)155": {
             "Locations": [
                 {
                     "LocationName": "Submarine",
@@ -226,7 +226,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Stonefish
-        "158": {
+        "(O)158": {
             "Locations": [
                 {
                     "LocationName": "UndergroundMine",
@@ -237,7 +237,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Crimsonfish (legendary)
-        "159": {
+        "(O)159": {
             "IsUnique": true,
             "MinFishingLevel": 5,
             "Locations": [
@@ -250,7 +250,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Angler (legendary)
-        "160": {
+        "(O)160": {
             "IsUnique": true,
             "MinFishingLevel": 3,
             "Locations": [
@@ -263,7 +263,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Ice Pip
-        "161": {
+        "(O)161": {
             "Locations": [
                 {
                     "LocationName": "UndergroundMine",
@@ -274,7 +274,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Lava Eel
-        "162": {
+        "(O)162": {
             "Locations": [
                 {
                     "LocationName": "UndergroundMine",
@@ -285,7 +285,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Legend (legendary)
-        "163": {
+        "(O)163": {
             "IsUnique": true,
             "MinFishingLevel": 10,
             "Weather": "Rainy",
@@ -298,7 +298,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Mutant Carp (legendary)
-        "682": {
+        "(O)682": {
             "IsUnique": true,
             "Locations": [
                 {
@@ -309,7 +309,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Glacierfish (legendary)
-        "775": {
+        "(O)775": {
             "IsUnique": true,
             "MinFishingLevel": 6,
             "Locations": [
@@ -322,7 +322,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Midnight Squid
-        "798": {
+        "(O)798": {
             "Locations": [
                 {
                     "LocationName": "Submarine",
@@ -332,7 +332,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Spook Fish
-        "799": {
+        "(O)799": {
             "Locations": [
                 {
                     "LocationName": "Submarine",
@@ -342,7 +342,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Blobfish
-        "800": {
+        "(O)800": {
             "Locations": [
                 {
                     "LocationName": "Submarine",


### PR DESCRIPTION
Use qualified id to obtain fish spawn info, so that a big craftable like chest isn't showing tuna schedule.