### PR TITLE
[Lookup Anything] Add spawn rules for extended family fish

### DIFF
--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -149,8 +149,9 @@ namespace Pathoschild.Stardew.LookupAnything
         /// <remarks>Derived from <see cref="GameLocation.getFish"/>.</remarks>
         public FishSpawnData? GetFishSpawnRules(string fishID, Metadata metadata)
         {
-            // parse location data
+            // parse location and condition data
             var locations = new List<FishSpawnLocationData>();
+            bool isLegendaryFamily = false;
             foreach ((string locationId, LocationData data) in DataLoader.Locations(Game1.content))
             {
                 if (metadata.IgnoreFishingLocations.Contains(locationId))
@@ -181,6 +182,9 @@ namespace Pathoschild.Stardew.LookupAnything
                             }
                             curLocations.Add(new FishSpawnLocationData(locationId, fish.FishAreaId, seasons.ToArray()));
                         }
+
+                        // check if fish is part of Qi's Extended Family quest
+                        isLegendaryFamily = conditionData.Any(condition => !condition.Negated && condition.Query.SequenceEqual(["PLAYER_SPECIAL_ORDER_RULE_ACTIVE", "Current", "LEGENDARY_FAMILY"]));
                     }
                     else
                         curLocations.Add(new FishSpawnLocationData(locationId, fish.FishAreaId, new[] { "spring", "summer", "fall", "winter" }));
@@ -252,7 +256,8 @@ namespace Pathoschild.Stardew.LookupAnything
                 TimesOfDay: timesOfDay.ToArray(),
                 Weather: weather,
                 MinFishingLevel: minFishingLevel,
-                IsUnique: isUnique
+                IsUnique: isUnique,
+                IsLegendaryFamily: isLegendaryFamily
             );
         }
 

--- a/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
+++ b/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
@@ -53,6 +53,10 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields
             if (spawnRules.MinFishingLevel > 0)
                 yield return this.GetCondition(I18n.Item_FishSpawnRules_MinFishingLevel(level: spawnRules.MinFishingLevel), Game1.player.FishingLevel >= spawnRules.MinFishingLevel);
 
+            // extended family quest
+            if (spawnRules.IsLegendaryFamily)
+                yield return this.GetCondition(I18n.Item_FishSpawnRules_ExtendedFamilyQuestActive(), Game1.player.team.SpecialOrderRuleActive("LEGENDARY_FAMILY"));
+
             // weather
             if (spawnRules.Weather == FishSpawnWeather.Sunny)
                 yield return this.GetCondition(I18n.Item_FishSpawnRules_WeatherSunny(), !Game1.isRaining);

--- a/LookupAnything/Framework/Models/FishData/FishSpawnData.cs
+++ b/LookupAnything/Framework/Models/FishData/FishSpawnData.cs
@@ -9,7 +9,8 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Models.FishData
     /// <param name="Weather">The weather in which the fish will spawn.</param>
     /// <param name="MinFishingLevel">The minimum fishing level.</param>
     /// <param name="IsUnique">Whether the fish can only be caught once.</param>
-    internal record FishSpawnData(string FishID, FishSpawnLocationData[]? Locations, FishSpawnTimeOfDayData[]? TimesOfDay, FishSpawnWeather Weather, int MinFishingLevel, bool IsUnique)
+    /// <param name="IsLegendaryFamily">Whether the fish is part of Qi's Extended Family quest.</param>
+    internal record FishSpawnData(string FishID, FishSpawnLocationData[]? Locations, FishSpawnTimeOfDayData[]? TimesOfDay, FishSpawnWeather Weather, int MinFishingLevel, bool IsUnique, bool IsLegendaryFamily)
     {
         /*********
         ** Public methods

--- a/LookupAnything/assets/data.json
+++ b/LookupAnything/assets/data.json
@@ -349,6 +349,93 @@ You shouldn't change this file unless you know what you're doing.
                     "Seasons": [ "winter" ]
                 }
             ]
+        },
+
+        // Son of Crimsonfish
+        "898": {
+            "MinFishingLevel": 5,
+            "Locations": [
+                {
+                    "LocationId": "Beach",
+                    "Area": "east-pier",
+                    "Seasons": [ "spring", "summer", "fall", "winter" ]
+                }
+            ],
+            "TimesOfDay": [
+                {
+                    "MinTime": "600",
+                    "MaxTime": "2600"
+                }
+            ]
+        },
+
+        // Ms. Angler
+        "899": {
+            "MinFishingLevel": 3,
+            "Locations": [
+                {
+                    "LocationId": "Town",
+                    "Area": "northmost-bridge",
+                    "Seasons": [ "spring", "summer", "fall", "winter" ]
+                }
+            ],
+            "TimesOfDay": [
+                {
+                    "MinTime": "600",
+                    "MaxTime": "2600"
+                }
+            ]
+        },
+
+        // Legend II
+        "900": {
+            "MinFishingLevel": 10,
+            "Locations": [
+                {
+                    "LocationId": "Mountain",
+                    "Seasons": [ "spring", "summer", "fall", "winter" ]
+                }
+            ],
+            "TimesOfDay": [
+                {
+                    "MinTime": "600",
+                    "MaxTime": "2600"
+                }
+            ]
+        },
+
+        // Radioactive Carp
+        "901": {
+            "Locations": [
+                {
+                    "LocationId": "Sewer",
+                    "Seasons": [ "spring", "summer", "fall", "winter" ]
+                }
+            ],
+            "TimesOfDay": [
+                {
+                    "MinTime": "600",
+                    "MaxTime": "2600"
+                }
+            ]
+        },
+
+        // Glacierfish Jr.
+        "902": {
+            "MinFishingLevel": 6,
+            "Locations": [
+                {
+                    "LocationId": "Forest",
+                    "Area": "island-tip",
+                    "Seasons": [ "spring", "summer", "fall", "winter" ]
+                }
+            ],
+            "TimesOfDay": [
+                {
+                    "MinTime": "600",
+                    "MaxTime": "2600"
+                }
+            ]
         }
     },
 

--- a/LookupAnything/assets/data.json
+++ b/LookupAnything/assets/data.json
@@ -352,7 +352,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Son of Crimsonfish
-        "898": {
+        "(O)898": {
             "MinFishingLevel": 5,
             "Locations": [
                 {
@@ -370,7 +370,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Ms. Angler
-        "899": {
+        "(O)899": {
             "MinFishingLevel": 3,
             "Locations": [
                 {
@@ -388,7 +388,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Legend II
-        "900": {
+        "(O)900": {
             "MinFishingLevel": 10,
             "Locations": [
                 {
@@ -405,7 +405,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Radioactive Carp
-        "901": {
+        "(O)901": {
             "Locations": [
                 {
                     "LocationId": "Sewer",
@@ -421,7 +421,7 @@ You shouldn't change this file unless you know what you're doing.
         },
 
         // Glacierfish Jr.
-        "902": {
+        "(O)902": {
             "MinFishingLevel": 6,
             "Locations": [
                 {

--- a/LookupAnything/assets/data.json
+++ b/LookupAnything/assets/data.json
@@ -360,12 +360,6 @@ You shouldn't change this file unless you know what you're doing.
                     "Area": "east-pier",
                     "Seasons": [ "spring", "summer", "fall", "winter" ]
                 }
-            ],
-            "TimesOfDay": [
-                {
-                    "MinTime": "600",
-                    "MaxTime": "2600"
-                }
             ]
         },
 
@@ -378,12 +372,6 @@ You shouldn't change this file unless you know what you're doing.
                     "Area": "northmost-bridge",
                     "Seasons": [ "spring", "summer", "fall", "winter" ]
                 }
-            ],
-            "TimesOfDay": [
-                {
-                    "MinTime": "600",
-                    "MaxTime": "2600"
-                }
             ]
         },
 
@@ -395,12 +383,6 @@ You shouldn't change this file unless you know what you're doing.
                     "LocationId": "Mountain",
                     "Seasons": [ "spring", "summer", "fall", "winter" ]
                 }
-            ],
-            "TimesOfDay": [
-                {
-                    "MinTime": "600",
-                    "MaxTime": "2600"
-                }
             ]
         },
 
@@ -410,12 +392,6 @@ You shouldn't change this file unless you know what you're doing.
                 {
                     "LocationId": "Sewer",
                     "Seasons": [ "spring", "summer", "fall", "winter" ]
-                }
-            ],
-            "TimesOfDay": [
-                {
-                    "MinTime": "600",
-                    "MaxTime": "2600"
                 }
             ]
         },
@@ -428,12 +404,6 @@ You shouldn't change this file unless you know what you're doing.
                     "LocationId": "Forest",
                     "Area": "island-tip",
                     "Seasons": [ "spring", "summer", "fall", "winter" ]
-                }
-            ],
-            "TimesOfDay": [
-                {
-                    "MinTime": "600",
-                    "MaxTime": "2600"
                 }
             ]
         }

--- a/LookupAnything/i18n/de.json
+++ b/LookupAnything/i18n/de.json
@@ -398,6 +398,7 @@
     // values
     "item.fish-spawn-rules.min-fishing-level": "Mindest-Angelstufe: {{level}}",
     "item.fish-spawn-rules.not-caught-yet": "Noch nicht gefangen (kann nur einmal gefangen werden)",
+    "item.fish-spawn-rules.extended-family-quest-active": "\"Extended Family\" quest active", // TODO
     "item.fish-spawn-rules.locations": "Standorte: {{locations}}",
     "item.fish-spawn-rules.locations-by-season.label": "Standorte:",
     "item.fish-spawn-rules.locations-by-season.season-locations": "{{season}}: {{locations}}",

--- a/LookupAnything/i18n/default.json
+++ b/LookupAnything/i18n/default.json
@@ -398,6 +398,7 @@
     // values
     "item.fish-spawn-rules.min-fishing-level": "min fishing level: {{level}}",
     "item.fish-spawn-rules.not-caught-yet": "not caught yet (can only be caught once)",
+    "item.fish-spawn-rules.extended-family-quest-active": "\"Extended Family\" quest active",
     "item.fish-spawn-rules.locations": "locations: {{locations}}",
     "item.fish-spawn-rules.locations-by-season.label": "locations:",
     "item.fish-spawn-rules.locations-by-season.season-locations": "{{season}}: {{locations}}",

--- a/LookupAnything/i18n/es.json
+++ b/LookupAnything/i18n/es.json
@@ -399,6 +399,7 @@
     // values
     "item.fish-spawn-rules.min-fishing-level": "nivel de pescar mínimo: {{level}}",
     "item.fish-spawn-rules.not-caught-yet": "aún no ha sido atrapado (solo se puede atrapar una vez)",
+    "item.fish-spawn-rules.extended-family-quest-active": "\"Extended Family\" quest active", // TODO
     "item.fish-spawn-rules.locations": "ubicaciones: {{locations}}",
     "item.fish-spawn-rules.locations-by-season.label": "ubicaciones:",
     "item.fish-spawn-rules.locations-by-season.season-locations": "{{season}}: {{locations}}",

--- a/LookupAnything/i18n/fr.json
+++ b/LookupAnything/i18n/fr.json
@@ -401,6 +401,7 @@
     // values
     "item.fish-spawn-rules.min-fishing-level": "niveau minimum de pêche : {{level}}",
     "item.fish-spawn-rules.not-caught-yet": "pas encore attrapé (ne peux être attrapé qu'une fois)",
+    "item.fish-spawn-rules.extended-family-quest-active": "\"Extended Family\" quest active", // TODO
     "item.fish-spawn-rules.locations": "emplacements : {{locations}}",
     "item.fish-spawn-rules.locations-by-season.label": "emplacements :",
     "item.fish-spawn-rules.locations-by-season.season-locations": "{{season}} : {{locations}}",

--- a/LookupAnything/i18n/hu.json
+++ b/LookupAnything/i18n/hu.json
@@ -399,6 +399,7 @@
     // values
     "item.fish-spawn-rules.min-fishing-level": "minimum horgász szint: {{level}}",
     "item.fish-spawn-rules.not-caught-yet": "nem fogtál még (csak egyszer lehet elkapni)",
+    "item.fish-spawn-rules.extended-family-quest-active": "\"Extended Family\" quest active", // TODO
     "item.fish-spawn-rules.locations": "helyszínek: {{locations}}",
     "item.fish-spawn-rules.locations-by-season.label": "helyszínek:",
     "item.fish-spawn-rules.locations-by-season.season-locations": "{{season}}: {{locations}}",

--- a/LookupAnything/i18n/it.json
+++ b/LookupAnything/i18n/it.json
@@ -397,6 +397,7 @@
     // values
     "item.fish-spawn-rules.min-fishing-level": "livello minimo di pesca: {{level}}",
     "item.fish-spawn-rules.not-caught-yet": "Non ancora pescato (si può pescare solo una volta)",
+    "item.fish-spawn-rules.extended-family-quest-active": "\"Extended Family\" quest active", // TODO
     "item.fish-spawn-rules.locations": "luogo: {{locations}}",
     "item.fish-spawn-rules.locations-by-season.label": "luoghi:",
     "item.fish-spawn-rules.locations-by-season.season-locations": "{{season}}: {{locations}}",

--- a/LookupAnything/i18n/ja.json
+++ b/LookupAnything/i18n/ja.json
@@ -398,6 +398,7 @@
     // values
     "item.fish-spawn-rules.min-fishing-level": "必要釣りレベル：{{level}}",
     "item.fish-spawn-rules.not-caught-yet": "まだ釣った事がない（釣れるのは一度だけです）",
+    "item.fish-spawn-rules.extended-family-quest-active": "\"Extended Family\" quest active", // TODO
     "item.fish-spawn-rules.locations": "場所：{{locations}}",
     "item.fish-spawn-rules.locations-by-season.label": "場所：",
     "item.fish-spawn-rules.locations-by-season.season-locations": "{{season}}：{{locations}}",

--- a/LookupAnything/i18n/ko.json
+++ b/LookupAnything/i18n/ko.json
@@ -398,6 +398,7 @@
     // values
     "item.fish-spawn-rules.min-fishing-level": "최소 낚시 레벨: {{level}}",
     "item.fish-spawn-rules.not-caught-yet": "아직 잡히지 않음(한 번만 잡을 수 있음)",
+    "item.fish-spawn-rules.extended-family-quest-active": "\"Extended Family\" quest active", // TODO
     "item.fish-spawn-rules.locations": "장소: {{locations}}",
     "item.fish-spawn-rules.locations-by-season.label": "장소:",
     "item.fish-spawn-rules.locations-by-season.season-locations": "{{season}}: {{locations}}",

--- a/LookupAnything/i18n/pl.json
+++ b/LookupAnything/i18n/pl.json
@@ -399,6 +399,7 @@
     // values
     "item.fish-spawn-rules.min-fishing-level": "min. poziom wędkarstwa: {{level}}",
     "item.fish-spawn-rules.not-caught-yet": "jeszcze nie złowiono (można złapać tylko raz na grę)",
+    "item.fish-spawn-rules.extended-family-quest-active": "\"Extended Family\" quest active", // TODO
     "item.fish-spawn-rules.locations": "lokacje: {{locations}}",
     "item.fish-spawn-rules.locations-by-season.label": "lokacje:",
     "item.fish-spawn-rules.locations-by-season.season-locations": "{{season}}: {{locations}}",

--- a/LookupAnything/i18n/pt.json
+++ b/LookupAnything/i18n/pt.json
@@ -399,6 +399,7 @@
     // values
     "item.fish-spawn-rules.min-fishing-level": "nível mínimo de pesca: {{level}}",
     "item.fish-spawn-rules.not-caught-yet": "não capturado ainda (pode ser capturado apenas uma vez)",
+    "item.fish-spawn-rules.extended-family-quest-active": "\"Extended Family\" quest active", // TODO
     "item.fish-spawn-rules.locations": "localizações: {{locations}}",
     "item.fish-spawn-rules.locations-by-season.label": "localizações:",
     "item.fish-spawn-rules.locations-by-season.season-locations": "{{season}}: {{locations}}",

--- a/LookupAnything/i18n/ru.json
+++ b/LookupAnything/i18n/ru.json
@@ -398,6 +398,7 @@
     // values
     "item.fish-spawn-rules.min-fishing-level": "минимальный уровень рыбалки: {{level}}",
     "item.fish-spawn-rules.not-caught-yet": "пока не пойман (может быть пойман только один раз)",
+    "item.fish-spawn-rules.extended-family-quest-active": "\"Extended Family\" quest active", // TODO
     "item.fish-spawn-rules.locations": "местонахождение: {{locations}}",
     "item.fish-spawn-rules.locations-by-season.label": "местонахождение:",
     "item.fish-spawn-rules.locations-by-season.season-locations": "{{season}}: {{locations}}",

--- a/LookupAnything/i18n/th.json
+++ b/LookupAnything/i18n/th.json
@@ -399,6 +399,7 @@
     // values
     "item.fish-spawn-rules.min-fishing-level": "เลเวลตกปลาขั้นต่ำ: {{level}}",
     "item.fish-spawn-rules.not-caught-yet": "ยังตกไม่ได้ (ตกได้ครั้งเดียว)",
+    "item.fish-spawn-rules.extended-family-quest-active": "\"Extended Family\" quest active", // TODO
     "item.fish-spawn-rules.locations": "สถานที่: {{locations}}",
     "item.fish-spawn-rules.locations-by-season.label": "สถานที่:",
     "item.fish-spawn-rules.locations-by-season.season-locations": "{{season}}: {{locations}}",

--- a/LookupAnything/i18n/tr.json
+++ b/LookupAnything/i18n/tr.json
@@ -398,6 +398,7 @@
     // values
     "item.fish-spawn-rules.min-fishing-level": "minimum balıkçılık seviyesi: {{level}}",
     "item.fish-spawn-rules.not-caught-yet": "henüz yakalanmamış (sadece bir defa yakalanabilir)",
+    "item.fish-spawn-rules.extended-family-quest-active": "\"Extended Family\" quest active", // TODO
     "item.fish-spawn-rules.locations": "bölgeler: {{locations}}",
     "item.fish-spawn-rules.locations-by-season.label": "bölgeler:",
     "item.fish-spawn-rules.locations-by-season.season-locations": "{{season}}: {{locations}}",

--- a/LookupAnything/i18n/uk.json
+++ b/LookupAnything/i18n/uk.json
@@ -399,6 +399,7 @@
     // values
     "item.fish-spawn-rules.min-fishing-level": "Мінімальний рівень рибальства: {{level}}",
     "item.fish-spawn-rules.not-caught-yet": "Поки-що не зловлено (Можна зловити лише один раз)",
+    "item.fish-spawn-rules.extended-family-quest-active": "\"Extended Family\" quest active", // TODO
     "item.fish-spawn-rules.locations": "Місцезнаходження: {{locations}}",
     "item.fish-spawn-rules.locations-by-season.label": "Місцезнаходження:",
     "item.fish-spawn-rules.locations-by-season.season-locations": "{{season}}: {{locations}}",

--- a/LookupAnything/i18n/zh.json
+++ b/LookupAnything/i18n/zh.json
@@ -399,6 +399,7 @@
 
     "item.fish-spawn-rules.min-fishing-level": "最低钓鱼等级：{{level}}",
     "item.fish-spawn-rules.not-caught-yet": "尚未被抓住（只能被抓住一次）",
+    "item.fish-spawn-rules.extended-family-quest-active": "\"Extended Family\" quest active", // TODO
     "item.fish-spawn-rules.locations": "地点：{{locations}}",
     "item.fish-spawn-rules.locations-by-season.label": "地点：",
     "item.fish-spawn-rules.locations-by-season.season-locations": "{{season}}: {{locations}}",


### PR DESCRIPTION
Added spawn rules for the fish from Qi's "Extended Family" quest.

Screenshots:
<img width="644" alt="image" src="https://github.com/user-attachments/assets/3a6b73b2-75b9-4691-b124-4554fbe99037">
<img width="644" alt="image" src="https://github.com/user-attachments/assets/fba8a264-3fb3-4699-9ba8-1ea9a339e61e">
<img width="648" alt="image" src="https://github.com/user-attachments/assets/9afdccd8-2d8d-498f-8a69-e383a0e8b685">
<img width="647" alt="image" src="https://github.com/user-attachments/assets/95c89913-44a8-44f8-8625-468cdbf60e88">
<img width="649" alt="image" src="https://github.com/user-attachments/assets/c194cd8e-f4d4-43e9-8a6f-254cc47c82d4">



