### PR TITLE
[ChestsAnywhere] Tweak condition for big chest offset.

### DIFF
--- a/ChestsAnywhere/Menus/Overlays/ChestOverlay.cs
+++ b/ChestsAnywhere/Menus/Overlays/ChestOverlay.cs
@@ -183,7 +183,7 @@ internal class ChestOverlay : BaseChestOverlay
         bool hasColorPicker = false;
         if (menu is ItemGrabMenu grabMenu)
         {
-            isBigChest = grabMenu.ItemsToGrabMenu.capacity >= 70;
+            isBigChest = grabMenu.ItemsToGrabMenu.rows >= 5;
             hasColorPicker = this.IsColorPickerShown(grabMenu);
         }
 


### PR DESCRIPTION
This is a small change that behaves identically to the prior logic, but fixes a future incompatibility with the Unlimited Storage Mod where chests will have a configurable width and height, and so the offset should apply to all ItemGrabMenu containing 5 rows of inventory slots.