### PR TITLE
[LookupAnything] Add a continue after detecting complex output method

### DIFF
--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -497,8 +497,10 @@ internal class DataParser
                             continue;
 
                         // track whether some recipes are too complex to fully display
-                        if (outputItem.OutputMethod != null)
+                        if (outputItem.OutputMethod != null) {
                             someRulesTooComplex = true;
+                            continue;
+                        }
 
                         // add ingredients
                         List<RecipeIngredientModel> ingredients = [

--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -497,7 +497,8 @@ internal class DataParser
                             continue;
 
                         // track whether some recipes are too complex to fully display
-                        if (outputItem.OutputMethod != null) {
+                        if (outputItem.OutputMethod != null)
+                        {
                             someRulesTooComplex = true;
                             continue;
                         }


### PR DESCRIPTION
The base ItemQueryResolver.TryResolve overload seems to be using Game1.log.Warn instead of Helpers.ErrorResult (which respects the logError delegate passed into TryResolve), leading to some warnings even when logError is null.

LookupAnything currently attempts to resolve item query for case where OutputMethod is set. Skip this as vanilla game does not try to resolve item query in this case, only apply item fields.