### PR TITLE
[DataLayers] Add check for "Passable" in Tile.Properties

### DIFF
--- a/DataLayers/Layers/AccessibleLayer.cs
+++ b/DataLayers/Layers/AccessibleLayer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Xna.Framework;
@@ -126,17 +127,20 @@ internal class AccessibleLayer : BaseLayer
     /// <returns></returns>
     public static bool IsTileDataPassable(GameLocation location, Vector2 tileLocation)
     {
+        Tile building = location.map.RequireLayer("Buildings").Tiles[(int)tileLocation.X, (int)tileLocation.Y];
+        if (building != null && building.Properties.ContainsKey("Passable"))
+        {
+            // Building layer Passable=* makes the layer passible
+            return true;
+        }
         Tile back = location.map.RequireLayer("Back").Tiles[(int)tileLocation.X, (int)tileLocation.Y];
         if (back != null && back.Properties.ContainsKey("Passable"))
         {
+            // Back layer Passable=* makes the layer impassible
             return false;
         }
-        Tile building = location.map.RequireLayer("Buildings").Tiles[(int)tileLocation.X, (int)tileLocation.Y];
-        if (building != null && !building.Properties.ContainsKey("Shadow") && !building.Properties.ContainsKey("Passable"))
-        {
-            return false;
-        }
-        return true;
+        // fall back to the vanilla check
+        return location.isTilePassable(tileLocation);
     }
 
     /// <summary>Get the updated data layer tiles.</summary>
@@ -165,7 +169,7 @@ internal class AccessibleLayer : BaseLayer
             LegendEntry type;
             if (this.IsWarp(location, tile, tilePixels, buildingDoors))
                 type = this.Warp;
-            else if (location.isTilePassable(tile) && IsTileDataPassable(location, tile))
+            else if (IsTileDataPassable(location, tile))
                 type = location.IsTileBlockedBy(tile, ignorePassables: CollisionMask.All) ? this.Occupied : this.Clear;
             else
                 type = this.Impassable;

--- a/DataLayers/Layers/AccessibleLayer.cs
+++ b/DataLayers/Layers/AccessibleLayer.cs
@@ -119,6 +119,26 @@ internal class AccessibleLayer : BaseLayer
             : tile;
     }
 
+    /// <summary>
+    /// GameLocation.isTilePassable only checks tilesheet properties, does not check TileData.
+    /// </summary>
+    /// <param name="tileLocation"></param>
+    /// <returns></returns>
+    public static bool IsTileDataPassable(GameLocation location, Vector2 tileLocation)
+    {
+        Tile back = location.map.RequireLayer("Back").Tiles[(int)tileLocation.X, (int)tileLocation.Y];
+        if (back != null && back.Properties.ContainsKey("Passable"))
+        {
+            return false;
+        }
+        Tile building = location.map.RequireLayer("Buildings").Tiles[(int)tileLocation.X, (int)tileLocation.Y];
+        if (building != null && !building.Properties.ContainsKey("Shadow") && !building.Properties.ContainsKey("Passable"))
+        {
+            return false;
+        }
+        return true;
+    }
+
     /// <summary>Get the updated data layer tiles.</summary>
     /// <param name="location">The current location.</param>
     /// <param name="visibleTiles">The tiles currently visible on the screen.</param>
@@ -145,7 +165,7 @@ internal class AccessibleLayer : BaseLayer
             LegendEntry type;
             if (this.IsWarp(location, tile, tilePixels, buildingDoors))
                 type = this.Warp;
-            else if (location.isTilePassable(tile))
+            else if (location.isTilePassable(tile) && IsTileDataPassable(location, tile))
                 type = location.IsTileBlockedBy(tile, ignorePassables: CollisionMask.All) ? this.Occupied : this.Clear;
             else
                 type = this.Impassable;


### PR DESCRIPTION
GameLocation.isTilePassable does not check tile.Properties for "Passable", only tile.TileIndexProperties, this causes the Accessible data layer to not match the actual collision experienced by player. Possibly a vanilla bug?

Add a check for those in DataLayers.

Sample repro mod, has large amounts of TileData with Passable F on Back layer.
[[CP] Krikos Greenhouse.zip](https://github.com/user-attachments/files/17727005/CP.Krikos.Greenhouse.zip)
