### PR TITLE
Add support for Better Game Menu

### DIFF
--- a/ChestsAnywhere/ModEntry.cs
+++ b/ChestsAnywhere/ModEntry.cs
@@ -99,6 +99,9 @@ internal class ModEntry : Mod
             set: config => this.Config = config
         );
 
+        // add Better Game Menu support
+        this.BetterGameMenu = new(this.Helper.ModRegistry, this.Monitor);
+
         // add Iconic Framework icon
         IconicFrameworkIntegration iconicFramework = new(this.Helper.ModRegistry, this.Monitor);
         if (iconicFramework.IsLoaded)
@@ -111,9 +114,6 @@ internal class ModEntry : Mod
                 this.OpenMenu
             );
         }
-
-        // add Better Game Menu
-        this.BetterGameMenu = new(this.Helper.ModRegistry, this.Monitor);
     }
 
     /// <inheritdoc cref="IGameLoopEvents.SaveLoaded" />
@@ -172,7 +172,7 @@ internal class ModEntry : Mod
                 }
 
                 // open from inventory if it's safe to close the inventory screen
-                else if (this.GetCurrentMenuPage() is InventoryPage inventoryPage)
+                else if (this.GetGameMenuPage() is InventoryPage inventoryPage)
                 {
                     if (inventoryPage.readyToClose())
                         this.OpenMenu();
@@ -185,11 +185,12 @@ internal class ModEntry : Mod
         }
     }
 
-    /// <summary>Get the current page of the currently active game menu, or <c>null</c> if no game menu is active.</summary>
-    private IClickableMenu? GetCurrentMenuPage()
+    /// <summary>Get the current page of the open active game menu, if applicable.</summary>
+    private IClickableMenu? GetGameMenuPage()
     {
         if (Game1.activeClickableMenu is GameMenu gameMenu)
             return gameMenu.GetCurrentPage();
+
         return this.BetterGameMenu?.GetCurrentPage(Game1.activeClickableMenu);
     }
 

--- a/ChestsAnywhere/ModEntry.cs
+++ b/ChestsAnywhere/ModEntry.cs
@@ -5,6 +5,7 @@ using Pathoschild.Stardew.ChestsAnywhere.Framework;
 using Pathoschild.Stardew.ChestsAnywhere.Framework.Containers;
 using Pathoschild.Stardew.ChestsAnywhere.Menus.Overlays;
 using Pathoschild.Stardew.Common;
+using Pathoschild.Stardew.Common.Integrations.BetterGameMenu;
 using Pathoschild.Stardew.Common.Integrations.GenericModConfigMenu;
 using Pathoschild.Stardew.Common.Integrations.IconicFramework;
 using Pathoschild.Stardew.Common.Messages;
@@ -44,6 +45,8 @@ internal class ModEntry : Mod
     /// <summary>The overlay for the current menu, which lets the player navigate and edit chests (or <c>null</c> if not applicable).</summary>
     private readonly PerScreen<IStorageOverlay?> CurrentOverlay = new();
 
+    /// <summary>The Better Game Menu integration.</summary>
+    private BetterGameMenuIntegration? BetterGameMenu;
 
     /*********
     ** Public methods
@@ -108,6 +111,9 @@ internal class ModEntry : Mod
                 this.OpenMenu
             );
         }
+
+        // add Better Game Menu
+        this.BetterGameMenu = new(this.Helper.ModRegistry, this.Monitor);
     }
 
     /// <inheritdoc cref="IGameLoopEvents.SaveLoaded" />
@@ -166,9 +172,8 @@ internal class ModEntry : Mod
                 }
 
                 // open from inventory if it's safe to close the inventory screen
-                else if (Game1.activeClickableMenu is GameMenu gameMenu && gameMenu.currentTab == GameMenu.inventoryTab)
+                else if (this.GetCurrentMenuPage() is InventoryPage inventoryPage)
                 {
-                    IClickableMenu inventoryPage = gameMenu.pages[GameMenu.inventoryTab];
                     if (inventoryPage.readyToClose())
                         this.OpenMenu();
                 }
@@ -178,6 +183,14 @@ internal class ModEntry : Mod
         {
             this.HandleError(ex, "handling key input");
         }
+    }
+
+    /// <summary>Get the current page of the currently active game menu, or <c>null</c> if no game menu is active.</summary>
+    private IClickableMenu? GetCurrentMenuPage()
+    {
+        if (Game1.activeClickableMenu is GameMenu gameMenu)
+            return gameMenu.GetCurrentPage();
+        return this.BetterGameMenu?.ActiveMenu?.CurrentPage;
     }
 
     /// <summary>Change the chest UI overlay if needed to match the current menu.</summary>

--- a/ChestsAnywhere/ModEntry.cs
+++ b/ChestsAnywhere/ModEntry.cs
@@ -190,7 +190,7 @@ internal class ModEntry : Mod
     {
         if (Game1.activeClickableMenu is GameMenu gameMenu)
             return gameMenu.GetCurrentPage();
-        return this.BetterGameMenu?.ActiveMenu?.CurrentPage;
+        return this.BetterGameMenu?.GetCurrentPage(Game1.activeClickableMenu);
     }
 
     /// <summary>Change the chest UI overlay if needed to match the current menu.</summary>

--- a/Common/Common.projitems
+++ b/Common/Common.projitems
@@ -21,8 +21,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\Automate\AutomateIntegration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\Automate\IAutomateApi.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\BaseIntegration.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)integrations\bettergamemenu\BetterGameMenuIntegration.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)integrations\bettergamemenu\IBetterGameMenuApi.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Integrations\BetterGameMenu\BetterGameMenuIntegration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Integrations\BetterGameMenu\IBetterGameMenuApi.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\BetterSprinklers\BetterSprinklersIntegration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\BetterSprinklers\IBetterSprinklersApi.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\BetterSprinklersPlus\BetterSprinklersPlusIntegration.cs" />
@@ -81,8 +81,5 @@
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\InvariantSet.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\MutableInvariantSet.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\ObjectReferenceComparer.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="$(MSBuildThisFileDirectory)Integrations\BetterGameMenu\" />
   </ItemGroup>
 </Project>

--- a/Common/Common.projitems
+++ b/Common/Common.projitems
@@ -21,6 +21,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\Automate\AutomateIntegration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\Automate\IAutomateApi.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\BaseIntegration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)integrations\bettergamemenu\BetterGameMenuIntegration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)integrations\bettergamemenu\IBetterGameMenuApi.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\BetterSprinklers\BetterSprinklersIntegration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\BetterSprinklers\IBetterSprinklersApi.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Integrations\BetterSprinklersPlus\BetterSprinklersPlusIntegration.cs" />
@@ -79,5 +81,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\InvariantSet.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\MutableInvariantSet.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\ObjectReferenceComparer.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="$(MSBuildThisFileDirectory)Integrations\BetterGameMenu\" />
   </ItemGroup>
 </Project>

--- a/Common/Integrations/BetterGameMenu/BetterGameMenuIntegration.cs
+++ b/Common/Integrations/BetterGameMenu/BetterGameMenuIntegration.cs
@@ -1,27 +1,24 @@
-using System;
-
 using StardewModdingAPI;
-
 using StardewValley.Menus;
-
 
 namespace Pathoschild.Stardew.Common.Integrations.BetterGameMenu;
 
 /// <summary>Handles the logic for integrating with the Better Game Menu mod.</summary>
 internal class BetterGameMenuIntegration : BaseIntegration<IBetterGameMenuApi>
 {
+    /*********
+    ** Public methods
+    *********/
     public BetterGameMenuIntegration(IModRegistry modRegistry, IMonitor monitor)
         : base("BetterGameMenu", "leclair.bettergamemenu", "0.5.2", modRegistry, monitor) { }
 
-    /// <summary>
-    /// Get the currently active page of the provided Better Game Menu instance. If
-    /// the provided menu isn't a Better Game Menu, return <c>null</c>.
-    /// </summary>
+    /// <summary>Get the currently active page of the provided Better Game Menu instance. If the provided menu isn't a Better Game Menu, return <c>null</c>.</summary>
     /// <param name="menu">The game menu to get the page from.</param>
     public IClickableMenu? GetCurrentPage(IClickableMenu? menu)
     {
         if (this.IsLoaded && menu is not null)
             return this.ModApi.GetCurrentPage(menu);
+
         return null;
     }
 

--- a/Common/Integrations/BetterGameMenu/BetterGameMenuIntegration.cs
+++ b/Common/Integrations/BetterGameMenu/BetterGameMenuIntegration.cs
@@ -1,0 +1,34 @@
+using System;
+
+using StardewModdingAPI;
+
+using StardewValley.Menus;
+
+
+namespace Pathoschild.Stardew.Common.Integrations.BetterGameMenu;
+
+/// <summary>Handles the logic for integrating with the Better Game Menu mod.</summary>
+internal class BetterGameMenuIntegration : BaseIntegration<IBetterGameMenuApi>
+{
+    public BetterGameMenuIntegration(IModRegistry modRegistry, IMonitor monitor)
+        : base("BetterGameMenu", "leclair.bettergamemenu", "0.5.0", modRegistry, monitor) { }
+
+    /// <summary>
+    /// Get the currently active page of the provided Better Game Menu instance. If
+    /// the provided menu isn't a Better Game Menu, return <c>null</c>.
+    /// </summary>
+    /// <param name="menu">The game menu to get the page from.</param>
+    public IClickableMenu? GetCurrentPage(IClickableMenu menu)
+    {
+        if (this.IsLoaded && this.ModApi.AsMenu(menu) is IBetterGameMenu bgm)
+            return bgm.CurrentPage;
+        return null;
+    }
+
+    /// <summary>
+    /// The currently active Better Game Menu instance of the current screen, if one
+    /// exists, otherwise <c>null</c>.
+    /// </summary>
+    public IBetterGameMenu? ActiveMenu => this.IsLoaded ? this.ModApi.ActiveMenu : null;
+
+}

--- a/Common/Integrations/BetterGameMenu/BetterGameMenuIntegration.cs
+++ b/Common/Integrations/BetterGameMenu/BetterGameMenuIntegration.cs
@@ -11,24 +11,18 @@ namespace Pathoschild.Stardew.Common.Integrations.BetterGameMenu;
 internal class BetterGameMenuIntegration : BaseIntegration<IBetterGameMenuApi>
 {
     public BetterGameMenuIntegration(IModRegistry modRegistry, IMonitor monitor)
-        : base("BetterGameMenu", "leclair.bettergamemenu", "0.5.0", modRegistry, monitor) { }
+        : base("BetterGameMenu", "leclair.bettergamemenu", "0.5.2", modRegistry, monitor) { }
 
     /// <summary>
     /// Get the currently active page of the provided Better Game Menu instance. If
     /// the provided menu isn't a Better Game Menu, return <c>null</c>.
     /// </summary>
     /// <param name="menu">The game menu to get the page from.</param>
-    public IClickableMenu? GetCurrentPage(IClickableMenu menu)
+    public IClickableMenu? GetCurrentPage(IClickableMenu? menu)
     {
-        if (this.IsLoaded && this.ModApi.AsMenu(menu) is IBetterGameMenu bgm)
-            return bgm.CurrentPage;
+        if (this.IsLoaded && menu is not null)
+            return this.ModApi.GetCurrentPage(menu);
         return null;
     }
-
-    /// <summary>
-    /// The currently active Better Game Menu instance of the current screen, if one
-    /// exists, otherwise <c>null</c>.
-    /// </summary>
-    public IBetterGameMenu? ActiveMenu => this.IsLoaded ? this.ModApi.ActiveMenu : null;
 
 }

--- a/Common/Integrations/BetterGameMenu/IBetterGameMenuApi.cs
+++ b/Common/Integrations/BetterGameMenu/IBetterGameMenuApi.cs
@@ -1,118 +1,11 @@
 #nullable enable
 
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
-using StardewValley;
 using StardewValley.Menus;
 
 namespace Pathoschild.Stardew.Common.Integrations.BetterGameMenu;
-
-
-/// <summary>
-/// This interface represents a Better Game Menu. 
-/// </summary>
-public interface IBetterGameMenu
-{
-    /// <summary>
-    /// The <see cref="IClickableMenu"/> instance for this game menu. This is
-    /// the same object, but with a different type. This property is included
-    /// for convenience due to how API proxying works.
-    /// </summary>
-    IClickableMenu Menu { get; }
-
-    /// <summary>
-    /// Whether or not the menu is currently drawing itself. This is typically
-    /// always <c>false</c> except when viewing the <c>Map</c> tab.
-    /// </summary>
-    bool Invisible { get; set; }
-
-    /// <summary>
-    /// A list of ids of the currently visible tabs.
-    /// </summary>
-    IReadOnlyList<string> VisibleTabs { get; }
-
-    /// <summary>
-    /// The id of the currently active tab.
-    /// </summary>
-    string CurrentTab { get; }
-
-    /// <summary>
-    /// The <see cref="IClickableMenu"/> instance for the currently active tab.
-    /// This may be <c>null</c> if the page instance for the currently active
-    /// tab is still being initialized.
-    /// </summary>
-    IClickableMenu? CurrentPage { get; }
-
-    /// <summary>
-    /// Whether or not the currently displayed page is an error page. Error
-    /// pages are used when a tab implementation's GetPageInstance method
-    /// throws an exception.
-    /// </summary>
-    bool CurrentTabHasErrored { get; }
-
-    /// <summary>
-    /// Try to get the source for the specific tab.
-    /// </summary>
-    /// <param name="target">The id of the tab to get the source of.</param>
-    /// <param name="source">The unique ID of the mod that registered the
-    /// implementation being used, or <c>stardew</c> if the base game's
-    /// implementation is being used.</param>
-    /// <returns>Whether or not the tab is registered with the system.</returns>
-    bool TryGetSource(string target, [NotNullWhen(true)] out string? source);
-
-    /// <summary>
-    /// Try to get the <see cref="IClickableMenu"/> instance for a specific tab.
-    /// </summary>
-    /// <param name="target">The id of the tab to get the page for.</param>
-    /// <param name="page">The page instance, if one exists.</param>
-    /// <param name="forceCreation">If set to true, an instance will attempt to
-    /// be created if one has not already been created.</param>
-    /// <returns>Whether or not a page instance for that tab exists.</returns>
-    bool TryGetPage(string target, [NotNullWhen(true)] out IClickableMenu? page, bool forceCreation = false);
-
-    /// <summary>
-    /// Attempt to change the currently active tab to the target tab.
-    /// </summary>
-    /// <param name="target">The id of the tab to change to.</param>
-    /// <param name="playSound">Whether or not to play a sound.</param>
-    /// <returns>Whether or not the tab was changed successfully.</returns>
-    bool TryChangeTab(string target, bool playSound = true);
-
-    /// <summary>
-    /// Force the menu to recalculate the visible tabs. This will not recreate
-    /// <see cref="IClickableMenu"/> instances, but can be used to cause an
-    /// inactive tab to be removed, or a previously hidden tab to be added.
-    /// This can also be used to update tab decorations if necessary.
-    /// </summary>
-    /// <param name="target">Optionally, a specific tab to update rather than
-    /// updating all tabs.</param>
-    void UpdateTabs(string? target = null);
-
-}
-
-
-/// <summary>
-/// This enum is included for reference and has the order value for
-/// all the default tabs from the base game. These values are intentionally
-/// spaced out to allow for modded tabs to be inserted at specific points.
-/// </summary>
-public enum VanillaTabOrders
-{
-    Inventory = 0,
-    Skills = 20,
-    Social = 40,
-    Map = 60,
-    Crafting = 80,
-    Animals = 100,
-    Powers = 120,
-    Collections = 140,
-    Options = 160,
-    Exit = 200
-}
 
 
 public interface IBetterGameMenuApi
@@ -128,18 +21,12 @@ public interface IBetterGameMenuApi
     #region Menu Class Access
 
     /// <summary>
-    /// The active screen's current Better Game Menu, if one is open,
-    /// else <c>null</c>.
+    /// Get the current page of the provided Better Game Menu instance. If the
+    /// provided menu is not a Better Game Menu, or a page is not ready, then
+    /// return <c>null</c> instead.
     /// </summary>
-    IBetterGameMenu? ActiveMenu { get; }
-
-    /// <summary>
-    /// Attempt to cast the provided menu into an <see cref="IBetterGameMenu"/>.
-    /// This can be useful if you're working with a menu that isn't currently
-    /// assigned to <see cref="Game1.activeClickableMenu"/>.
-    /// </summary>
-    /// <param name="menu">The menu to attempt to cast</param>
-    IBetterGameMenu? AsMenu(IClickableMenu menu);
+    /// <param name="menu">The menu to get the page from.</param>
+    IClickableMenu? GetCurrentPage(IClickableMenu menu);
 
     #endregion
 

--- a/Common/Integrations/BetterGameMenu/IBetterGameMenuApi.cs
+++ b/Common/Integrations/BetterGameMenu/IBetterGameMenuApi.cs
@@ -1,33 +1,10 @@
-#nullable enable
-
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-
 using StardewValley.Menus;
 
 namespace Pathoschild.Stardew.Common.Integrations.BetterGameMenu;
 
-
 public interface IBetterGameMenuApi
 {
-
-    /// <summary>
-    /// A delegate for drawing something onto the screen.
-    /// </summary>
-    /// <param name="batch">The <see cref="SpriteBatch"/> to draw with.</param>
-    /// <param name="bounds">The region where the thing should be drawn.</param>
-    public delegate void DrawDelegate(SpriteBatch batch, Rectangle bounds);
-
-    #region Menu Class Access
-
-    /// <summary>
-    /// Get the current page of the provided Better Game Menu instance. If the
-    /// provided menu is not a Better Game Menu, or a page is not ready, then
-    /// return <c>null</c> instead.
-    /// </summary>
+    /// <summary>Get the current page of the provided Better Game Menu instance. If the provided menu is not a Better Game Menu, or a page is not ready, then return <c>null</c> instead.</summary>
     /// <param name="menu">The menu to get the page from.</param>
     IClickableMenu? GetCurrentPage(IClickableMenu menu);
-
-    #endregion
-
 }

--- a/Common/Integrations/BetterGameMenu/IBetterGameMenuApi.cs
+++ b/Common/Integrations/BetterGameMenu/IBetterGameMenuApi.cs
@@ -1,0 +1,146 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using StardewValley;
+using StardewValley.Menus;
+
+namespace Pathoschild.Stardew.Common.Integrations.BetterGameMenu;
+
+
+/// <summary>
+/// This interface represents a Better Game Menu. 
+/// </summary>
+public interface IBetterGameMenu
+{
+    /// <summary>
+    /// The <see cref="IClickableMenu"/> instance for this game menu. This is
+    /// the same object, but with a different type. This property is included
+    /// for convenience due to how API proxying works.
+    /// </summary>
+    IClickableMenu Menu { get; }
+
+    /// <summary>
+    /// Whether or not the menu is currently drawing itself. This is typically
+    /// always <c>false</c> except when viewing the <c>Map</c> tab.
+    /// </summary>
+    bool Invisible { get; set; }
+
+    /// <summary>
+    /// A list of ids of the currently visible tabs.
+    /// </summary>
+    IReadOnlyList<string> VisibleTabs { get; }
+
+    /// <summary>
+    /// The id of the currently active tab.
+    /// </summary>
+    string CurrentTab { get; }
+
+    /// <summary>
+    /// The <see cref="IClickableMenu"/> instance for the currently active tab.
+    /// This may be <c>null</c> if the page instance for the currently active
+    /// tab is still being initialized.
+    /// </summary>
+    IClickableMenu? CurrentPage { get; }
+
+    /// <summary>
+    /// Whether or not the currently displayed page is an error page. Error
+    /// pages are used when a tab implementation's GetPageInstance method
+    /// throws an exception.
+    /// </summary>
+    bool CurrentTabHasErrored { get; }
+
+    /// <summary>
+    /// Try to get the source for the specific tab.
+    /// </summary>
+    /// <param name="target">The id of the tab to get the source of.</param>
+    /// <param name="source">The unique ID of the mod that registered the
+    /// implementation being used, or <c>stardew</c> if the base game's
+    /// implementation is being used.</param>
+    /// <returns>Whether or not the tab is registered with the system.</returns>
+    bool TryGetSource(string target, [NotNullWhen(true)] out string? source);
+
+    /// <summary>
+    /// Try to get the <see cref="IClickableMenu"/> instance for a specific tab.
+    /// </summary>
+    /// <param name="target">The id of the tab to get the page for.</param>
+    /// <param name="page">The page instance, if one exists.</param>
+    /// <param name="forceCreation">If set to true, an instance will attempt to
+    /// be created if one has not already been created.</param>
+    /// <returns>Whether or not a page instance for that tab exists.</returns>
+    bool TryGetPage(string target, [NotNullWhen(true)] out IClickableMenu? page, bool forceCreation = false);
+
+    /// <summary>
+    /// Attempt to change the currently active tab to the target tab.
+    /// </summary>
+    /// <param name="target">The id of the tab to change to.</param>
+    /// <param name="playSound">Whether or not to play a sound.</param>
+    /// <returns>Whether or not the tab was changed successfully.</returns>
+    bool TryChangeTab(string target, bool playSound = true);
+
+    /// <summary>
+    /// Force the menu to recalculate the visible tabs. This will not recreate
+    /// <see cref="IClickableMenu"/> instances, but can be used to cause an
+    /// inactive tab to be removed, or a previously hidden tab to be added.
+    /// This can also be used to update tab decorations if necessary.
+    /// </summary>
+    /// <param name="target">Optionally, a specific tab to update rather than
+    /// updating all tabs.</param>
+    void UpdateTabs(string? target = null);
+
+}
+
+
+/// <summary>
+/// This enum is included for reference and has the order value for
+/// all the default tabs from the base game. These values are intentionally
+/// spaced out to allow for modded tabs to be inserted at specific points.
+/// </summary>
+public enum VanillaTabOrders
+{
+    Inventory = 0,
+    Skills = 20,
+    Social = 40,
+    Map = 60,
+    Crafting = 80,
+    Animals = 100,
+    Powers = 120,
+    Collections = 140,
+    Options = 160,
+    Exit = 200
+}
+
+
+public interface IBetterGameMenuApi
+{
+
+    /// <summary>
+    /// A delegate for drawing something onto the screen.
+    /// </summary>
+    /// <param name="batch">The <see cref="SpriteBatch"/> to draw with.</param>
+    /// <param name="bounds">The region where the thing should be drawn.</param>
+    public delegate void DrawDelegate(SpriteBatch batch, Rectangle bounds);
+
+    #region Menu Class Access
+
+    /// <summary>
+    /// The active screen's current Better Game Menu, if one is open,
+    /// else <c>null</c>.
+    /// </summary>
+    IBetterGameMenu? ActiveMenu { get; }
+
+    /// <summary>
+    /// Attempt to cast the provided menu into an <see cref="IBetterGameMenu"/>.
+    /// This can be useful if you're working with a menu that isn't currently
+    /// assigned to <see cref="Game1.activeClickableMenu"/>.
+    /// </summary>
+    /// <param name="menu">The menu to attempt to cast</param>
+    IBetterGameMenu? AsMenu(IClickableMenu menu);
+
+    #endregion
+
+}

--- a/DebugMode/ModEntry.cs
+++ b/DebugMode/ModEntry.cs
@@ -103,6 +103,9 @@ internal class ModEntry : Mod
             set: config => this.Config = config
         );
 
+        // add Better Game Menu support
+        this.BetterGameMenu = new(this.Helper.ModRegistry, this.Monitor);
+
         // add Iconic Framework icon
         IconicFrameworkIntegration iconicFramework = new(this.Helper.ModRegistry, this.Monitor);
         if (iconicFramework.IsLoaded)
@@ -115,9 +118,6 @@ internal class ModEntry : Mod
                 this.ToggleDebugMenu
             );
         }
-
-        // add Better Game Menu
-        this.BetterGameMenu = new(this.Helper.ModRegistry, this.Monitor);
     }
 
     /// <inheritdoc cref="IInputEvents.ButtonsChanged" />

--- a/DebugMode/ModEntry.cs
+++ b/DebugMode/ModEntry.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Pathoschild.Stardew.Common;
+using Pathoschild.Stardew.Common.Integrations.BetterGameMenu;
 using Pathoschild.Stardew.Common.Integrations.GenericModConfigMenu;
 using Pathoschild.Stardew.Common.Integrations.IconicFramework;
 using Pathoschild.Stardew.DebugMode.Framework;
@@ -30,6 +31,9 @@ internal class ModEntry : Mod
 
     /// <summary>Whether to show the debug info overlay.</summary>
     private readonly PerScreen<bool> ShowOverlay = new();
+
+    /// <summary>The Better Game Menu integration.</summary>
+    private BetterGameMenuIntegration? BetterGameMenu;
 
     /// <summary>Whether the built-in debug mode is enabled.</summary>
     private bool GameDebugMode
@@ -111,6 +115,9 @@ internal class ModEntry : Mod
                 this.ToggleDebugMenu
             );
         }
+
+        // add Better Game Menu
+        this.BetterGameMenu = new(this.Helper.ModRegistry, this.Monitor);
     }
 
     /// <inheritdoc cref="IInputEvents.ButtonsChanged" />
@@ -310,7 +317,7 @@ internal class ModEntry : Mod
         {
             GameMenu gameMenu => gameMenu.pages[gameMenu.currentTab],
             TitleMenu => TitleMenu.subMenu,
-            _ => null
+            _ => this.BetterGameMenu?.GetCurrentPage(menu)
         };
     }
 }

--- a/LookupAnything/Framework/Lookups/Characters/CharacterLookupProvider.cs
+++ b/LookupAnything/Framework/Lookups/Characters/CharacterLookupProvider.cs
@@ -78,7 +78,7 @@ internal class CharacterLookupProvider : BaseLookupProvider
     /// <inheritdoc />
     public override ISubject? GetSubject(IClickableMenu menu, int cursorX, int cursorY)
     {
-        IClickableMenu targetMenu = this.GameHelper.GetCurrentMenuPage(menu) ?? menu;
+        IClickableMenu targetMenu = this.GameHelper.GetGameMenuPage(menu) ?? menu;
         switch (targetMenu)
         {
             /****

--- a/LookupAnything/Framework/Lookups/Characters/CharacterLookupProvider.cs
+++ b/LookupAnything/Framework/Lookups/Characters/CharacterLookupProvider.cs
@@ -78,7 +78,7 @@ internal class CharacterLookupProvider : BaseLookupProvider
     /// <inheritdoc />
     public override ISubject? GetSubject(IClickableMenu menu, int cursorX, int cursorY)
     {
-        IClickableMenu targetMenu = (menu as GameMenu)?.GetCurrentPage() ?? menu;
+        IClickableMenu targetMenu = this.GameHelper.GetCurrentMenuPage(menu) ?? menu;
         switch (targetMenu)
         {
             /****

--- a/LookupAnything/Framework/Lookups/Items/ItemLookupProvider.cs
+++ b/LookupAnything/Framework/Lookups/Items/ItemLookupProvider.cs
@@ -100,7 +100,7 @@ internal class ItemLookupProvider : BaseLookupProvider
     /// <inheritdoc />
     public override ISubject? GetSubject(IClickableMenu menu, int cursorX, int cursorY)
     {
-        IClickableMenu targetMenu = this.GameHelper.GetCurrentMenuPage(menu) ?? menu;
+        IClickableMenu targetMenu = this.GameHelper.GetGameMenuPage(menu) ?? menu;
         switch (targetMenu)
         {
             /****

--- a/LookupAnything/Framework/Lookups/Items/ItemLookupProvider.cs
+++ b/LookupAnything/Framework/Lookups/Items/ItemLookupProvider.cs
@@ -100,7 +100,7 @@ internal class ItemLookupProvider : BaseLookupProvider
     /// <inheritdoc />
     public override ISubject? GetSubject(IClickableMenu menu, int cursorX, int cursorY)
     {
-        IClickableMenu targetMenu = (menu as GameMenu)?.GetCurrentPage() ?? menu;
+        IClickableMenu targetMenu = this.GameHelper.GetCurrentMenuPage(menu) ?? menu;
         switch (targetMenu)
         {
             /****

--- a/LookupAnything/GameHelper.cs
+++ b/LookupAnything/GameHelper.cs
@@ -653,13 +653,16 @@ internal class GameHelper
         CommonHelper.ShowErrorMessage(message);
     }
 
-    /// <summary>Get the currently active page of the provided game menu, or <c>null</c> if the provided menu is not a game menu.</summary>
-    public IClickableMenu? GetCurrentMenuPage(IClickableMenu menu)
+    /// <summary>Get the current page of an active game menu, if applicable.</summary>
+    /// <param name="menu">The menu to check.</param>
+    public IClickableMenu? GetGameMenuPage(IClickableMenu menu)
     {
         if (menu is GameMenu gameMenu)
             return gameMenu.GetCurrentPage();
+
         return this.BetterGameMenu.GetCurrentPage(menu);
     }
+
 
     /*********
     ** Private methods

--- a/LookupAnything/GameHelper.cs
+++ b/LookupAnything/GameHelper.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Pathoschild.Stardew.Common;
+using Pathoschild.Stardew.Common.Integrations.BetterGameMenu;
 using Pathoschild.Stardew.Common.Integrations.BushBloomMod;
 using Pathoschild.Stardew.Common.Integrations.CustomBush;
 using Pathoschild.Stardew.Common.Integrations.CustomFarmingRedux;
@@ -77,6 +78,9 @@ internal class GameHelper
     /// <summary>Provides metadata that's not available from the game data directly.</summary>
     public Metadata Metadata { get; }
 
+    /// <summary>The Better Game Menu integration.</summary>
+    public BetterGameMenuIntegration BetterGameMenu { get; }
+
     /// <summary>The Bush Bloom Mod integration.</summary>
     public BushBloomModIntegration BushBloomMod { get; }
 
@@ -108,6 +112,7 @@ internal class GameHelper
         this.ModRegistry = modRegistry;
         this.WorldItemScanner = new WorldItemScanner(reflection);
 
+        this.BetterGameMenu = new BetterGameMenuIntegration(modRegistry, monitor);
         this.BushBloomMod = new BushBloomModIntegration(modRegistry, monitor);
         this.CustomBush = new CustomBushIntegration(modRegistry, monitor);
         this.CustomFarmingRedux = new CustomFarmingReduxIntegration(modRegistry, monitor);
@@ -648,6 +653,13 @@ internal class GameHelper
         CommonHelper.ShowErrorMessage(message);
     }
 
+    /// <summary>Get the currently active page of the provided game menu, or <c>null</c> if the provided menu is not a game menu.</summary>
+    public IClickableMenu? GetCurrentMenuPage(IClickableMenu menu)
+    {
+        if (menu is GameMenu gameMenu)
+            return gameMenu.GetCurrentPage();
+        return this.BetterGameMenu.GetCurrentPage(menu);
+    }
 
     /*********
     ** Private methods


### PR DESCRIPTION
Hello!

[Better Game Menu](https://github.com/KhloeLeclair/StardewMods/releases/tag/BetterGameMenu-Preview3) is a new mod I'm going to be releasing that replaces `GameMenu` with a replacement that:

1. Is considerably more efficient by virtue of only creating page instances when the pages are actually accessed.
2. Has a robust API to let other mods work with the game menu, making it easy to register new tabs, override existing tabs, and respond to events involving the menu.

I realize this has the potential to break a lot of things, so I'm going to be submitting PRs to various mods that interact with GameMenu to implement support for BetterGameMenu. This is such a PR.

---

Your mods don't touch on `GameMenu` much from what I can tell, with the exception of finding the current page to extract information. As such, I've stripped out almost the entire API from the `BetterGameMenuImplementation` this creates, leaving just a method to get the current page of a menu instance.

Everything was simple and easy to implement. The only note I have is that there's a logical change in Chests Everywhere to check if the current page is an `InventoryPage` instance, rather than checking which tab number is open in the `GameMenu`.

I hope this is helpful. Please contact me if you have any questions!