### PR TITLE
[Lookup Anything] Add support for multiple lists of checkboxes in CheckboxListField

### DIFF
--- a/LookupAnything/Framework/Fields/CheckboxListField.cs
+++ b/LookupAnything/Framework/Fields/CheckboxListField.cs
@@ -1,9 +1,8 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Pathoschild.Stardew.Common.UI;
+using Pathoschild.Stardew.LookupAnything.Framework.Fields.Models;
 using StardewValley;
 
 namespace Pathoschild.Stardew.LookupAnything.Framework.Fields;
@@ -15,10 +14,7 @@ internal class CheckboxListField : GenericField
     ** Fields
     *********/
     /// <summary>The checkbox values to display.</summary>
-    protected KeyValuePair<IFormattedText[], bool>[] Checkboxes;
-
-    /// <summary>The intro text to show before the checkboxes.</summary>
-    protected IFormattedText[]? Intro;
+    protected CheckboxList CheckboxList;
 
 
     /*********
@@ -26,20 +22,11 @@ internal class CheckboxListField : GenericField
     *********/
     /// <summary>Construct an instance.</summary>
     /// <param name="label">A short field label.</param>
-    /// <param name="checkboxes">The checkbox labels and values to display.</param>
-    public CheckboxListField(string label, IEnumerable<KeyValuePair<IFormattedText[], bool>> checkboxes)
+    /// <param name="checkboxList">The checkbox labels and values to display.</param>
+    public CheckboxListField(string label, CheckboxList checkboxList)
         : this(label)
     {
-        this.Checkboxes = checkboxes.ToArray();
-    }
-
-    /// <summary>Construct an instance.</summary>
-    /// <param name="label">A short field label.</param>
-    /// <param name="checkboxes">The checkbox labels and values to display.</param>
-    public CheckboxListField(string label, params KeyValuePair<IFormattedText[], bool>[] checkboxes)
-        : this(label)
-    {
-        this.Checkboxes = checkboxes;
+        this.CheckboxList = checkboxList;
     }
 
     /// <inheritdoc />
@@ -50,10 +37,10 @@ internal class CheckboxListField : GenericField
         float lineHeight = Math.Max(checkboxSize, Game1.smallFont.MeasureString("ABC").Y);
         float checkboxOffset = (lineHeight - checkboxSize) / 2;
 
-        if (this.Intro != null)
-            topOffset += spriteBatch.DrawTextBlock(font, this.Intro, position, wrapWidth).Y;
+        if (this.CheckboxList.Intro != null)
+            topOffset += spriteBatch.DrawTextBlock(font, this.CheckboxList.Intro, position, wrapWidth).Y;
 
-        foreach ((IFormattedText[] label, bool isChecked) in this.Checkboxes)
+        foreach ((bool isChecked, IFormattedText[] label) in this.CheckboxList.Checkboxes)
         {
             // draw icon
             spriteBatch.Draw(
@@ -78,39 +65,6 @@ internal class CheckboxListField : GenericField
         return new Vector2(wrapWidth, topOffset);
     }
 
-    /// <summary>Add intro text before the checkboxes.</summary>
-    /// <param name="text">The text to show before the checkboxes.</param>
-    public CheckboxListField AddIntro(params IFormattedText[] text)
-    {
-        this.Intro = text;
-        return this;
-    }
-
-    /// <summary>Add intro text before the checkboxes.</summary>
-    /// <param name="text">The text to show before the checkboxes.</param>
-    public CheckboxListField AddIntro(params string[] text)
-    {
-        return this.AddIntro(
-            text.Select(p => (IFormattedText)new FormattedText(p)).ToArray()
-        );
-    }
-
-    /// <summary>Build a checkbox entry.</summary>
-    /// <param name="value">Whether the value is enabled.</param>
-    /// <param name="text">The checkbox text to display.</param>
-    public static KeyValuePair<IFormattedText[], bool> Checkbox(bool value, params IFormattedText[] text)
-    {
-        return new KeyValuePair<IFormattedText[], bool>(text, value);
-    }
-
-    /// <summary>Build a checkbox entry.</summary>
-    /// <param name="value">Whether the value is enabled.</param>
-    /// <param name="text">The checkbox text to display.</param>
-    public static KeyValuePair<IFormattedText[], bool> Checkbox(bool value, string text)
-    {
-        return CheckboxListField.Checkbox(value, new FormattedText(text));
-    }
-
 
     /*********
     ** Protected methods
@@ -120,6 +74,6 @@ internal class CheckboxListField : GenericField
     protected CheckboxListField(string label)
         : base(label, hasValue: true)
     {
-        this.Checkboxes = [];
+        this.CheckboxList = new CheckboxList();
     }
 }

--- a/LookupAnything/Framework/Fields/CheckboxListField.cs
+++ b/LookupAnything/Framework/Fields/CheckboxListField.cs
@@ -7,14 +7,20 @@ using StardewValley;
 
 namespace Pathoschild.Stardew.LookupAnything.Framework.Fields;
 
-/// <summary>A metadata field which shows a list of checkbox values.</summary>
+/// <summary>A metadata field which shows one or more lists of checkbox values.</summary>
 internal class CheckboxListField : GenericField
 {
     /*********
     ** Fields
     *********/
     /// <summary>The checkbox values to display.</summary>
-    protected CheckboxList CheckboxList;
+    protected CheckboxList[] CheckboxLists;
+
+    /// <summary>The size of each checkbox to draw.</summary>
+    protected readonly float CheckboxSize;
+
+    /// <summary>The height of one line of the checkbox list.</summary>
+    protected readonly float LineHeight;
 
 
     /*********
@@ -22,47 +28,24 @@ internal class CheckboxListField : GenericField
     *********/
     /// <summary>Construct an instance.</summary>
     /// <param name="label">A short field label.</param>
-    /// <param name="checkboxList">The checkbox labels and values to display.</param>
-    public CheckboxListField(string label, CheckboxList checkboxList)
+    /// <param name="checkboxLists">The checkbox lists to display.</param>
+    public CheckboxListField(string label, params CheckboxList[] checkboxLists)
         : this(label)
     {
-        this.CheckboxList = checkboxList;
+        this.CheckboxLists = checkboxLists;
     }
 
     /// <inheritdoc />
     public override Vector2? DrawValue(SpriteBatch spriteBatch, SpriteFont font, Vector2 position, float wrapWidth)
     {
         float topOffset = 0;
-        float checkboxSize = CommonSprites.Icons.FilledCheckbox.Width * (Game1.pixelZoom / 2);
-        float lineHeight = Math.Max(checkboxSize, Game1.smallFont.MeasureString("ABC").Y);
-        float checkboxOffset = (lineHeight - checkboxSize) / 2;
 
-        if (this.CheckboxList.Intro != null)
-            topOffset += spriteBatch.DrawTextBlock(font, this.CheckboxList.Intro, position, wrapWidth).Y;
-
-        foreach ((bool isChecked, IFormattedText[] label) in this.CheckboxList.Checkboxes)
+        foreach (CheckboxList checkboxList in this.CheckboxLists)
         {
-            // draw icon
-            spriteBatch.Draw(
-                texture: CommonSprites.Icons.Sheet,
-                position: new Vector2(position.X, position.Y + topOffset + checkboxOffset),
-                sourceRectangle: isChecked ? CommonSprites.Icons.FilledCheckbox : CommonSprites.Icons.EmptyCheckbox,
-                color: Color.White,
-                rotation: 0,
-                origin: Vector2.Zero,
-                scale: checkboxSize / CommonSprites.Icons.FilledCheckbox.Width,
-                effects: SpriteEffects.None,
-                layerDepth: 1f
-            );
-
-            // draw text
-            Vector2 textSize = spriteBatch.DrawTextBlock(Game1.smallFont, label, new Vector2(position.X + checkboxSize + 7, position.Y + topOffset), wrapWidth - checkboxSize - 7);
-
-            // update offset
-            topOffset += Math.Max(checkboxSize, textSize.Y);
+            topOffset += this.DrawCheckboxList(checkboxList, spriteBatch, font, new Vector2(position.X, position.Y + topOffset), wrapWidth).Y;
         }
 
-        return new Vector2(wrapWidth, topOffset);
+        return new Vector2(wrapWidth, topOffset - this.LineHeight);
     }
 
 
@@ -74,6 +57,41 @@ internal class CheckboxListField : GenericField
     protected CheckboxListField(string label)
         : base(label, hasValue: true)
     {
-        this.CheckboxList = new CheckboxList();
+        this.CheckboxLists = [];
+        this.CheckboxSize = CommonSprites.Icons.FilledCheckbox.Width * (Game1.pixelZoom / 2);
+        this.LineHeight = Math.Max(this.CheckboxSize, Game1.smallFont.MeasureString("ABC").Y);
+    }
+
+    protected Vector2 DrawCheckboxList(CheckboxList checkboxList, SpriteBatch spriteBatch, SpriteFont font, Vector2 position, float wrapWidth)
+    {
+        float topOffset = 0;
+        float checkboxOffset = (this.LineHeight - this.CheckboxSize) / 2;
+
+        if (checkboxList.Intro != null)
+            topOffset += spriteBatch.DrawTextBlock(font, checkboxList.Intro, position, wrapWidth).Y;
+
+        foreach (CheckboxList.Checkbox checkbox in checkboxList.Checkboxes)
+        {
+            // draw icon
+            spriteBatch.Draw(
+                texture: CommonSprites.Icons.Sheet,
+                position: new Vector2(position.X, position.Y + topOffset + checkboxOffset),
+                sourceRectangle: checkbox.IsChecked ? CommonSprites.Icons.FilledCheckbox : CommonSprites.Icons.EmptyCheckbox,
+                color: Color.White,
+                rotation: 0,
+                origin: Vector2.Zero,
+                scale: this.CheckboxSize / CommonSprites.Icons.FilledCheckbox.Width,
+                effects: SpriteEffects.None,
+                layerDepth: 1f
+            );
+
+            // draw text
+            Vector2 textSize = spriteBatch.DrawTextBlock(Game1.smallFont, checkbox.Text, new Vector2(position.X + this.CheckboxSize + 7, position.Y + topOffset), wrapWidth - this.CheckboxSize - 7);
+
+            // update offset for next checkbox
+            topOffset += Math.Max(this.CheckboxSize, textSize.Y);
+        }
+
+        return new Vector2(position.X, topOffset + this.LineHeight);
     }
 }

--- a/LookupAnything/Framework/Fields/CheckboxListField.cs
+++ b/LookupAnything/Framework/Fields/CheckboxListField.cs
@@ -68,7 +68,7 @@ internal class CheckboxListField : GenericField
         float checkboxOffset = (this.LineHeight - this.CheckboxSize) / 2;
 
         if (checkboxList.Intro != null)
-            topOffset += spriteBatch.DrawTextBlock(font, checkboxList.Intro, position, wrapWidth).Y;
+            topOffset += this.DrawIconText(spriteBatch, font, new Vector2(position.X, position.Y + topOffset), wrapWidth, checkboxList.Intro.Text, Color.Black, checkboxList.Intro.Icon, new Vector2(this.LineHeight)).Y;
 
         foreach (CheckboxList.Checkbox checkbox in checkboxList.Checkboxes)
         {

--- a/LookupAnything/Framework/Fields/CheckboxListField.cs
+++ b/LookupAnything/Framework/Fields/CheckboxListField.cs
@@ -7,7 +7,7 @@ using StardewValley;
 
 namespace Pathoschild.Stardew.LookupAnything.Framework.Fields;
 
-/// <summary>A metadata field which shows one or more lists of checkbox values.</summary>
+/// <summary>A metadata field which lists checkbox values.</summary>
 internal class CheckboxListField : GenericField
 {
     /*********
@@ -41,9 +41,7 @@ internal class CheckboxListField : GenericField
         float topOffset = 0;
 
         foreach (CheckboxList checkboxList in this.CheckboxLists)
-        {
             topOffset += this.DrawCheckboxList(checkboxList, spriteBatch, font, new Vector2(position.X, position.Y + topOffset), wrapWidth).Y;
-        }
 
         return new Vector2(wrapWidth, topOffset - this.LineHeight);
     }
@@ -62,10 +60,18 @@ internal class CheckboxListField : GenericField
         this.LineHeight = Math.Max(this.CheckboxSize, Game1.smallFont.MeasureString("ABC").Y);
     }
 
+    /// <summary>Draw a checkbox list.</summary>
+    /// <param name="checkboxList">The checkbox list info to render.</param>
+    /// <param name="spriteBatch">The sprite batch being drawn.</param>
+    /// <param name="font">The recommended font.</param>
+    /// <param name="position">The position at which to draw.</param>
+    /// <param name="wrapWidth">The maximum width before which content should be wrapped.</param>
+    /// <returns>Returns the drawn dimensions.</returns>
     protected Vector2 DrawCheckboxList(CheckboxList checkboxList, SpriteBatch spriteBatch, SpriteFont font, Vector2 position, float wrapWidth)
     {
         float topOffset = 0;
-        float checkboxOffset = (this.LineHeight - this.CheckboxSize) / 2;
+        float checkboxSize = this.CheckboxSize;
+        float checkboxOffset = (this.LineHeight - checkboxSize) / 2;
 
         if (checkboxList.Intro != null)
             topOffset += this.DrawIconText(spriteBatch, font, new Vector2(position.X, position.Y + topOffset), wrapWidth, checkboxList.Intro.Text, Color.Black, checkboxList.Intro.Icon, new Vector2(this.LineHeight)).Y;
@@ -80,16 +86,16 @@ internal class CheckboxListField : GenericField
                 color: Color.White,
                 rotation: 0,
                 origin: Vector2.Zero,
-                scale: this.CheckboxSize / CommonSprites.Icons.FilledCheckbox.Width,
+                scale: checkboxSize / CommonSprites.Icons.FilledCheckbox.Width,
                 effects: SpriteEffects.None,
                 layerDepth: 1f
             );
 
             // draw text
-            Vector2 textSize = spriteBatch.DrawTextBlock(Game1.smallFont, checkbox.Text, new Vector2(position.X + this.CheckboxSize + 7, position.Y + topOffset), wrapWidth - this.CheckboxSize - 7);
+            Vector2 textSize = spriteBatch.DrawTextBlock(Game1.smallFont, checkbox.Text, new Vector2(position.X + checkboxSize + 7, position.Y + topOffset), wrapWidth - checkboxSize - 7);
 
             // update offset for next checkbox
-            topOffset += Math.Max(this.CheckboxSize, textSize.Y);
+            topOffset += Math.Max(checkboxSize, textSize.Y);
         }
 
         return new Vector2(position.X, topOffset + this.LineHeight);

--- a/LookupAnything/Framework/Fields/CheckboxListField.cs
+++ b/LookupAnything/Framework/Fields/CheckboxListField.cs
@@ -70,7 +70,7 @@ internal class CheckboxListField : GenericField
         if (checkboxList.Intro != null)
             topOffset += this.DrawIconText(spriteBatch, font, new Vector2(position.X, position.Y + topOffset), wrapWidth, checkboxList.Intro.Text, Color.Black, checkboxList.Intro.Icon, new Vector2(this.LineHeight)).Y;
 
-        foreach (CheckboxList.Checkbox checkbox in checkboxList.Checkboxes)
+        foreach (Checkbox checkbox in checkboxList.Checkboxes)
         {
             // draw icon
             spriteBatch.Draw(

--- a/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
+++ b/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
@@ -30,7 +30,7 @@ internal class FishSpawnRulesField : CheckboxListField
     public FishSpawnRulesField(GameHelper gameHelper, string label, ParsedItemData fish)
         : base(label)
     {
-        this.CheckboxLists = [ new CheckboxList(this.GetConditions(gameHelper, fish)) ];
+        this.CheckboxLists = [new CheckboxList(this.GetConditions(gameHelper, fish))];
         this.HasValue = this.CheckboxLists.Any();
     }
 
@@ -142,7 +142,7 @@ internal class FishSpawnRulesField : CheckboxListField
     /// <param name="isMet">Whether the condition is met.</param>
     private Checkbox GetCondition(string label, bool isMet)
     {
-        return new Checkbox(text: label, isChecked: isMet);
+        return new Checkbox(isMet, label);
     }
 
     /// <summary>Get a condition formatted for checkbox rendering.</summary>
@@ -150,7 +150,7 @@ internal class FishSpawnRulesField : CheckboxListField
     /// <param name="isMet">Whether the condition is met.</param>
     private Checkbox GetCondition(IEnumerable<IFormattedText> label, bool isMet)
     {
-        return new Checkbox(Text: label.ToArray(), IsChecked: isMet);
+        return new Checkbox(isMet, label.ToArray());
     }
 
     /// <summary>Get whether all locations specify the same seasons.</summary>

--- a/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
+++ b/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
@@ -41,7 +41,7 @@ internal class FishSpawnRulesField : CheckboxListField
     /// <summary>Get the formatted checkbox conditions to display.</summary>
     /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
     /// <param name="fish">The fish item data.</param>
-    private IEnumerable<CheckboxList.Checkbox> GetConditions(GameHelper gameHelper, ParsedItemData fish)
+    private IEnumerable<Checkbox> GetConditions(GameHelper gameHelper, ParsedItemData fish)
     {
         // get spawn data
         FishSpawnData spawnRules = gameHelper.GetFishSpawnRules(fish);
@@ -140,17 +140,17 @@ internal class FishSpawnRulesField : CheckboxListField
     /// <summary>Get a condition formatted for checkbox rendering.</summary>
     /// <param name="label">The display text for the condition.</param>
     /// <param name="isMet">Whether the condition is met.</param>
-    private CheckboxList.Checkbox GetCondition(string label, bool isMet)
+    private Checkbox GetCondition(string label, bool isMet)
     {
-        return new CheckboxList.Checkbox(text: label, isChecked: isMet);
+        return new Checkbox(text: label, isChecked: isMet);
     }
 
     /// <summary>Get a condition formatted for checkbox rendering.</summary>
     /// <param name="label">The display text for the condition.</param>
     /// <param name="isMet">Whether the condition is met.</param>
-    private CheckboxList.Checkbox GetCondition(IEnumerable<IFormattedText> label, bool isMet)
+    private Checkbox GetCondition(IEnumerable<IFormattedText> label, bool isMet)
     {
-        return new CheckboxList.Checkbox(Text: label.ToArray(), IsChecked: isMet);
+        return new Checkbox(Text: label.ToArray(), IsChecked: isMet);
     }
 
     /// <summary>Get whether all locations specify the same seasons.</summary>

--- a/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
+++ b/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
@@ -30,8 +30,8 @@ internal class FishSpawnRulesField : CheckboxListField
     public FishSpawnRulesField(GameHelper gameHelper, string label, ParsedItemData fish)
         : base(label)
     {
-        this.CheckboxList = new CheckboxList(this.GetConditions(gameHelper, fish));
-        this.HasValue = this.CheckboxList.Checkboxes.Any();
+        this.CheckboxLists = [ new CheckboxList(this.GetConditions(gameHelper, fish)) ];
+        this.HasValue = this.CheckboxLists.Any();
     }
 
 

--- a/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
+++ b/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
 using Pathoschild.Stardew.Common;
+using Pathoschild.Stardew.LookupAnything.Framework.Fields.Models;
 using Pathoschild.Stardew.LookupAnything.Framework.Models.FishData;
 using StardewValley;
 using StardewValley.ItemTypeDefinitions;
@@ -29,8 +30,8 @@ internal class FishSpawnRulesField : CheckboxListField
     public FishSpawnRulesField(GameHelper gameHelper, string label, ParsedItemData fish)
         : base(label)
     {
-        this.Checkboxes = this.GetConditions(gameHelper, fish).ToArray();
-        this.HasValue = this.Checkboxes.Any();
+        this.CheckboxList = new CheckboxList(this.GetConditions(gameHelper, fish));
+        this.HasValue = this.CheckboxList.Checkboxes.Any();
     }
 
 
@@ -40,7 +41,7 @@ internal class FishSpawnRulesField : CheckboxListField
     /// <summary>Get the formatted checkbox conditions to display.</summary>
     /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
     /// <param name="fish">The fish item data.</param>
-    private IEnumerable<KeyValuePair<IFormattedText[], bool>> GetConditions(GameHelper gameHelper, ParsedItemData fish)
+    private IEnumerable<CheckboxList.Checkbox> GetConditions(GameHelper gameHelper, ParsedItemData fish)
     {
         // get spawn data
         FishSpawnData spawnRules = gameHelper.GetFishSpawnRules(fish);
@@ -139,17 +140,17 @@ internal class FishSpawnRulesField : CheckboxListField
     /// <summary>Get a condition formatted for checkbox rendering.</summary>
     /// <param name="label">The display text for the condition.</param>
     /// <param name="isMet">Whether the condition is met.</param>
-    private KeyValuePair<IFormattedText[], bool> GetCondition(string label, bool isMet)
+    private CheckboxList.Checkbox GetCondition(string label, bool isMet)
     {
-        return CheckboxListField.Checkbox(text: label, value: isMet);
+        return new CheckboxList.Checkbox(text: label, isChecked: isMet);
     }
 
     /// <summary>Get a condition formatted for checkbox rendering.</summary>
     /// <param name="label">The display text for the condition.</param>
     /// <param name="isMet">Whether the condition is met.</param>
-    private KeyValuePair<IFormattedText[], bool> GetCondition(IEnumerable<IFormattedText> label, bool isMet)
+    private CheckboxList.Checkbox GetCondition(IEnumerable<IFormattedText> label, bool isMet)
     {
-        return CheckboxListField.Checkbox(text: label.ToArray(), value: isMet);
+        return new CheckboxList.Checkbox(Text: label.ToArray(), IsChecked: isMet);
     }
 
     /// <summary>Get whether all locations specify the same seasons.</summary>

--- a/LookupAnything/Framework/Fields/GenericField.cs
+++ b/LookupAnything/Framework/Fields/GenericField.cs
@@ -1,11 +1,15 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Pathoschild.Stardew.Common;
 using Pathoschild.Stardew.LookupAnything.Framework.Constants;
 using Pathoschild.Stardew.LookupAnything.Framework.Lookups;
 using Pathoschild.Stardew.LookupAnything.Framework.Models;
+using StardewValley;
+using SObject = StardewValley.Object;
 
 namespace Pathoschild.Stardew.LookupAnything.Framework.Fields;
 
@@ -18,6 +22,8 @@ internal class GenericField : ICustomField
     /// <summary>The clickable areas that should open a new page when clicked.</summary>
     protected readonly List<LinkTextArea> LinkTextAreas = [];
 
+    /// <summary>The number of pixels between an item's icon and text.</summary>
+    protected readonly int IconMargin = 5;
 
     /*********
     ** Accessors
@@ -180,5 +186,59 @@ internal class GenericField : ICustomField
                 break;
         }
         return I18n.List(priceStrings);
+    }
+
+    /// <summary>Draw text with an icon.</summary>
+    /// <param name="batch">The sprite batch.</param>
+    /// <param name="font">The sprite font.</param>
+    /// <param name="position">The position at which to draw the text.</param>
+    /// <param name="absoluteWrapWidth">The width at which to wrap the text.</param>
+    /// <param name="text">The block of text to write.</param>
+    /// <param name="textColor">The text color.</param>
+    /// <param name="icon">The sprite to draw.</param>
+    /// <param name="iconSize">The size to draw.</param>
+    /// <param name="iconColor">The color to tint the sprite.</param>
+    /// <param name="qualityIcon">The quality for which to draw an icon over the sprite.</param>
+    /// <param name="probe">Whether to calculate the positions without actually drawing anything to the screen.</param>
+    /// <returns>Returns the drawn size.</returns>
+    protected Vector2 DrawIconText(SpriteBatch batch, SpriteFont font, Vector2 position, float absoluteWrapWidth, string text, Color textColor, SpriteInfo? icon = null, Vector2? iconSize = null, Color? iconColor = null, int? qualityIcon = null, bool probe = false)
+    {
+        // draw icon
+        int textOffset = 0;
+        if (icon != null && iconSize.HasValue)
+        {
+            if (!probe)
+                batch.DrawSpriteWithin(icon, position.X, position.Y, iconSize.Value, iconColor);
+            textOffset = this.IconMargin;
+        }
+        else
+            iconSize = Vector2.Zero;
+
+        // draw quality icon overlay
+        if (qualityIcon > 0 && iconSize is { X: > 0, Y: > 0 })
+        {
+            Rectangle qualityRect = qualityIcon < SObject.bestQuality ? new(338 + (qualityIcon.Value - 1) * 8, 400, 8, 8) : new(346, 392, 8, 8); // from Item.DrawMenuIcons
+            Texture2D qualitySprite = Game1.mouseCursors;
+
+            Vector2 qualitySize = iconSize.Value / 2;
+            Vector2 qualityPos = new Vector2(
+                position.X + iconSize.Value.X - qualitySize.X,
+                position.Y + iconSize.Value.Y - qualitySize.Y
+            );
+
+            batch.DrawSpriteWithin(qualitySprite, qualityRect, qualityPos.X, qualityPos.Y, qualitySize, iconColor);
+        }
+
+
+        // draw text
+        Vector2 textSize = probe
+            ? font.MeasureString(text)
+            : batch.DrawTextBlock(font, text, position + new Vector2(iconSize.Value.X + textOffset, 0), absoluteWrapWidth - position.X, textColor);
+
+        // get drawn size
+        return new Vector2(
+            x: iconSize.Value.X + textSize.X,
+            y: Math.Max(iconSize.Value.Y, textSize.Y)
+        );
     }
 }

--- a/LookupAnything/Framework/Fields/GenericField.cs
+++ b/LookupAnything/Framework/Fields/GenericField.cs
@@ -25,6 +25,7 @@ internal class GenericField : ICustomField
     /// <summary>The number of pixels between an item's icon and text.</summary>
     protected readonly int IconMargin = 5;
 
+
     /*********
     ** Accessors
     *********/
@@ -228,7 +229,6 @@ internal class GenericField : ICustomField
 
             batch.DrawSpriteWithin(qualitySprite, qualityRect, qualityPos.X, qualityPos.Y, qualitySize, iconColor);
         }
-
 
         // draw text
         Vector2 textSize = probe

--- a/LookupAnything/Framework/Fields/ItemRecipesField.cs
+++ b/LookupAnything/Framework/Fields/ItemRecipesField.cs
@@ -40,9 +40,6 @@ internal class ItemRecipesField : GenericField
     /// <summary>Whether to show the output item for recipes.</summary>
     private readonly bool ShowOutputLabels;
 
-    /// <summary>The number of pixels between an item's icon and text.</summary>
-    private readonly int IconMargin = 5;
-
     /// <summary>The height of a recipe line.</summary>
     private readonly float LineHeight = Game1.smallFont.MeasureString("ABC").Y;
 
@@ -468,60 +465,6 @@ internal class ItemRecipesField : GenericField
             return null;
 
         return this.Codex.GetByEntity(entity, null);
-    }
-
-    /// <summary>Draw text with an icon.</summary>
-    /// <param name="batch">The sprite batch.</param>
-    /// <param name="font">The sprite font.</param>
-    /// <param name="position">The position at which to draw the text.</param>
-    /// <param name="absoluteWrapWidth">The width at which to wrap the text.</param>
-    /// <param name="text">The block of text to write.</param>
-    /// <param name="textColor">The text color.</param>
-    /// <param name="icon">The sprite to draw.</param>
-    /// <param name="iconSize">The size to draw.</param>
-    /// <param name="iconColor">The color to tint the sprite.</param>
-    /// <param name="qualityIcon">The quality for which to draw an icon over the sprite.</param>
-    /// <param name="probe">Whether to calculate the positions without actually drawing anything to the screen.</param>
-    /// <returns>Returns the drawn size.</returns>
-    private Vector2 DrawIconText(SpriteBatch batch, SpriteFont font, Vector2 position, float absoluteWrapWidth, string text, Color textColor, SpriteInfo? icon = null, Vector2? iconSize = null, Color? iconColor = null, int? qualityIcon = null, bool probe = false)
-    {
-        // draw icon
-        int textOffset = 0;
-        if (icon != null && iconSize.HasValue)
-        {
-            if (!probe)
-                batch.DrawSpriteWithin(icon, position.X, position.Y, iconSize.Value, iconColor);
-            textOffset = this.IconMargin;
-        }
-        else
-            iconSize = Vector2.Zero;
-
-        // draw quality icon overlay
-        if (qualityIcon > 0 && iconSize is { X: > 0, Y: > 0 })
-        {
-            Rectangle qualityRect = qualityIcon < SObject.bestQuality ? new(338 + (qualityIcon.Value - 1) * 8, 400, 8, 8) : new(346, 392, 8, 8); // from Item.DrawMenuIcons
-            Texture2D qualitySprite = Game1.mouseCursors;
-
-            Vector2 qualitySize = iconSize.Value / 2;
-            Vector2 qualityPos = new Vector2(
-                position.X + iconSize.Value.X - qualitySize.X,
-                position.Y + iconSize.Value.Y - qualitySize.Y
-            );
-
-            batch.DrawSpriteWithin(qualitySprite, qualityRect, qualityPos.X, qualityPos.Y, qualitySize, iconColor);
-        }
-
-
-        // draw text
-        Vector2 textSize = probe
-            ? font.MeasureString(text)
-            : batch.DrawTextBlock(font, text, position + new Vector2(iconSize.Value.X + textOffset, 0), absoluteWrapWidth - position.X, textColor);
-
-        // get drawn size
-        return new Vector2(
-            x: iconSize.Value.X + textSize.X,
-            y: Math.Max(iconSize.Value.Y, textSize.Y)
-        );
     }
 
     /// <summary>Create a recipe item model.</summary>

--- a/LookupAnything/Framework/Fields/Models/Checkbox.cs
+++ b/LookupAnything/Framework/Fields/Models/Checkbox.cs
@@ -1,0 +1,13 @@
+namespace Pathoschild.Stardew.LookupAnything.Framework.Fields.Models;
+
+/// <summary>A checkbox with a label.</summary>
+/// <param name="IsChecked">Whether the checkbox is checked.</param>
+/// <param name="Text">The text to display next to the checkbox.</param>
+internal record Checkbox(bool IsChecked, params IFormattedText[] Text)
+{
+    /// <summary>Construct an instance.</summary>
+    /// <param name="isChecked">Whether the checkbox is checked.</param>
+    /// <param name="text">The text to display next to the checkbox.</param>
+    public Checkbox(bool isChecked, string text)
+        : this(isChecked, new FormattedText(text)) { }
+}

--- a/LookupAnything/Framework/Fields/Models/CheckboxList.cs
+++ b/LookupAnything/Framework/Fields/Models/CheckboxList.cs
@@ -4,25 +4,28 @@ using Pathoschild.Stardew.Common;
 
 namespace Pathoschild.Stardew.LookupAnything.Framework.Fields.Models;
 
-/// <summary>A list of checkboxes with labels. The list may optionally contain intro text.</summary>
-/// <param name="checkboxes">The checkbox values to display.</param>
-internal class CheckboxList(Checkbox[] checkboxes)
+/// <summary>A list of checkboxes with labels and an optional intro line.</summary>
+internal class CheckboxList
 {
     /*********
-    ** Fields
+    ** Accessors
     *********/
     /// <summary>The checkbox values to display.</summary>
-    public Checkbox[] Checkboxes = checkboxes;
+    public Checkbox[] Checkboxes;
 
     /// <summary>The intro text and icon to show before the checkboxes.</summary>
     public IntroData? Intro;
 
+
     /*********
     ** Public methods
     *********/
-    /// <summary>Construct an instance.</summary>
-    public CheckboxList()
-        : this([]) { }
+    /// <summary>A list of checkboxes with labels and an optional intro line.</summary>
+    /// <param name="checkboxes">The checkbox values to display.</param>
+    public CheckboxList(params Checkbox[] checkboxes)
+    {
+        this.Checkboxes = checkboxes;
+    }
 
     /// <summary>Construct an instance.</summary>
     /// <param name="checkboxes">The checkbox values to display.</param>
@@ -30,15 +33,16 @@ internal class CheckboxList(Checkbox[] checkboxes)
         : this(checkboxes.ToArray()) { }
 
     /// <summary>Add intro text before the checkboxes.</summary>
-    /// <param name="text">The text to show before the checkboxes.</param>
+    /// <param name="text">The text to render before the checkbox list.</param>
+    /// <param name="icon">The icon to render before the <paramref name="text"/>, if any.</param>
     public CheckboxList AddIntro(string text, SpriteInfo? icon = null)
     {
-        this.Intro = new(text, icon);
+        this.Intro = new IntroData(text, icon);
         return this;
     }
 
-    /// <summary>The text and icon to display above a checkbox list.</summary>
-    /// <param name="Text">The text to display above the checkbox list.</param>
-    /// <param name="Icon">The icon to display above the checkbox list.</param>
+    /// <summary>The text and icon to render above a checkbox list.</summary>
+    /// <param name="Text">The text to render above the checkbox list.</param>
+    /// <param name="Icon">The icon to render before the <see cref="Icon"/>, if any.</param>
     internal record IntroData(string Text, SpriteInfo? Icon);
 }

--- a/LookupAnything/Framework/Fields/Models/CheckboxList.cs
+++ b/LookupAnything/Framework/Fields/Models/CheckboxList.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Pathoschild.Stardew.LookupAnything.Framework.Fields.Models;
+
+/// <summary>A list of checkboxes with labels. The list may optionally contain intro text.</summary>
+/// <param name="checkboxes">The checkbox values to display.</param>
+internal class CheckboxList(CheckboxList.Checkbox[] checkboxes)
+{
+    /*********
+    ** Fields
+    *********/
+    /// <summary>The checkbox values to display.</summary>
+    public Checkbox[] Checkboxes = checkboxes;
+
+    /// <summary>The intro text to show before the checkboxes.</summary>
+    public IFormattedText[]? Intro;
+
+    /*********
+    ** Public methods
+    *********/
+    /// <summary>Construct an instance.</summary>
+    public CheckboxList() : this([])
+    {
+    }
+
+    /// <summary>Construct an instance.</summary>
+    /// <param name="checkboxes">The checkbox values to display.</param>
+    public CheckboxList(IEnumerable<Checkbox> checkboxes) : this(checkboxes.ToArray())
+    {
+    }
+
+    /// <summary>Add intro text before the checkboxes.</summary>
+    /// <param name="text">The text to show before the checkboxes.</param>
+    public CheckboxList AddIntro(params IFormattedText[] text)
+    {
+        this.Intro = text;
+        return this;
+    }
+
+    /// <summary>Add intro text before the checkboxes.</summary>
+    /// <param name="text">The text to show before the checkboxes.</param>
+    public CheckboxList AddIntro(params string[] text)
+    {
+        return this.AddIntro(
+            text.Select(p => (IFormattedText)new FormattedText(p)).ToArray()
+        );
+    }
+
+    /// <summary>A checkbox with a label.</summary>
+    /// <param name="IsChecked">Whether the checkbox is checked.</param>
+    /// <param name="Text">The text to display next to the checkbox.</param>
+    internal record Checkbox(bool IsChecked, params IFormattedText[] Text)
+    {
+        /// <summary>Construct an instance.</summary>
+        /// <param name="isChecked">Whether the checkbox is checked.</param>
+        /// <param name="text">The text to display next to the checkbox.</param>
+        public Checkbox(bool isChecked, string text) : this(isChecked, new FormattedText(text))
+        {
+        }
+    }
+}

--- a/LookupAnything/Framework/Fields/Models/CheckboxList.cs
+++ b/LookupAnything/Framework/Fields/Models/CheckboxList.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Pathoschild.Stardew.Common;
 
 namespace Pathoschild.Stardew.LookupAnything.Framework.Fields.Models;
 
@@ -13,8 +14,8 @@ internal class CheckboxList(CheckboxList.Checkbox[] checkboxes)
     /// <summary>The checkbox values to display.</summary>
     public Checkbox[] Checkboxes = checkboxes;
 
-    /// <summary>The intro text to show before the checkboxes.</summary>
-    public IFormattedText[]? Intro;
+    /// <summary>The intro text and icon to show before the checkboxes.</summary>
+    public IntroData? Intro;
 
     /*********
     ** Public methods
@@ -32,19 +33,10 @@ internal class CheckboxList(CheckboxList.Checkbox[] checkboxes)
 
     /// <summary>Add intro text before the checkboxes.</summary>
     /// <param name="text">The text to show before the checkboxes.</param>
-    public CheckboxList AddIntro(params IFormattedText[] text)
+    public CheckboxList AddIntro(string text, SpriteInfo? icon = null)
     {
-        this.Intro = text;
+        this.Intro = new(text, icon);
         return this;
-    }
-
-    /// <summary>Add intro text before the checkboxes.</summary>
-    /// <param name="text">The text to show before the checkboxes.</param>
-    public CheckboxList AddIntro(params string[] text)
-    {
-        return this.AddIntro(
-            text.Select(p => (IFormattedText)new FormattedText(p)).ToArray()
-        );
     }
 
     /// <summary>A checkbox with a label.</summary>
@@ -59,4 +51,9 @@ internal class CheckboxList(CheckboxList.Checkbox[] checkboxes)
         {
         }
     }
+
+    /// <summary>The text and icon to display above a checkbox list.</summary>
+    /// <param name="Text">The text to display above the checkbox list.</param>
+    /// <param name="Icon">The icon to display above the checkbox list.</param>
+    internal record IntroData(string Text, SpriteInfo? Icon);
 }

--- a/LookupAnything/Framework/Fields/Models/CheckboxList.cs
+++ b/LookupAnything/Framework/Fields/Models/CheckboxList.cs
@@ -6,7 +6,7 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Fields.Models;
 
 /// <summary>A list of checkboxes with labels. The list may optionally contain intro text.</summary>
 /// <param name="checkboxes">The checkbox values to display.</param>
-internal class CheckboxList(CheckboxList.Checkbox[] checkboxes)
+internal class CheckboxList(Checkbox[] checkboxes)
 {
     /*********
     ** Fields
@@ -21,15 +21,13 @@ internal class CheckboxList(CheckboxList.Checkbox[] checkboxes)
     ** Public methods
     *********/
     /// <summary>Construct an instance.</summary>
-    public CheckboxList() : this([])
-    {
-    }
+    public CheckboxList()
+        : this([]) { }
 
     /// <summary>Construct an instance.</summary>
     /// <param name="checkboxes">The checkbox values to display.</param>
-    public CheckboxList(IEnumerable<Checkbox> checkboxes) : this(checkboxes.ToArray())
-    {
-    }
+    public CheckboxList(IEnumerable<Checkbox> checkboxes)
+        : this(checkboxes.ToArray()) { }
 
     /// <summary>Add intro text before the checkboxes.</summary>
     /// <param name="text">The text to show before the checkboxes.</param>
@@ -37,19 +35,6 @@ internal class CheckboxList(CheckboxList.Checkbox[] checkboxes)
     {
         this.Intro = new(text, icon);
         return this;
-    }
-
-    /// <summary>A checkbox with a label.</summary>
-    /// <param name="IsChecked">Whether the checkbox is checked.</param>
-    /// <param name="Text">The text to display next to the checkbox.</param>
-    internal record Checkbox(bool IsChecked, params IFormattedText[] Text)
-    {
-        /// <summary>Construct an instance.</summary>
-        /// <param name="isChecked">Whether the checkbox is checked.</param>
-        /// <param name="text">The text to display next to the checkbox.</param>
-        public Checkbox(bool isChecked, string text) : this(isChecked, new FormattedText(text))
-        {
-        }
     }
 
     /// <summary>The text and icon to display above a checkbox list.</summary>

--- a/LookupAnything/Framework/Lookups/Buildings/BuildingSubject.cs
+++ b/LookupAnything/Framework/Lookups/Buildings/BuildingSubject.cs
@@ -361,39 +361,39 @@ internal class BuildingSubject : BaseSubject
     /// <summary>Get the upgrade levels for a building, for use with a checkbox field.</summary>
     /// <param name="building">The building to check.</param>
     /// <param name="upgradeLevel">The current upgrade level, if applicable.</param>
-    private IEnumerable<CheckboxList.Checkbox> GetUpgradeLevelSummary(Building building, int? upgradeLevel)
+    private IEnumerable<Checkbox> GetUpgradeLevelSummary(Building building, int? upgradeLevel)
     {
         // TODO: animal buildings were de-hardcoded in Stardew Valley 1.6, so we should generate this info from Data/Buildings instead.
 
         // barn
         if (this.IsBarn(building))
         {
-            yield return new CheckboxList.Checkbox(text: I18n.Building_Upgrades_Barn_0(), isChecked: true);
-            yield return new CheckboxList.Checkbox(text: I18n.Building_Upgrades_Barn_1(), isChecked: upgradeLevel >= 1);
-            yield return new CheckboxList.Checkbox(text: I18n.Building_Upgrades_Barn_2(), isChecked: upgradeLevel >= 2);
+            yield return new Checkbox(text: I18n.Building_Upgrades_Barn_0(), isChecked: true);
+            yield return new Checkbox(text: I18n.Building_Upgrades_Barn_1(), isChecked: upgradeLevel >= 1);
+            yield return new Checkbox(text: I18n.Building_Upgrades_Barn_2(), isChecked: upgradeLevel >= 2);
         }
 
         // cabin
         else if (building.GetIndoors() is Cabin)
         {
-            yield return new CheckboxList.Checkbox(text: I18n.Building_Upgrades_Cabin_0(), isChecked: true);
-            yield return new CheckboxList.Checkbox(text: I18n.Building_Upgrades_Cabin_1(), isChecked: upgradeLevel >= 1);
-            yield return new CheckboxList.Checkbox(text: I18n.Building_Upgrades_Cabin_2(), isChecked: upgradeLevel >= 2);
+            yield return new Checkbox(text: I18n.Building_Upgrades_Cabin_0(), isChecked: true);
+            yield return new Checkbox(text: I18n.Building_Upgrades_Cabin_1(), isChecked: upgradeLevel >= 1);
+            yield return new Checkbox(text: I18n.Building_Upgrades_Cabin_2(), isChecked: upgradeLevel >= 2);
         }
 
         // coop
         else if (this.IsCoop(building))
         {
-            yield return new CheckboxList.Checkbox(text: I18n.Building_Upgrades_Coop_0(), isChecked: true);
-            yield return new CheckboxList.Checkbox(text: I18n.Building_Upgrades_Coop_1(), isChecked: upgradeLevel >= 1);
-            yield return new CheckboxList.Checkbox(text: I18n.Building_Upgrades_Coop_2(), isChecked: upgradeLevel >= 2);
+            yield return new Checkbox(text: I18n.Building_Upgrades_Coop_0(), isChecked: true);
+            yield return new Checkbox(text: I18n.Building_Upgrades_Coop_1(), isChecked: upgradeLevel >= 1);
+            yield return new Checkbox(text: I18n.Building_Upgrades_Coop_2(), isChecked: upgradeLevel >= 2);
         }
     }
 
     /// <summary>Get a fish pond's population gates for display.</summary>
     /// <param name="pond">The fish pond.</param>
     /// <param name="data">The fish pond data.</param>
-    private IEnumerable<CheckboxList.Checkbox> GetPopulationGates(FishPond pond, FishPondData data)
+    private IEnumerable<Checkbox> GetPopulationGates(FishPond pond, FishPondData data)
     {
         bool foundNextQuest = false;
         foreach (FishPondPopulationGateData gate in this.GameHelper.GetFishPondPopulationGates(data))
@@ -403,7 +403,7 @@ internal class BuildingSubject : BaseSubject
             // done
             if (pond.lastUnlockedPopulationGate.Value >= gate.RequiredPopulation)
             {
-                yield return new CheckboxList.Checkbox(text: I18n.Building_FishPond_Quests_Done(count: newPopulation), isChecked: true);
+                yield return new Checkbox(text: I18n.Building_FishPond_Quests_Done(count: newPopulation), isChecked: true);
                 continue;
             }
 
@@ -438,7 +438,7 @@ internal class BuildingSubject : BaseSubject
                     - pond.daysSinceSpawn.Value;
                 result += $"; {I18n.Building_FishPond_Quests_Available(relativeDate: this.GetRelativeDateStr(nextQuestDays))}";
             }
-            yield return new CheckboxList.Checkbox(text: result, isChecked: false);
+            yield return new Checkbox(text: result, isChecked: false);
         }
     }
 }

--- a/LookupAnything/Framework/Lookups/Buildings/BuildingSubject.cs
+++ b/LookupAnything/Framework/Lookups/Buildings/BuildingSubject.cs
@@ -7,6 +7,7 @@ using Pathoschild.Stardew.Common;
 using Pathoschild.Stardew.LookupAnything.Framework.Data;
 using Pathoschild.Stardew.LookupAnything.Framework.DebugFields;
 using Pathoschild.Stardew.LookupAnything.Framework.Fields;
+using Pathoschild.Stardew.LookupAnything.Framework.Fields.Models;
 using Pathoschild.Stardew.LookupAnything.Framework.Models;
 using StardewModdingAPI;
 using StardewModdingAPI.Utilities;
@@ -145,7 +146,7 @@ internal class BuildingSubject : BaseSubject
         {
             var upgradeLevelSummary = this.GetUpgradeLevelSummary(building, upgradeLevel).ToArray();
             if (upgradeLevelSummary.Any())
-                yield return new CheckboxListField(I18n.Building_Upgrades(), upgradeLevelSummary);
+                yield return new CheckboxListField(I18n.Building_Upgrades(), new CheckboxList(upgradeLevelSummary));
         }
 
         // specific buildings
@@ -185,7 +186,7 @@ internal class BuildingSubject : BaseSubject
 
                         // quests
                         if (pondData.PopulationGates?.Any(gate => gate.Key > pond.lastUnlockedPopulationGate.Value) == true)
-                            yield return new CheckboxListField(I18n.Building_FishPond_Quests(), this.GetPopulationGates(pond, pondData));
+                            yield return new CheckboxListField(I18n.Building_FishPond_Quests(), new CheckboxList(this.GetPopulationGates(pond, pondData)));
                     }
                     break;
 
@@ -360,39 +361,39 @@ internal class BuildingSubject : BaseSubject
     /// <summary>Get the upgrade levels for a building, for use with a checkbox field.</summary>
     /// <param name="building">The building to check.</param>
     /// <param name="upgradeLevel">The current upgrade level, if applicable.</param>
-    private IEnumerable<KeyValuePair<IFormattedText[], bool>> GetUpgradeLevelSummary(Building building, int? upgradeLevel)
+    private IEnumerable<CheckboxList.Checkbox> GetUpgradeLevelSummary(Building building, int? upgradeLevel)
     {
         // TODO: animal buildings were de-hardcoded in Stardew Valley 1.6, so we should generate this info from Data/Buildings instead.
 
         // barn
         if (this.IsBarn(building))
         {
-            yield return CheckboxListField.Checkbox(text: I18n.Building_Upgrades_Barn_0(), value: true);
-            yield return CheckboxListField.Checkbox(text: I18n.Building_Upgrades_Barn_1(), value: upgradeLevel >= 1);
-            yield return CheckboxListField.Checkbox(text: I18n.Building_Upgrades_Barn_2(), value: upgradeLevel >= 2);
+            yield return new CheckboxList.Checkbox(text: I18n.Building_Upgrades_Barn_0(), isChecked: true);
+            yield return new CheckboxList.Checkbox(text: I18n.Building_Upgrades_Barn_1(), isChecked: upgradeLevel >= 1);
+            yield return new CheckboxList.Checkbox(text: I18n.Building_Upgrades_Barn_2(), isChecked: upgradeLevel >= 2);
         }
 
         // cabin
         else if (building.GetIndoors() is Cabin)
         {
-            yield return CheckboxListField.Checkbox(text: I18n.Building_Upgrades_Cabin_0(), value: true);
-            yield return CheckboxListField.Checkbox(text: I18n.Building_Upgrades_Cabin_1(), value: upgradeLevel >= 1);
-            yield return CheckboxListField.Checkbox(text: I18n.Building_Upgrades_Cabin_2(), value: upgradeLevel >= 2);
+            yield return new CheckboxList.Checkbox(text: I18n.Building_Upgrades_Cabin_0(), isChecked: true);
+            yield return new CheckboxList.Checkbox(text: I18n.Building_Upgrades_Cabin_1(), isChecked: upgradeLevel >= 1);
+            yield return new CheckboxList.Checkbox(text: I18n.Building_Upgrades_Cabin_2(), isChecked: upgradeLevel >= 2);
         }
 
         // coop
         else if (this.IsCoop(building))
         {
-            yield return CheckboxListField.Checkbox(text: I18n.Building_Upgrades_Coop_0(), value: true);
-            yield return CheckboxListField.Checkbox(text: I18n.Building_Upgrades_Coop_1(), value: upgradeLevel >= 1);
-            yield return CheckboxListField.Checkbox(text: I18n.Building_Upgrades_Coop_2(), value: upgradeLevel >= 2);
+            yield return new CheckboxList.Checkbox(text: I18n.Building_Upgrades_Coop_0(), isChecked: true);
+            yield return new CheckboxList.Checkbox(text: I18n.Building_Upgrades_Coop_1(), isChecked: upgradeLevel >= 1);
+            yield return new CheckboxList.Checkbox(text: I18n.Building_Upgrades_Coop_2(), isChecked: upgradeLevel >= 2);
         }
     }
 
     /// <summary>Get a fish pond's population gates for display.</summary>
     /// <param name="pond">The fish pond.</param>
     /// <param name="data">The fish pond data.</param>
-    private IEnumerable<KeyValuePair<IFormattedText[], bool>> GetPopulationGates(FishPond pond, FishPondData data)
+    private IEnumerable<CheckboxList.Checkbox> GetPopulationGates(FishPond pond, FishPondData data)
     {
         bool foundNextQuest = false;
         foreach (FishPondPopulationGateData gate in this.GameHelper.GetFishPondPopulationGates(data))
@@ -402,7 +403,7 @@ internal class BuildingSubject : BaseSubject
             // done
             if (pond.lastUnlockedPopulationGate.Value >= gate.RequiredPopulation)
             {
-                yield return CheckboxListField.Checkbox(text: I18n.Building_FishPond_Quests_Done(count: newPopulation), value: true);
+                yield return new CheckboxList.Checkbox(text: I18n.Building_FishPond_Quests_Done(count: newPopulation), isChecked: true);
                 continue;
             }
 
@@ -437,7 +438,7 @@ internal class BuildingSubject : BaseSubject
                     - pond.daysSinceSpawn.Value;
                 result += $"; {I18n.Building_FishPond_Quests_Available(relativeDate: this.GetRelativeDateStr(nextQuestDays))}";
             }
-            yield return CheckboxListField.Checkbox(text: result, value: false);
+            yield return new CheckboxList.Checkbox(text: result, isChecked: false);
         }
     }
 }

--- a/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
+++ b/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
@@ -251,14 +251,14 @@ internal class CharacterSubject : BaseSubject
         // show items wanted
         if (questsDone <= maxQuests)
         {
-            var checkboxes = new List<CheckboxList.Checkbox>();
+            var checkboxes = new List<Checkbox>();
             for (int i = 0; i < maxQuests; i++)
             {
                 string wantedKey = cave.IndexForRequest(i);
                 if (!CommonHelper.IsItemId(wantedKey))
                     continue;
 
-                checkboxes.Add(new CheckboxList.Checkbox(text: ItemRegistry.GetDataOrErrorItem(wantedKey).DisplayName, isChecked: questsDone > i));
+                checkboxes.Add(new Checkbox(text: ItemRegistry.GetDataOrErrorItem(wantedKey).DisplayName, isChecked: questsDone > i));
             }
 
             if (checkboxes.Any())
@@ -292,7 +292,7 @@ internal class CharacterSubject : BaseSubject
 
             int kills = questData.Targets.Sum(Game1.stats.getMonstersKilled);
             string goalName = TokenParser.ParseText(questData.DisplayName);
-            var checkbox = new CheckboxList.Checkbox(
+            var checkbox = new Checkbox(
                 text: I18n.Monster_AdventureGuild_EradicationGoal(name: goalName, count: kills, requiredCount: questData.Count),
                 isChecked: kills >= questData.Count
             );

--- a/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
+++ b/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
@@ -8,6 +8,7 @@ using Pathoschild.Stardew.LookupAnything.Framework.Constants;
 using Pathoschild.Stardew.LookupAnything.Framework.Data;
 using Pathoschild.Stardew.LookupAnything.Framework.DebugFields;
 using Pathoschild.Stardew.LookupAnything.Framework.Fields;
+using Pathoschild.Stardew.LookupAnything.Framework.Fields.Models;
 using Pathoschild.Stardew.LookupAnything.Framework.Models;
 using StardewModdingAPI;
 using StardewModdingAPI.Utilities;
@@ -250,23 +251,18 @@ internal class CharacterSubject : BaseSubject
         // show items wanted
         if (questsDone <= maxQuests)
         {
-            var checkboxes = new List<KeyValuePair<IFormattedText[], bool>>();
+            var checkboxes = new List<CheckboxList.Checkbox>();
             for (int i = 0; i < maxQuests; i++)
             {
                 string wantedKey = cave.IndexForRequest(i);
                 if (!CommonHelper.IsItemId(wantedKey))
                     continue;
 
-                checkboxes.Add(
-                    CheckboxListField.Checkbox(
-                        text: ItemRegistry.GetDataOrErrorItem(wantedKey).DisplayName,
-                        value: questsDone > i
-                    )
-                );
+                checkboxes.Add(new CheckboxList.Checkbox(text: ItemRegistry.GetDataOrErrorItem(wantedKey).DisplayName, isChecked: questsDone > i));
             }
 
             if (checkboxes.Any())
-                yield return new CheckboxListField(I18n.TrashBearOrGourmand_ItemWanted(), checkboxes);
+                yield return new CheckboxListField(I18n.TrashBearOrGourmand_ItemWanted(), new CheckboxList(checkboxes));
         }
 
         // show progress
@@ -296,11 +292,11 @@ internal class CharacterSubject : BaseSubject
 
             int kills = questData.Targets.Sum(Game1.stats.getMonstersKilled);
             string goalName = TokenParser.ParseText(questData.DisplayName);
-            var checkbox = CheckboxListField.Checkbox(
+            var checkbox = new CheckboxList.Checkbox(
                 text: I18n.Monster_AdventureGuild_EradicationGoal(name: goalName, count: kills, requiredCount: questData.Count),
-                value: kills >= questData.Count
+                isChecked: kills >= questData.Count
             );
-            yield return new CheckboxListField(I18n.Monster_AdventureGuild(), checkbox);
+            yield return new CheckboxListField(I18n.Monster_AdventureGuild(), new CheckboxList([checkbox]));
         }
     }
 

--- a/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
+++ b/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
@@ -258,7 +258,10 @@ internal class CharacterSubject : BaseSubject
                 if (!CommonHelper.IsItemId(wantedKey))
                     continue;
 
-                checkboxes.Add(new Checkbox(text: ItemRegistry.GetDataOrErrorItem(wantedKey).DisplayName, isChecked: questsDone > i));
+                checkboxes.Add(new Checkbox(
+                    text: ItemRegistry.GetDataOrErrorItem(wantedKey).DisplayName,
+                    isChecked: questsDone > i
+                ));
             }
 
             if (checkboxes.Any())
@@ -296,7 +299,7 @@ internal class CharacterSubject : BaseSubject
                 text: I18n.Monster_AdventureGuild_EradicationGoal(name: goalName, count: kills, requiredCount: questData.Count),
                 isChecked: kills >= questData.Count
             );
-            yield return new CheckboxListField(I18n.Monster_AdventureGuild(), new CheckboxList([checkbox]));
+            yield return new CheckboxListField(I18n.Monster_AdventureGuild(), new CheckboxList(checkbox));
         }
     }
 

--- a/LookupAnything/Framework/Lookups/Tiles/CrystalCavePuzzleSubject.cs
+++ b/LookupAnything/Framework/Lookups/Tiles/CrystalCavePuzzleSubject.cs
@@ -68,7 +68,7 @@ internal class CrystalCavePuzzleSubject : TileSubject
                     var checkboxes = cave
                         .currentCrystalSequence
                         .Select((id, index) =>
-                            new CheckboxList.Checkbox(
+                            new Checkbox(
                                 text: this.Stringify(id + 1),
                                 isChecked: cave.currentCrystalSequenceIndex.Value > index
                             )

--- a/LookupAnything/Framework/Lookups/Tiles/CrystalCavePuzzleSubject.cs
+++ b/LookupAnything/Framework/Lookups/Tiles/CrystalCavePuzzleSubject.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
 using Pathoschild.Stardew.LookupAnything.Framework.Fields;
+using Pathoschild.Stardew.LookupAnything.Framework.Fields.Models;
 using StardewValley;
 using StardewValley.Locations;
 
@@ -67,15 +68,17 @@ internal class CrystalCavePuzzleSubject : TileSubject
                     var checkboxes = cave
                         .currentCrystalSequence
                         .Select((id, index) =>
-                            CheckboxListField.Checkbox(
+                            new CheckboxList.Checkbox(
                                 text: this.Stringify(id + 1),
-                                value: cave.currentCrystalSequenceIndex.Value > index
+                                isChecked: cave.currentCrystalSequenceIndex.Value > index
                             )
                         )
                         .ToArray();
 
-                    yield return new CheckboxListField(label, checkboxes)
-                        .AddIntro(I18n.Puzzle_IslandCrystalCave_Solution_Activated());
+                    CheckboxList checkboxList = new(checkboxes);
+                    checkboxList.AddIntro(I18n.Puzzle_IslandCrystalCave_Solution_Activated());
+
+                    yield return new CheckboxListField(label, checkboxList);
                 }
             }
         }

--- a/LookupAnything/Framework/Lookups/Tiles/IslandMermaidPuzzleSubject.cs
+++ b/LookupAnything/Framework/Lookups/Tiles/IslandMermaidPuzzleSubject.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
 using Pathoschild.Stardew.LookupAnything.Framework.Fields;
+using Pathoschild.Stardew.LookupAnything.Framework.Fields.Models;
 using StardewValley;
 using StardewValley.Locations;
 
@@ -51,11 +52,13 @@ internal class IslandMermaidPuzzleSubject : TileSubject
                 int songIndex = location.songIndex;
 
                 var checkboxes = sequence
-                    .Select((pitch, i) => CheckboxListField.Checkbox(text: this.Stringify(pitch), value: complete || songIndex >= i))
+                    .Select((pitch, i) => new CheckboxList.Checkbox(text: this.Stringify(pitch), isChecked: complete || songIndex >= i))
                     .ToArray();
 
-                yield return new CheckboxListField(I18n.Puzzle_Solution(), checkboxes)
-                    .AddIntro(complete ? I18n.Puzzle_Solution_Solved() : I18n.Puzzle_IslandMermaid_Solution_Intro());
+                CheckboxList checkboxList = new(checkboxes);
+                checkboxList.AddIntro(complete ? I18n.Puzzle_Solution_Solved() : I18n.Puzzle_IslandMermaid_Solution_Intro());
+
+                yield return new CheckboxListField(I18n.Puzzle_Solution(), checkboxList);
             }
         }
 

--- a/LookupAnything/Framework/Lookups/Tiles/IslandMermaidPuzzleSubject.cs
+++ b/LookupAnything/Framework/Lookups/Tiles/IslandMermaidPuzzleSubject.cs
@@ -52,7 +52,7 @@ internal class IslandMermaidPuzzleSubject : TileSubject
                 int songIndex = location.songIndex;
 
                 var checkboxes = sequence
-                    .Select((pitch, i) => new CheckboxList.Checkbox(text: this.Stringify(pitch), isChecked: complete || songIndex >= i))
+                    .Select((pitch, i) => new Checkbox(text: this.Stringify(pitch), isChecked: complete || songIndex >= i))
                     .ToArray();
 
                 CheckboxList checkboxList = new(checkboxes);

--- a/LookupAnything/Framework/Lookups/Tiles/IslandShrinePuzzleSubject.cs
+++ b/LookupAnything/Framework/Lookups/Tiles/IslandShrinePuzzleSubject.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Pathoschild.Stardew.LookupAnything.Framework.Fields;
+using Pathoschild.Stardew.LookupAnything.Framework.Fields.Models;
 using StardewValley;
 using StardewValley.Locations;
 
@@ -46,31 +47,31 @@ internal class IslandShrinePuzzleSubject : TileSubject
                 yield return new GenericField(I18n.Puzzle_Solution(), new FormattedText(I18n.Puzzle_Solution_Hidden(), Color.Gray));
             else
             {
-                var field = new CheckboxListField(I18n.Puzzle_Solution(),
-                    CheckboxListField.Checkbox(
+                CheckboxList checkboxList = new([
+                    new CheckboxList.Checkbox(
                         text: I18n.Puzzle_IslandShrine_Solution_North(shrine.northPedestal.requiredItem.Value.DisplayName),
-                        value: complete || shrine.northPedestal.match.Value
+                        isChecked: complete || shrine.northPedestal.match.Value
                     ),
-                    CheckboxListField.Checkbox(
+                    new CheckboxList.Checkbox(
                         text: I18n.Puzzle_IslandShrine_Solution_East(shrine.eastPedestal.requiredItem.Value.DisplayName),
-                        value: complete || shrine.eastPedestal.match.Value
+                        isChecked: complete || shrine.eastPedestal.match.Value
                     ),
-                    CheckboxListField.Checkbox(
+                    new CheckboxList.Checkbox(
                         text: I18n.Puzzle_IslandShrine_Solution_South(shrine.southPedestal.requiredItem.Value.DisplayName),
-                        value: complete || shrine.southPedestal.match.Value
+                        isChecked: complete || shrine.southPedestal.match.Value
                     ),
-                    CheckboxListField.Checkbox(
+                    new CheckboxList.Checkbox(
                         text: I18n.Puzzle_IslandShrine_Solution_West(shrine.westPedestal.requiredItem.Value.DisplayName),
-                        value: complete || shrine.westPedestal.match.Value
+                        isChecked: complete || shrine.westPedestal.match.Value
                     )
-                );
+                ]);
 
-                field.AddIntro(complete
+                checkboxList.AddIntro(complete
                     ? I18n.Puzzle_Solution_Solved()
                     : I18n.Puzzle_IslandShrine_Solution()
                 );
 
-                yield return field;
+                yield return new CheckboxListField(I18n.Puzzle_Solution(), checkboxList);
             }
         }
 

--- a/LookupAnything/Framework/Lookups/Tiles/IslandShrinePuzzleSubject.cs
+++ b/LookupAnything/Framework/Lookups/Tiles/IslandShrinePuzzleSubject.cs
@@ -48,19 +48,19 @@ internal class IslandShrinePuzzleSubject : TileSubject
             else
             {
                 CheckboxList checkboxList = new([
-                    new CheckboxList.Checkbox(
+                    new Checkbox(
                         text: I18n.Puzzle_IslandShrine_Solution_North(shrine.northPedestal.requiredItem.Value.DisplayName),
                         isChecked: complete || shrine.northPedestal.match.Value
                     ),
-                    new CheckboxList.Checkbox(
+                    new Checkbox(
                         text: I18n.Puzzle_IslandShrine_Solution_East(shrine.eastPedestal.requiredItem.Value.DisplayName),
                         isChecked: complete || shrine.eastPedestal.match.Value
                     ),
-                    new CheckboxList.Checkbox(
+                    new Checkbox(
                         text: I18n.Puzzle_IslandShrine_Solution_South(shrine.southPedestal.requiredItem.Value.DisplayName),
                         isChecked: complete || shrine.southPedestal.match.Value
                     ),
-                    new CheckboxList.Checkbox(
+                    new Checkbox(
                         text: I18n.Puzzle_IslandShrine_Solution_West(shrine.westPedestal.requiredItem.Value.DisplayName),
                         isChecked: complete || shrine.westPedestal.match.Value
                     )

--- a/LookupAnything/Framework/Lookups/Tiles/IslandShrinePuzzleSubject.cs
+++ b/LookupAnything/Framework/Lookups/Tiles/IslandShrinePuzzleSubject.cs
@@ -47,7 +47,7 @@ internal class IslandShrinePuzzleSubject : TileSubject
                 yield return new GenericField(I18n.Puzzle_Solution(), new FormattedText(I18n.Puzzle_Solution_Hidden(), Color.Gray));
             else
             {
-                CheckboxList checkboxList = new([
+                CheckboxList checkboxList = new(
                     new Checkbox(
                         text: I18n.Puzzle_IslandShrine_Solution_North(shrine.northPedestal.requiredItem.Value.DisplayName),
                         isChecked: complete || shrine.northPedestal.match.Value
@@ -64,7 +64,7 @@ internal class IslandShrinePuzzleSubject : TileSubject
                         text: I18n.Puzzle_IslandShrine_Solution_West(shrine.westPedestal.requiredItem.Value.DisplayName),
                         isChecked: complete || shrine.westPedestal.match.Value
                     )
-                ]);
+                );
 
                 checkboxList.AddIntro(complete
                     ? I18n.Puzzle_Solution_Solved()


### PR DESCRIPTION
As discussed in #1033, I am opening this PR to prepare for implementing #42. This PR updates `CheckboxListField` to support multiple lists of checkboxes.
- Added a new model, `CheckboxList`, which stores a list of checkboxes along with an intro containing text and (optionally) an icon.
- Added the `Checkbox` record to replace instances of `KeyValuePair<IFormattedText[], bool>`.
- Updated drawing logic in `CheckboxListField` to support multiple lists of checkboxes.

The plan is to update `FishSpawnRulesField` to display the requirements for multiple fish when looking up a fishable tile. I will submit a separate MR for that once this change is merged :)