### PR TITLE
Cache source maps for a major performance optimization

### DIFF
--- a/ContentPatcher/Framework/PatchLoader.cs
+++ b/ContentPatcher/Framework/PatchLoader.cs
@@ -54,6 +54,18 @@ internal class PatchLoader
         nameof(ConditionType.TargetWithoutPath)
     );
 
+    private readonly Dictionary<string, xTile.Map> RawMapCache = [];
+
+    internal xTile.Map? TryGetMapCache(string filename)
+    {        
+        this.RawMapCache.TryGetValue(filename, out var map);
+        return map;
+    }
+    internal void PopulateMapCache(string filename, xTile.Map map)
+    {
+        this.RawMapCache.TryAdd(filename, map);
+    }
+    // TODO: Add clear function for Reload command
 
     /*********
     ** Public methods
@@ -817,7 +829,9 @@ internal class PatchLoader
                             migrator: rawContentPack.Migrator,
                             parentPatch: parentPatch,
                             monitor: this.Monitor,
-                            parseAssetName: this.ParseAssetName
+                            parseAssetName: this.ParseAssetName,
+                            populateMapCache: this.PopulateMapCache,
+                            tryGetMapCache: this.TryGetMapCache
                         );
                     }
                     break;

--- a/ContentPatcher/Framework/Patches/EditMapPatch.cs
+++ b/ContentPatcher/Framework/Patches/EditMapPatch.cs
@@ -31,6 +31,9 @@ internal class EditMapPatch : Patch
     /// <summary>Encapsulates monitoring and logging.</summary>
     private readonly IMonitor Monitor;
 
+    private readonly Func<string, Map?> TryGetMapCache;
+    private readonly Action<string, Map> PopulateMapCache;
+
     /// <summary>The map area from which to read tiles.</summary>
     private readonly TokenRectangle? FromArea;
 
@@ -89,7 +92,7 @@ internal class EditMapPatch : Patch
     /// <param name="parentPatch">The parent patch for which this patch was loaded, if any.</param>
     /// <param name="monitor">Encapsulates monitoring and logging.</param>
     /// <param name="parseAssetName">Parse an asset name.</param>
-    public EditMapPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString? fromAsset, TokenRectangle? fromArea, TokenRectangle? toArea, PatchMapMode patchMode, IEnumerable<EditMapPatchProperty>? mapProperties, IEnumerable<EditMapPatchTile>? mapTiles, IEnumerable<IManagedTokenString>? addNpcWarps, IEnumerable<IManagedTokenString>? addWarps, IEnumerable<ITextOperation>? textOperations, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? inheritedLocalTokens, InvariantDictionary<IManagedTokenString>? localTokens, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName)
+    public EditMapPatch(int[] indexPath, LogPathBuilder path, IManagedTokenString assetName, IManagedTokenString? assetLocale, AssetEditPriority priority, IEnumerable<Condition> conditions, IManagedTokenString? fromAsset, TokenRectangle? fromArea, TokenRectangle? toArea, PatchMapMode patchMode, IEnumerable<EditMapPatchProperty>? mapProperties, IEnumerable<EditMapPatchTile>? mapTiles, IEnumerable<IManagedTokenString>? addNpcWarps, IEnumerable<IManagedTokenString>? addWarps, IEnumerable<ITextOperation>? textOperations, UpdateRate updateRate, InvariantDictionary<IManagedTokenString>? inheritedLocalTokens, InvariantDictionary<IManagedTokenString>? localTokens, IContentPack contentPack, IRuntimeMigration migrator, IPatch? parentPatch, IMonitor monitor, Func<string, IAssetName> parseAssetName, Action<string, Map> populateMapCache, Func<string, Map?> tryGetMapCache)
         : base(
             indexPath: indexPath,
             path: path,
@@ -117,6 +120,8 @@ internal class EditMapPatch : Patch
         this.AddWarps = addWarps?.Reverse().ToArray() ?? [];
         this.TextOperations = textOperations?.ToArray() ?? [];
         this.Monitor = monitor;
+        this.TryGetMapCache = tryGetMapCache;
+        this.PopulateMapCache = populateMapCache;
 
         this.Contextuals
             .Add(this.FromArea)
@@ -150,7 +155,12 @@ internal class EditMapPatch : Patch
         // apply map area patch
         if (this.AppliesMapPatch)
         {
-            Map source = this.ContentPack.ModContent.Load<Map>(this.FromAsset!);
+            Map? source = this.TryGetMapCache(this.ContentPack.Manifest.UniqueID + "/" + this.FromAsset!);
+            if (source == null)
+            {
+                source = this.ContentPack.ModContent.Load<Map>(this.FromAsset!);
+                this.PopulateMapCache(this.ContentPack.Manifest.UniqueID + "/" + this.FromAsset!, source);
+            }
             if (!this.TryApplyMapPatch(source, targetAsset, out string? error))
                 this.WarnForPatch($"map patch couldn't be applied: {error}");
         }


### PR DESCRIPTION
TODO: Add ability for patch reload to empty the cache

Note below numbers include other unreleased SMAPI performance tweaks, and extra ContentPatcher instrumentation not included in this PR, but those differences are the same for both before and after.

Before: https://smapi.io/log/83897c04742e471a872a39b487bc1273
![image](https://github.com/user-attachments/assets/5f160449-81ae-4d6e-80c4-dc75af81183e)
https://smapi.io/json/none/632100bbfa654df7b120ba7e414e3bb3

After: https://smapi.io/log/7e2d28eab94345888979a7f7ab7f1d66
![image](https://github.com/user-attachments/assets/4a23c71a-36aa-4273-9613-2d0d8ea04461)
https://smapi.io/json/none/3372bb161640437db04b6ab0f369bb9e