### PR TITLE
[Lookup Anything] Add progression mode option for fish spawn conditions

### DIFF
--- a/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
+++ b/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Pathoschild.Stardew.Common;
 using Pathoschild.Stardew.LookupAnything.Framework.Fields.Models;
 using Pathoschild.Stardew.LookupAnything.Framework.Models.FishData;
@@ -27,8 +28,9 @@ internal class FishSpawnRulesField : CheckboxListField
     /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
     /// <param name="label">A short field label.</param>
     /// <param name="fish">The fish item data.</param>
-    public FishSpawnRulesField(GameHelper gameHelper, string label, ParsedItemData fish)
-        : this(label, new CheckboxList(FishSpawnRulesField.GetConditions(gameHelper, fish))) { }
+    /// <param name="showUncaughtFishSpawnRules">Whether to show spawn conditions of uncaught fish.</param>
+    public FishSpawnRulesField(GameHelper gameHelper, string label, ParsedItemData fish, bool showUncaughtFishSpawnRules)
+        : this(label, new CheckboxList(FishSpawnRulesField.GetConditions(gameHelper, fish), isHidden: !showUncaughtFishSpawnRules && !FishSpawnRulesField.HasPlayerCaughtFish(fish))) { }
 
     /// <summary>Construct an instance for all fish in a body of water.</summary>
     /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
@@ -36,8 +38,32 @@ internal class FishSpawnRulesField : CheckboxListField
     /// <param name="location">The location whose fish spawn conditions to get.</param>
     /// <param name="tile">The tile for which to get the spawn rules.</param>
     /// <param name="fishAreaId">The internal ID of the fishing area for which to get the spawn rules.</param>
-    public FishSpawnRulesField(GameHelper gameHelper, string label, GameLocation location, Vector2 tile, string fishAreaId)
-        : this(label, FishSpawnRulesField.GetConditions(gameHelper, location, tile, fishAreaId).ToArray()) { }
+    /// <param name="showUncaughtFishSpawnRules">Whether to show spawn conditions of uncaught fish.</param>
+    public FishSpawnRulesField(GameHelper gameHelper, string label, GameLocation location, Vector2 tile, string fishAreaId, bool showUncaughtFishSpawnRules)
+        : this(label, FishSpawnRulesField.GetConditions(gameHelper, location, tile, fishAreaId, showUncaughtFishSpawnRules).ToArray()) { }
+
+    /// <inheritdoc/>
+    public override Vector2? DrawValue(SpriteBatch spriteBatch, SpriteFont font, Vector2 position, float wrapWidth)
+    {
+        float topOffset = 0;
+        int hiddenSpawnRulesCount = 0;
+
+        foreach (CheckboxList checkboxList in this.CheckboxLists)
+        {
+            if (checkboxList.IsHidden)
+                // skip drawing
+                hiddenSpawnRulesCount++;
+            else
+                // draw checkbox list
+                topOffset += this.DrawCheckboxList(checkboxList, spriteBatch, font, new Vector2(position.X, position.Y + topOffset), wrapWidth).Y;
+        }
+
+        if (hiddenSpawnRulesCount > 0)
+            // draw number of hidden spawn rules
+            topOffset += this.LineHeight + this.DrawIconText(spriteBatch, font, new Vector2(position.X, position.Y + topOffset), wrapWidth, I18n.Item_UncaughtFish(hiddenSpawnRulesCount), Color.Gray).Y;
+
+        return new Vector2(wrapWidth, topOffset - this.LineHeight);
+    }
 
 
     /*********
@@ -58,13 +84,15 @@ internal class FishSpawnRulesField : CheckboxListField
     /// <param name="location">The location whose fish spawn conditions to get.</param>
     /// <param name="tile">The tile for which to get the spawn rules.</param>
     /// <param name="fishAreaId">The internal ID of the fishing area for which to get the spawn rules.</param>
-    private static IEnumerable<CheckboxList> GetConditions(GameHelper gameHelper, GameLocation location, Vector2 tile, string fishAreaId)
+    /// <param name="showUncaughtFishSpawnRules">Whether to show spawn conditions of uncaught fish.</param>
+    private static IEnumerable<CheckboxList> GetConditions(GameHelper gameHelper, GameLocation location, Vector2 tile, string fishAreaId, bool showUncaughtFishSpawnRules)
     {
         foreach (FishSpawnData spawnRules in gameHelper.GetFishSpawnRules(location, tile, fishAreaId))
         {
             ParsedItemData fishItemData = ItemRegistry.GetDataOrErrorItem(spawnRules.FishItem.QualifiedItemId);
+            bool isCheckboxListHidden = !showUncaughtFishSpawnRules && !FishSpawnRulesField.HasPlayerCaughtFish(fishItemData);
 
-            CheckboxList checkboxList = new(FishSpawnRulesField.GetConditions(gameHelper, fishItemData));
+            CheckboxList checkboxList = new(FishSpawnRulesField.GetConditions(gameHelper, fishItemData), isCheckboxListHidden);
             checkboxList.AddIntro(fishItemData.DisplayName, new SpriteInfo(fishItemData.GetTexture(), fishItemData.GetSourceRect()));
 
             yield return checkboxList;
@@ -83,7 +111,7 @@ internal class FishSpawnRulesField : CheckboxListField
 
         // not caught uet
         if (spawnRules.IsUnique)
-            yield return FishSpawnRulesField.GetCondition(I18n.Item_FishSpawnRules_NotCaughtYet(), !Game1.player.fishCaught.ContainsKey(fish.QualifiedItemId));
+            yield return FishSpawnRulesField.GetCondition(I18n.Item_FishSpawnRules_NotCaughtYet(), !FishSpawnRulesField.HasPlayerCaughtFish(fish));
 
         // fishing level
         if (spawnRules.MinFishingLevel > 0)
@@ -200,5 +228,12 @@ internal class FishSpawnRulesField : CheckboxListField
         }
 
         return true;
+    }
+
+    /// <summary>Gets whether the player has caught a given fish.</summary>
+    /// <param name="fish">The fish item data.</param>
+    private static bool HasPlayerCaughtFish(ParsedItemData fish)
+    {
+        return Game1.player.fishCaught.ContainsKey(fish.QualifiedItemId);
     }
 }

--- a/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
+++ b/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
@@ -28,7 +28,7 @@ internal class FishSpawnRulesField : CheckboxListField
     /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
     /// <param name="label">A short field label.</param>
     /// <param name="fish">The fish item data.</param>
-    /// <param name="showUncaughtFishSpawnRules">Whether to show spawn conditions of uncaught fish.</param>
+    /// <param name="showUncaughtFishSpawnRules">Whether to show spawn conditions for uncaught fish.</param>
     public FishSpawnRulesField(GameHelper gameHelper, string label, ParsedItemData fish, bool showUncaughtFishSpawnRules)
         : this(label, new CheckboxList(FishSpawnRulesField.GetConditions(gameHelper, fish), isHidden: !showUncaughtFishSpawnRules && !FishSpawnRulesField.HasPlayerCaughtFish(fish))) { }
 
@@ -38,7 +38,7 @@ internal class FishSpawnRulesField : CheckboxListField
     /// <param name="location">The location whose fish spawn conditions to get.</param>
     /// <param name="tile">The tile for which to get the spawn rules.</param>
     /// <param name="fishAreaId">The internal ID of the fishing area for which to get the spawn rules.</param>
-    /// <param name="showUncaughtFishSpawnRules">Whether to show spawn conditions of uncaught fish.</param>
+    /// <param name="showUncaughtFishSpawnRules">Whether to show spawn conditions for uncaught fish.</param>
     public FishSpawnRulesField(GameHelper gameHelper, string label, GameLocation location, Vector2 tile, string fishAreaId, bool showUncaughtFishSpawnRules)
         : this(label, FishSpawnRulesField.GetConditions(gameHelper, location, tile, fishAreaId, showUncaughtFishSpawnRules).ToArray()) { }
 
@@ -48,18 +48,18 @@ internal class FishSpawnRulesField : CheckboxListField
         float topOffset = 0;
         int hiddenSpawnRulesCount = 0;
 
+        // draw checkbox lists
         foreach (CheckboxList checkboxList in this.CheckboxLists)
         {
             if (checkboxList.IsHidden)
-                // skip drawing
                 hiddenSpawnRulesCount++;
             else
                 // draw checkbox list
                 topOffset += this.DrawCheckboxList(checkboxList, spriteBatch, font, new Vector2(position.X, position.Y + topOffset), wrapWidth).Y;
         }
 
+        // draw 'X uncaught fish' message
         if (hiddenSpawnRulesCount > 0)
-            // draw number of hidden spawn rules
             topOffset += this.LineHeight + this.DrawIconText(spriteBatch, font, new Vector2(position.X, position.Y + topOffset), wrapWidth, I18n.Item_UncaughtFish(hiddenSpawnRulesCount), Color.Gray).Y;
 
         return new Vector2(wrapWidth, topOffset - this.LineHeight);
@@ -84,7 +84,7 @@ internal class FishSpawnRulesField : CheckboxListField
     /// <param name="location">The location whose fish spawn conditions to get.</param>
     /// <param name="tile">The tile for which to get the spawn rules.</param>
     /// <param name="fishAreaId">The internal ID of the fishing area for which to get the spawn rules.</param>
-    /// <param name="showUncaughtFishSpawnRules">Whether to show spawn conditions of uncaught fish.</param>
+    /// <param name="showUncaughtFishSpawnRules">Whether to show spawn conditions for uncaught fish.</param>
     private static IEnumerable<CheckboxList> GetConditions(GameHelper gameHelper, GameLocation location, Vector2 tile, string fishAreaId, bool showUncaughtFishSpawnRules)
     {
         foreach (FishSpawnData spawnRules in gameHelper.GetFishSpawnRules(location, tile, fishAreaId))

--- a/LookupAnything/Framework/Fields/Models/CheckboxList.cs
+++ b/LookupAnything/Framework/Fields/Models/CheckboxList.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Pathoschild.Stardew.Common;
@@ -16,21 +17,27 @@ internal class CheckboxList
     /// <summary>The intro text and icon to show before the checkboxes.</summary>
     public IntroData? Intro;
 
+    /// <summary>Whether to hide the list when drawing (e.g. when using progression mode)</summary>
+    public bool IsHidden;
+
 
     /*********
     ** Public methods
     *********/
     /// <summary>A list of checkboxes with labels and an optional intro line.</summary>
     /// <param name="checkboxes">The checkbox values to display.</param>
-    public CheckboxList(params Checkbox[] checkboxes)
+    /// <param name="isHidden">Whether to hide the list when drawing (e.g. when using progression mode)</param>
+    public CheckboxList(Checkbox[] checkboxes, bool isHidden = false)
     {
         this.Checkboxes = checkboxes;
+        this.IsHidden = isHidden;
     }
 
     /// <summary>Construct an instance.</summary>
     /// <param name="checkboxes">The checkbox values to display.</param>
-    public CheckboxList(IEnumerable<Checkbox> checkboxes)
-        : this(checkboxes.ToArray()) { }
+    /// <param name="isHidden">Whether to hide the list when drawing (e.g. when using progression mode)</param>
+    public CheckboxList(IEnumerable<Checkbox> checkboxes, bool isHidden = false)
+        : this(checkboxes.ToArray(), isHidden) { }
 
     /// <summary>Add intro text before the checkboxes.</summary>
     /// <param name="text">The text to render before the checkbox list.</param>

--- a/LookupAnything/Framework/Fields/Models/CheckboxList.cs
+++ b/LookupAnything/Framework/Fields/Models/CheckboxList.cs
@@ -17,7 +17,7 @@ internal class CheckboxList
     /// <summary>The intro text and icon to show before the checkboxes.</summary>
     public IntroData? Intro;
 
-    /// <summary>Whether to hide the list when drawing (e.g. when using progression mode)</summary>
+    /// <summary>Whether to hide the list when drawing (e.g. when using progression mode).</summary>
     public bool IsHidden;
 
 
@@ -26,7 +26,7 @@ internal class CheckboxList
     *********/
     /// <summary>A list of checkboxes with labels and an optional intro line.</summary>
     /// <param name="checkboxes">The checkbox values to display.</param>
-    /// <param name="isHidden">Whether to hide the list when drawing (e.g. when using progression mode)</param>
+    /// <param name="isHidden">Whether to hide the list when drawing (e.g. when using progression mode).</param>
     public CheckboxList(Checkbox[] checkboxes, bool isHidden = false)
     {
         this.Checkboxes = checkboxes;
@@ -35,7 +35,7 @@ internal class CheckboxList
 
     /// <summary>Construct an instance.</summary>
     /// <param name="checkboxes">The checkbox values to display.</param>
-    /// <param name="isHidden">Whether to hide the list when drawing (e.g. when using progression mode)</param>
+    /// <param name="isHidden">Whether to hide the list when drawing (e.g. when using progression mode).</param>
     public CheckboxList(IEnumerable<Checkbox> checkboxes, bool isHidden = false)
         : this(checkboxes.ToArray(), isHidden) { }
 

--- a/LookupAnything/Framework/GenericModConfigMenuIntegrationForLookupAnything.cs
+++ b/LookupAnything/Framework/GenericModConfigMenuIntegrationForLookupAnything.cs
@@ -24,10 +24,10 @@ internal class GenericModConfigMenuIntegrationForLookupAnything : IGenericModCon
             // progression mode
             .AddSectionTitle(I18n.Config_Title_Progression)
             .AddCheckbox(
-                    name: I18n.Config_Progression_ShowUncaughtFishSpawnRules_Name,
-                    tooltip: I18n.Config_Progression_ShowUncaughtFishSpawnRules_Desc,
-                    get: config => config.ShowUncaughtFishSpawnRules,
-                    set: (config, value) => config.ShowUncaughtFishSpawnRules = value
+                name: I18n.Config_Progression_ShowUncaughtFishSpawnRules_Name,
+                tooltip: I18n.Config_Progression_ShowUncaughtFishSpawnRules_Desc,
+                get: config => config.ShowUncaughtFishSpawnRules,
+                set: (config, value) => config.ShowUncaughtFishSpawnRules = value
             )
             .AddCheckbox(
                 name: I18n.Config_Progression_ShowUnknownGiftTastes_Name,

--- a/LookupAnything/Framework/GenericModConfigMenuIntegrationForLookupAnything.cs
+++ b/LookupAnything/Framework/GenericModConfigMenuIntegrationForLookupAnything.cs
@@ -24,6 +24,12 @@ internal class GenericModConfigMenuIntegrationForLookupAnything : IGenericModCon
             // progression mode
             .AddSectionTitle(I18n.Config_Title_Progression)
             .AddCheckbox(
+                    name: I18n.Config_Progression_ShowUncaughtFishSpawnRules_Name,
+                    tooltip: I18n.Config_Progression_ShowUncaughtFishSpawnRules_Desc,
+                    get: config => config.ShowUncaughtFishSpawnRules,
+                    set: (config, value) => config.ShowUncaughtFishSpawnRules = value
+            )
+            .AddCheckbox(
                 name: I18n.Config_Progression_ShowUnknownGiftTastes_Name,
                 tooltip: I18n.Config_Progression_ShowUnknownGiftTastes_Desc,
                 get: config => config.ShowUnknownGiftTastes,

--- a/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
+++ b/LookupAnything/Framework/Lookups/Characters/CharacterSubject.cs
@@ -299,7 +299,7 @@ internal class CharacterSubject : BaseSubject
                 text: I18n.Monster_AdventureGuild_EradicationGoal(name: goalName, count: kills, requiredCount: questData.Count),
                 isChecked: kills >= questData.Count
             );
-            yield return new CheckboxListField(I18n.Monster_AdventureGuild(), new CheckboxList(checkbox));
+            yield return new CheckboxListField(I18n.Monster_AdventureGuild(), new CheckboxList([checkbox]));
         }
     }
 

--- a/LookupAnything/Framework/Lookups/Items/ItemLookupProvider.cs
+++ b/LookupAnything/Framework/Lookups/Items/ItemLookupProvider.cs
@@ -356,6 +356,7 @@ internal class ItemLookupProvider : BaseLookupProvider
         return new ItemSubject(
             codex: this.Codex,
             gameHelper: this.GameHelper,
+            showUncaughtFishSpawnRules: config.ShowUncaughtFishSpawnRules,
             showUnknownGiftTastes: config.ShowUnknownGiftTastes,
             showUnknownRecipes: config.ShowUnknownRecipes,
             showInvalidRecipes: config.ShowInvalidRecipes,
@@ -389,6 +390,7 @@ internal class ItemLookupProvider : BaseLookupProvider
         return new ItemSubject(
             codex: this.Codex,
             gameHelper: this.GameHelper,
+            showUncaughtFishSpawnRules: config.ShowUncaughtFishSpawnRules,
             showUnknownGiftTastes: config.ShowUnknownGiftTastes,
             showUnknownRecipes: config.ShowUnknownRecipes,
             showInvalidRecipes: config.ShowInvalidRecipes,

--- a/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
+++ b/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
@@ -58,7 +58,7 @@ internal class ItemSubject : BaseSubject
     /// <summary>The location containing the item, if applicable.</summary>
     private readonly GameLocation? Location;
 
-    /// <summary>Whether to show spawn conditions of uncaught fish.</summary>
+    /// <summary>Whether to show spawn conditions for uncaught fish.</summary>
     public bool ShowUncaughtFishSpawnRules;
 
     /// <summary>Whether to show gift tastes which the player hasn't learned about in-game yet</summary>
@@ -92,7 +92,7 @@ internal class ItemSubject : BaseSubject
     /// <summary>Construct an instance.</summary>
     /// <param name="codex">Provides subject entries</param>
     /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
-    /// <param name="showUncaughtFishSpawnRules">Whether to show spawn conditions of uncaught fish.</param>
+    /// <param name="showUncaughtFishSpawnRules">Whether to show spawn conditions for uncaught fish.</param>
     /// <param name="showUnknownGiftTastes">Whether to show gift tastes which the player hasn't learned about in-game yet</param>
     /// <param name="highlightUnrevealedGiftTastes">Whether to highlight item gift tastes which haven't been revealed in the NPC profile.</param>
     /// <param name="showGiftTastes">Which gift taste levels to show.</param>

--- a/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
+++ b/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
@@ -58,6 +58,9 @@ internal class ItemSubject : BaseSubject
     /// <summary>The location containing the item, if applicable.</summary>
     private readonly GameLocation? Location;
 
+    /// <summary>Whether to show spawn conditions of uncaught fish.</summary>
+    public bool ShowUncaughtFishSpawnRules;
+
     /// <summary>Whether to show gift tastes which the player hasn't learned about in-game yet</summary>
     private readonly bool ShowUnknownGiftTastes;
 
@@ -89,6 +92,7 @@ internal class ItemSubject : BaseSubject
     /// <summary>Construct an instance.</summary>
     /// <param name="codex">Provides subject entries</param>
     /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
+    /// <param name="showUncaughtFishSpawnRules">Whether to show spawn conditions of uncaught fish.</param>
     /// <param name="showUnknownGiftTastes">Whether to show gift tastes which the player hasn't learned about in-game yet</param>
     /// <param name="highlightUnrevealedGiftTastes">Whether to highlight item gift tastes which haven't been revealed in the NPC profile.</param>
     /// <param name="showGiftTastes">Which gift taste levels to show.</param>
@@ -102,10 +106,11 @@ internal class ItemSubject : BaseSubject
     /// <param name="getCropSubject">Get a lookup subject for a crop.</param>
     /// <param name="fromCrop">The crop associated with the item (if applicable).</param>
     /// <param name="fromDirt">The dirt containing the crop (if applicable).</param>
-    public ItemSubject(ISubjectRegistry codex, GameHelper gameHelper, bool showUnknownGiftTastes, bool highlightUnrevealedGiftTastes, ModGiftTasteConfig showGiftTastes, bool showUnknownRecipes, bool showInvalidRecipes, ModCollapseLargeFieldsConfig collapseFieldsConfig, Item item, ObjectContext context, bool knownQuality, GameLocation? location, Func<Crop, ObjectContext, HoeDirt?, ISubject> getCropSubject, Crop? fromCrop = null, HoeDirt? fromDirt = null)
+    public ItemSubject(ISubjectRegistry codex, GameHelper gameHelper, bool showUncaughtFishSpawnRules, bool showUnknownGiftTastes, bool highlightUnrevealedGiftTastes, ModGiftTasteConfig showGiftTastes, bool showUnknownRecipes, bool showInvalidRecipes, ModCollapseLargeFieldsConfig collapseFieldsConfig, Item item, ObjectContext context, bool knownQuality, GameLocation? location, Func<Crop, ObjectContext, HoeDirt?, ISubject> getCropSubject, Crop? fromCrop = null, HoeDirt? fromDirt = null)
         : base(gameHelper)
     {
         this.Codex = codex;
+        this.ShowUncaughtFishSpawnRules = showUncaughtFishSpawnRules;
         this.ShowUnknownGiftTastes = showUnknownGiftTastes;
         this.HighlightUnrevealedGiftTastes = highlightUnrevealedGiftTastes;
         this.ShowGiftTastes = showGiftTastes;
@@ -313,7 +318,7 @@ internal class ItemSubject : BaseSubject
         }
 
         // fish spawn rules
-        yield return new FishSpawnRulesField(this.GameHelper, I18n.Item_FishSpawnRules(), itemData);
+        yield return new FishSpawnRulesField(this.GameHelper, I18n.Item_FishSpawnRules(), itemData, this.ShowUncaughtFishSpawnRules);
 
         // fish pond data
         // derived from FishPond::doAction

--- a/LookupAnything/Framework/Lookups/Tiles/CrystalCavePuzzleSubject.cs
+++ b/LookupAnything/Framework/Lookups/Tiles/CrystalCavePuzzleSubject.cs
@@ -14,9 +14,6 @@ internal class CrystalCavePuzzleSubject : TileSubject
     /*********
     ** Fields
     *********/
-    /// <summary>Whether to show puzzle solutions.</summary>
-    private readonly bool ShowPuzzleSolutions;
-
     /// <summary>The ID of the crystal being looked up, if any.</summary>
     private readonly int? CrystalId;
 
@@ -26,18 +23,17 @@ internal class CrystalCavePuzzleSubject : TileSubject
     *********/
     /// <summary>Construct an instance.</summary>
     /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
+    /// <param name="config">The mod configuration.</param>
     /// <param name="location">The game location.</param>
     /// <param name="position">The tile position.</param>
     /// <param name="showRawTileInfo">Whether to show raw tile info like tilesheets and tile indexes.</param>
-    /// <param name="showPuzzleSolutions">Whether to show puzzle solutions.</param>
     /// <param name="crystalId">The ID of the crystal being looked up, if any.</param>
-    public CrystalCavePuzzleSubject(GameHelper gameHelper, GameLocation location, Vector2 position, bool showRawTileInfo, bool showPuzzleSolutions, int? crystalId)
-        : base(gameHelper, location, position, showRawTileInfo)
+    public CrystalCavePuzzleSubject(GameHelper gameHelper, ModConfig config, GameLocation location, Vector2 position, bool showRawTileInfo, int? crystalId)
+        : base(gameHelper, config, location, position, showRawTileInfo)
     {
         this.Name = I18n.Puzzle_IslandCrystalCave_Title();
         this.Description = null;
         this.Type = null;
-        this.ShowPuzzleSolutions = showPuzzleSolutions;
         this.CrystalId = crystalId;
     }
 
@@ -49,7 +45,7 @@ internal class CrystalCavePuzzleSubject : TileSubject
             var cave = (IslandWestCave1)this.Location;
 
             // crystal ID
-            if (this.CrystalId.HasValue && this.ShowPuzzleSolutions)
+            if (this.CrystalId.HasValue && this.Config.ShowPuzzleSolutions)
                 yield return new GenericField(I18n.Puzzle_IslandCrystalCave_CrystalId(), this.Stringify(this.CrystalId.Value));
 
             // sequence
@@ -57,7 +53,7 @@ internal class CrystalCavePuzzleSubject : TileSubject
                 string label = I18n.Puzzle_Solution();
                 if (cave.completed.Value)
                     yield return new GenericField(label, I18n.Puzzle_Solution_Solved());
-                else if (!this.ShowPuzzleSolutions)
+                else if (!this.Config.ShowPuzzleSolutions)
                     yield return new GenericField(label, new FormattedText(I18n.Puzzle_Solution_Hidden(), Color.Gray));
                 else if (!cave.isActivated.Value)
                     yield return new GenericField(label, I18n.Puzzle_IslandCrystalCave_Solution_NotActivated());

--- a/LookupAnything/Framework/Lookups/Tiles/IslandMermaidPuzzleSubject.cs
+++ b/LookupAnything/Framework/Lookups/Tiles/IslandMermaidPuzzleSubject.cs
@@ -12,28 +12,20 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Tiles;
 internal class IslandMermaidPuzzleSubject : TileSubject
 {
     /*********
-    ** Fields
-    *********/
-    /// <summary>Whether to show puzzle solutions.</summary>
-    private readonly bool ShowPuzzleSolutions;
-
-
-    /*********
     ** Public methods
     *********/
     /// <summary>Construct an instance.</summary>
     /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
+    /// <param name="config">The mod configuration.</param>
     /// <param name="location">The game location.</param>
     /// <param name="position">The tile position.</param>
     /// <param name="showRawTileInfo">Whether to show raw tile info like tilesheets and tile indexes.</param>
-    /// <param name="showPuzzleSolutions">Whether to show puzzle solutions.</param>
-    public IslandMermaidPuzzleSubject(GameHelper gameHelper, GameLocation location, Vector2 position, bool showRawTileInfo, bool showPuzzleSolutions)
-        : base(gameHelper, location, position, showRawTileInfo)
+    public IslandMermaidPuzzleSubject(GameHelper gameHelper, ModConfig config, GameLocation location, Vector2 position, bool showRawTileInfo)
+        : base(gameHelper, config, location, position, showRawTileInfo)
     {
         this.Name = I18n.Puzzle_IslandMermaid_Title();
         this.Description = null;
         this.Type = null;
-        this.ShowPuzzleSolutions = showPuzzleSolutions;
     }
 
     /// <inheritdoc />
@@ -44,7 +36,7 @@ internal class IslandMermaidPuzzleSubject : TileSubject
             IslandSouthEast location = (IslandSouthEast)this.Location;
             bool complete = location.mermaidPuzzleFinished.Value;
 
-            if (!this.ShowPuzzleSolutions && !complete)
+            if (!this.Config.ShowPuzzleSolutions && !complete)
                 yield return new GenericField(I18n.Puzzle_Solution(), I18n.Puzzle_Solution_Hidden());
             else
             {

--- a/LookupAnything/Framework/Lookups/Tiles/IslandShrinePuzzleSubject.cs
+++ b/LookupAnything/Framework/Lookups/Tiles/IslandShrinePuzzleSubject.cs
@@ -11,28 +11,20 @@ namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Tiles;
 internal class IslandShrinePuzzleSubject : TileSubject
 {
     /*********
-    ** Fields
-    *********/
-    /// <summary>Whether to show puzzle solutions.</summary>
-    private readonly bool ShowPuzzleSolutions;
-
-
-    /*********
     ** Public methods
     *********/
     /// <summary>Construct an instance.</summary>
     /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
+    /// <param name="config">The mod configuration.</param>
     /// <param name="location">The game location.</param>
     /// <param name="position">The tile position.</param>
     /// <param name="showRawTileInfo">Whether to show raw tile info like tilesheets and tile indexes.</param>
-    /// <param name="showPuzzleSolutions">Whether to show puzzle solutions.</param>
-    public IslandShrinePuzzleSubject(GameHelper gameHelper, GameLocation location, Vector2 position, bool showRawTileInfo, bool showPuzzleSolutions)
-        : base(gameHelper, location, position, showRawTileInfo)
+    public IslandShrinePuzzleSubject(GameHelper gameHelper, ModConfig config, GameLocation location, Vector2 position, bool showRawTileInfo)
+        : base(gameHelper, config, location, position, showRawTileInfo)
     {
         this.Name = I18n.Puzzle_IslandShrine_Title();
         this.Description = null;
         this.Type = null;
-        this.ShowPuzzleSolutions = showPuzzleSolutions;
     }
 
     /// <inheritdoc />
@@ -43,7 +35,7 @@ internal class IslandShrinePuzzleSubject : TileSubject
             IslandShrine shrine = (IslandShrine)this.Location;
             bool complete = shrine.puzzleFinished.Value;
 
-            if (!this.ShowPuzzleSolutions && !complete)
+            if (!this.Config.ShowPuzzleSolutions && !complete)
                 yield return new GenericField(I18n.Puzzle_Solution(), new FormattedText(I18n.Puzzle_Solution_Hidden(), Color.Gray));
             else
             {

--- a/LookupAnything/Framework/Lookups/Tiles/IslandShrinePuzzleSubject.cs
+++ b/LookupAnything/Framework/Lookups/Tiles/IslandShrinePuzzleSubject.cs
@@ -39,7 +39,7 @@ internal class IslandShrinePuzzleSubject : TileSubject
                 yield return new GenericField(I18n.Puzzle_Solution(), new FormattedText(I18n.Puzzle_Solution_Hidden(), Color.Gray));
             else
             {
-                CheckboxList checkboxList = new(
+                CheckboxList checkboxList = new([
                     new Checkbox(
                         text: I18n.Puzzle_IslandShrine_Solution_North(shrine.northPedestal.requiredItem.Value.DisplayName),
                         isChecked: complete || shrine.northPedestal.match.Value
@@ -56,7 +56,7 @@ internal class IslandShrinePuzzleSubject : TileSubject
                         text: I18n.Puzzle_IslandShrine_Solution_West(shrine.westPedestal.requiredItem.Value.DisplayName),
                         isChecked: complete || shrine.westPedestal.match.Value
                     )
-                );
+                ]);
 
                 checkboxList.AddIntro(complete
                     ? I18n.Puzzle_Solution_Solved()

--- a/LookupAnything/Framework/Lookups/Tiles/TileLookupProvider.cs
+++ b/LookupAnything/Framework/Lookups/Tiles/TileLookupProvider.cs
@@ -60,15 +60,15 @@ internal class TileLookupProvider : BaseLookupProvider
         ModConfig config = this.Config();
 
         if (this.IsCrystalCavePuzzle(location, tile, out int? crystalId))
-            return new CrystalCavePuzzleSubject(this.GameHelper, location, tile, showRaw, config.ShowPuzzleSolutions, crystalId);
+            return new CrystalCavePuzzleSubject(this.GameHelper, config, location, tile, showRaw, crystalId);
 
         if (this.GetIsIslandMermaidPuzzle(location, tile))
-            return new IslandMermaidPuzzleSubject(this.GameHelper, location, tile, showRaw, config.ShowPuzzleSolutions);
+            return new IslandMermaidPuzzleSubject(this.GameHelper, config, location, tile, showRaw);
 
         if (this.IsIslandShrinePuzzle(location, tile))
-            return new IslandShrinePuzzleSubject(this.GameHelper, location, tile, showRaw, config.ShowPuzzleSolutions);
+            return new IslandShrinePuzzleSubject(this.GameHelper, config, location, tile, showRaw);
 
-        if (TileSubject.TryCreate(this.GameHelper, location, tile, showRaw, out TileSubject? tileSubject))
+        if (TileSubject.TryCreate(this.GameHelper, config, location, tile, showRaw, out TileSubject? tileSubject))
             return tileSubject;
 
         return null;

--- a/LookupAnything/Framework/Lookups/Tiles/TileSubject.cs
+++ b/LookupAnything/Framework/Lookups/Tiles/TileSubject.cs
@@ -97,7 +97,7 @@ internal class TileSubject : BaseSubject
         if (TileSubject.IsFishingArea(this.Location, this.Position))
         {
             this.Location.TryGetFishAreaForTile(this.Position, out string fishAreaId, out _);
-            var field = new FishSpawnRulesField(this.GameHelper, I18n.Item_FishSpawnRules(), this.Location, this.Position, fishAreaId);
+            var field = new FishSpawnRulesField(this.GameHelper, I18n.Item_FishSpawnRules(), this.Location, this.Position, fishAreaId, this.Config.ShowUncaughtFishSpawnRules);
             if (field.HasValue) // don't yield empty field, so TryCreate can check if there's any data
                 yield return field;
         }

--- a/LookupAnything/Framework/Lookups/Tiles/TileSubject.cs
+++ b/LookupAnything/Framework/Lookups/Tiles/TileSubject.cs
@@ -18,6 +18,9 @@ internal class TileSubject : BaseSubject
     /*********
     ** Fields
     *********/
+    /// <summary>The mod configuration.</summary>
+    protected readonly ModConfig Config;
+
     /// <summary>The game location.</summary>
     protected readonly GameLocation Location;
 
@@ -33,12 +36,14 @@ internal class TileSubject : BaseSubject
     *********/
     /// <summary>Construct an instance.</summary>
     /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
+    /// <param name="config">The mod configuration.</param>
     /// <param name="location">The game location.</param>
     /// <param name="position">The tile position.</param>
     /// <param name="showRawTileInfo">Whether to show raw tile info like tilesheets and tile indexes.</param>
-    public TileSubject(GameHelper gameHelper, GameLocation location, Vector2 position, bool showRawTileInfo)
+    public TileSubject(GameHelper gameHelper, ModConfig config, GameLocation location, Vector2 position, bool showRawTileInfo)
         : base(gameHelper, I18n.Tile_Title(x: position.X, y: position.Y), showRawTileInfo ? I18n.Tile_Description() : null, null)
     {
+        this.Config = config;
         this.Location = location;
         this.Position = position;
         this.ShowRawTileInfo = showRawTileInfo;
@@ -46,14 +51,15 @@ internal class TileSubject : BaseSubject
 
     /// <summary>Create an instance of there's data to show.</summary>
     /// <param name="gameHelper">Provides utility methods for interacting with the game code.</param>
+    /// <param name="config">The mod configuration.</param>
     /// <param name="location">The game location.</param>
     /// <param name="position">The tile position.</param>
     /// <param name="showRawTileInfo">Whether to show raw tile info like tilesheets and tile indexes.</param>
     /// <param name="tileSubject">The tile subject to display, if applicable.</param>
     /// <returns>Returns whether a tile subject was successfully created.</returns>
-    public static bool TryCreate(GameHelper gameHelper, GameLocation location, Vector2 position, bool showRawTileInfo, [NotNullWhen(true)] out TileSubject? tileSubject)
+    public static bool TryCreate(GameHelper gameHelper, ModConfig config, GameLocation location, Vector2 position, bool showRawTileInfo, [NotNullWhen(true)] out TileSubject? tileSubject)
     {
-        tileSubject = new TileSubject(gameHelper, location, position, showRawTileInfo);
+        tileSubject = new TileSubject(gameHelper, config, location, position, showRawTileInfo);
         if (tileSubject.GetData().Any())
             return true;
 

--- a/LookupAnything/Framework/ModConfig.cs
+++ b/LookupAnything/Framework/ModConfig.cs
@@ -19,6 +19,9 @@ internal class ModConfig
     /// <summary>Whether to show gift tastes which the player hasn't learned about in-game yet (e.g. from dialogue text or experimenting).</summary>
     public bool ShowUnknownGiftTastes { get; set; } = true;
 
+    /// <summary>Whether to show spawn conditions of uncaught fish.</summary>
+    public bool ShowUncaughtFishSpawnRules { get; set; } = true;
+
     /// <summary>Whether to show recipes the player hasn't learned in-game yet.</summary>
     public bool ShowUnknownRecipes { get; set; } = true;
 

--- a/LookupAnything/Framework/ModConfig.cs
+++ b/LookupAnything/Framework/ModConfig.cs
@@ -19,7 +19,7 @@ internal class ModConfig
     /// <summary>Whether to show gift tastes which the player hasn't learned about in-game yet (e.g. from dialogue text or experimenting).</summary>
     public bool ShowUnknownGiftTastes { get; set; } = true;
 
-    /// <summary>Whether to show spawn conditions of uncaught fish.</summary>
+    /// <summary>Whether to show spawn conditions for uncaught fish.</summary>
     public bool ShowUncaughtFishSpawnRules { get; set; } = true;
 
     /// <summary>Whether to show recipes the player hasn't learned in-game yet.</summary>

--- a/LookupAnything/i18n/de.json
+++ b/LookupAnything/i18n/de.json
@@ -415,6 +415,7 @@
     "item.fish-spawn-rules.time": "Uhrzeit: {{times}}",
     "item.fish-spawn-rules.weather-sunny": "Wetter: sonnig",
     "item.fish-spawn-rules.weather-rainy": "Wetter: regnerisch",
+    "item.uncaught-fish": "{{count}} uncaught fish", // TODO
 
 
     /*********
@@ -708,6 +709,9 @@
 
     // progression mode
     "config.title.progression": "Fortschrittsmodus",
+
+    "config.progression.show-uncaught-fish-spawn-rules.name": "Show uncaught fish spawn rules", // TODO
+    "config.progression.show-uncaught-fish-spawn-rules.desc": "Whether to show spawn conditions for fish you haven't caught yet.", // TODO
 
     "config.progression.show-unknown-gift-tastes.name": "Unbekannte Geschenke Vorlieben anzeigen",
     "config.progression.show-unknown-gift-tastes.desc": "Ob Geschenk Vorlieben gezeigt werden sollen, die du im Spiel noch nicht kennengelernt hast (z. B. aus Dialogtexten oder beim Experimentieren).",

--- a/LookupAnything/i18n/default.json
+++ b/LookupAnything/i18n/default.json
@@ -415,6 +415,7 @@
     "item.fish-spawn-rules.time": "time of day: {{times}}",
     "item.fish-spawn-rules.weather-sunny": "weather: sunny",
     "item.fish-spawn-rules.weather-rainy": "weather: raining",
+    "item.uncaught-fish": "{{count}} uncaught fish",
 
 
     /*********
@@ -708,6 +709,9 @@
 
     // progression mode
     "config.title.progression": "Progression mode",
+
+    "config.progression.show-uncaught-fish-spawn-rules.name": "Show uncaught fish spawn rules", // TODO
+    "config.progression.show-uncaught-fish-spawn-rules.desc": "Whether to show spawn conditions for fish you haven't caught yet.", // TODO
 
     "config.progression.show-unknown-gift-tastes.name": "Show unknown gift tastes",
     "config.progression.show-unknown-gift-tastes.desc": "Whether to show gift tastes you haven't learned about in-game yet (e.g. from dialogue text or experimenting).",

--- a/LookupAnything/i18n/es.json
+++ b/LookupAnything/i18n/es.json
@@ -417,6 +417,7 @@
     "item.fish-spawn-rules.time": "horas: {{times}}",
     "item.fish-spawn-rules.weather-sunny": "tiempo: soleado",
     "item.fish-spawn-rules.weather-rainy": "tiempo: lluvioso",
+    "item.uncaught-fish": "{{count}} uncaught fish", // TODO
 
 
     /*********
@@ -712,6 +713,9 @@
     // progression mode
     // TODO
     "config.title.progression": "Modo de progresión",
+
+    "config.progression.show-uncaught-fish-spawn-rules.name": "Show uncaught fish spawn rules", // TODO
+    "config.progression.show-uncaught-fish-spawn-rules.desc": "Whether to show spawn conditions for fish you haven't caught yet.", // TODO
 
     "config.progression.show-unknown-gift-tastes.name": "Show unknown gift tastes",
     "config.progression.show-unknown-gift-tastes.desc": "Whether to show gift tastes you haven't learned about in-game yet (e.g. from dialogue text or experimenting).",

--- a/LookupAnything/i18n/fr.json
+++ b/LookupAnything/i18n/fr.json
@@ -419,6 +419,7 @@
     "item.fish-spawn-rules.time": "heure : {{times}}",
     "item.fish-spawn-rules.weather-sunny": "temps : ensoleillé",
     "item.fish-spawn-rules.weather-rainy": "temps : pluvieux",
+    "item.uncaught-fish": "{{count}} uncaught fish", // TODO
 
 
     /*********
@@ -713,6 +714,9 @@
     // progression mode
     // TODO
     "config.title.progression": "Mode de progression",
+
+    "config.progression.show-uncaught-fish-spawn-rules.name": "Show uncaught fish spawn rules", // TODO
+    "config.progression.show-uncaught-fish-spawn-rules.desc": "Whether to show spawn conditions for fish you haven't caught yet.", // TODO
 
     "config.progression.show-unknown-gift-tastes.name": "Show unknown gift tastes",
     "config.progression.show-unknown-gift-tastes.desc": "Whether to show gift tastes you haven't learned about in-game yet (e.g. from dialogue text or experimenting).",

--- a/LookupAnything/i18n/hu.json
+++ b/LookupAnything/i18n/hu.json
@@ -417,6 +417,7 @@
     "item.fish-spawn-rules.time": "napszak: {{times}}",
     "item.fish-spawn-rules.weather-sunny": "időjárás: napos",
     "item.fish-spawn-rules.weather-rainy": "időjárás: esős",
+    "item.uncaught-fish": "{{count}} uncaught fish", // TODO
 
 
     /*********
@@ -721,6 +722,9 @@
     // progression mode
     // TODO
     "config.title.progression": "Progression mode",
+
+    "config.progression.show-uncaught-fish-spawn-rules.name": "Show uncaught fish spawn rules", // TODO
+    "config.progression.show-uncaught-fish-spawn-rules.desc": "Whether to show spawn conditions for fish you haven't caught yet.", // TODO
 
     "config.progression.show-unknown-gift-tastes.name": "Show unknown gift tastes",
     "config.progression.show-unknown-gift-tastes.desc": "Whether to show gift tastes you haven't learned about in-game yet (e.g. from dialogue text or experimenting).",

--- a/LookupAnything/i18n/it.json
+++ b/LookupAnything/i18n/it.json
@@ -414,6 +414,7 @@
     "item.fish-spawn-rules.time": "orario: {{times}}",
     "item.fish-spawn-rules.weather-sunny": "tempo meteo: soleggiato",
     "item.fish-spawn-rules.weather-rainy": "tempo meteo: pioggia",
+    "item.uncaught-fish": "{{count}} uncaught fish", // TODO
 
 
     /*********
@@ -707,6 +708,9 @@
 
     // progression mode
     "config.title.progression": "Modalità progressione",
+
+    "config.progression.show-uncaught-fish-spawn-rules.name": "Show uncaught fish spawn rules", // TODO
+    "config.progression.show-uncaught-fish-spawn-rules.desc": "Whether to show spawn conditions for fish you haven't caught yet.", // TODO
 
     "config.progression.show-unknown-gift-tastes.name": "Mostra gusti dei regali sconosciuti",
     "config.progression.show-unknown-gift-tastes.desc": "Scegli se mostrare i gusti dei regali che non si sono ancora appresi nel gioco (ad esempio dal testo del dialogo o sperimentando).",

--- a/LookupAnything/i18n/ja.json
+++ b/LookupAnything/i18n/ja.json
@@ -416,6 +416,7 @@
     "item.fish-spawn-rules.time": "釣れる時間：{{times}}",
     "item.fish-spawn-rules.weather-sunny": "天気：晴れ",
     "item.fish-spawn-rules.weather-rainy": "天気：雨",
+    "item.uncaught-fish": "{{count}} uncaught fish", // TODO
 
 
     /*********
@@ -709,6 +710,9 @@
 
     // progression mode
     "config.title.progression": "プログレッションモード",
+
+    "config.progression.show-uncaught-fish-spawn-rules.name": "Show uncaught fish spawn rules", // TODO
+    "config.progression.show-uncaught-fish-spawn-rules.desc": "Whether to show spawn conditions for fish you haven't caught yet.", // TODO
 
     "config.progression.show-unknown-gift-tastes.name": "未知の贈り物の好みを表示",
     "config.progression.show-unknown-gift-tastes.desc": "ゲーム内でまだ知らない贈り物の好みを表示する。",

--- a/LookupAnything/i18n/ko.json
+++ b/LookupAnything/i18n/ko.json
@@ -416,6 +416,7 @@
     "item.fish-spawn-rules.time": "시간: {{times}}",
     "item.fish-spawn-rules.weather-sunny": "날씨: 맑은 날",
     "item.fish-spawn-rules.weather-rainy": "날씨: 비 오는 날",
+    "item.uncaught-fish": "{{count}} uncaught fish", // TODO
 
 
     /*********
@@ -709,6 +710,9 @@
 
     // progression mode
     "config.title.progression": "진행 모드",
+
+    "config.progression.show-uncaught-fish-spawn-rules.name": "Show uncaught fish spawn rules", // TODO
+    "config.progression.show-uncaught-fish-spawn-rules.desc": "Whether to show spawn conditions for fish you haven't caught yet.", // TODO
 
     "config.progression.show-unknown-gift-tastes.name": "모르는 선물 취향 보기",
     "config.progression.show-unknown-gift-tastes.desc": "게임 내에서 아직 알지 못한 선물 취향을 표시할지 여부(예: 대화 텍스트 또는 실험을 통해).",

--- a/LookupAnything/i18n/pl.json
+++ b/LookupAnything/i18n/pl.json
@@ -416,6 +416,7 @@
     "item.fish-spawn-rules.time": "pora dnia: {{times}}",
     "item.fish-spawn-rules.weather-sunny": "pogoda: słonecznie",
     "item.fish-spawn-rules.weather-rainy": "pogoda: deszczowo",
+    "item.uncaught-fish": "{{count}} uncaught fish", // TODO
 
 
     /*********
@@ -709,6 +710,9 @@
 
     // progression mode
     "config.title.progression": "Tryb progresji",
+
+    "config.progression.show-uncaught-fish-spawn-rules.name": "Show uncaught fish spawn rules", // TODO
+    "config.progression.show-uncaught-fish-spawn-rules.desc": "Whether to show spawn conditions for fish you haven't caught yet.", // TODO
 
     "config.progression.show-unknown-gift-tastes.name": "Pokaż nieznane upodobania prezentowe",
     "config.progression.show-unknown-gift-tastes.desc": "Czy pokazywać upodobania prezentowe, których jeszcze nie ${nauczyłeś¦nauczyłaś}$ się w grze (np. z tekstu dialogowego lub eksperymentując).",

--- a/LookupAnything/i18n/pt.json
+++ b/LookupAnything/i18n/pt.json
@@ -417,6 +417,7 @@
     "item.fish-spawn-rules.time": "Horário do dia: {{times}}",
     "item.fish-spawn-rules.weather-sunny": "Clima: Ensolarado",
     "item.fish-spawn-rules.weather-rainy": "Clima: Chuva",
+    "item.uncaught-fish": "{{count}} uncaught fish", // TODO
 
 
     /*********
@@ -711,6 +712,9 @@
     // progression mode
     // TODO
     "config.title.progression": "Modo de progressão",
+
+    "config.progression.show-uncaught-fish-spawn-rules.name": "Show uncaught fish spawn rules", // TODO
+    "config.progression.show-uncaught-fish-spawn-rules.desc": "Whether to show spawn conditions for fish you haven't caught yet.", // TODO
 
     "config.progression.show-unknown-gift-tastes.name": "Show unknown gift tastes",
     "config.progression.show-unknown-gift-tastes.desc": "Whether to show gift tastes you haven't learned about in-game yet (e.g. from dialogue text or experimenting).",

--- a/LookupAnything/i18n/ru.json
+++ b/LookupAnything/i18n/ru.json
@@ -416,6 +416,7 @@
     "item.fish-spawn-rules.time": "время суток: {{times}}",
     "item.fish-spawn-rules.weather-sunny": "погода: солнечно",
     "item.fish-spawn-rules.weather-rainy": "погода: дождь",
+    "item.uncaught-fish": "{{count}} uncaught fish", // TODO
 
 
     /*********
@@ -709,6 +710,9 @@
 
     // progression mode
     "config.title.progression": "Режим прохождения без спойлеров",
+
+    "config.progression.show-uncaught-fish-spawn-rules.name": "Show uncaught fish spawn rules", // TODO
+    "config.progression.show-uncaught-fish-spawn-rules.desc": "Whether to show spawn conditions for fish you haven't caught yet.", // TODO
 
     "config.progression.show-unknown-gift-tastes.name": "Показывать неизвестные предпочтения подарков",
     "config.progression.show-unknown-gift-tastes.desc": "Показывать ли предпочтения подарков, о которых вы еще не узнали в игре (например, из текста диалога или экспериментируя)",

--- a/LookupAnything/i18n/th.json
+++ b/LookupAnything/i18n/th.json
@@ -417,6 +417,7 @@
     "item.fish-spawn-rules.time": "ช่วงเวลา: {{times}}",
     "item.fish-spawn-rules.weather-sunny": "สภาพอากาศ: แดดสดใส",
     "item.fish-spawn-rules.weather-rainy": "สภาพอากาศ: ฝนตก",
+    "item.uncaught-fish": "{{count}} uncaught fish", // TODO
 
 
     /*********
@@ -713,6 +714,9 @@
     // progression mode
     // TODO
     "config.title.progression": "โหมดความก้าวหน้า",
+
+    "config.progression.show-uncaught-fish-spawn-rules.name": "Show uncaught fish spawn rules", // TODO
+    "config.progression.show-uncaught-fish-spawn-rules.desc": "Whether to show spawn conditions for fish you haven't caught yet.", // TODO
 
     "config.progression.show-unknown-gift-tastes.name": "Show unknown gift tastes",
     "config.progression.show-unknown-gift-tastes.desc": "Whether to show gift tastes you haven't learned about in-game yet (e.g. from dialogue text or experimenting).",

--- a/LookupAnything/i18n/tr.json
+++ b/LookupAnything/i18n/tr.json
@@ -415,6 +415,7 @@
     "item.fish-spawn-rules.time": "günün saati: {{times}}",
     "item.fish-spawn-rules.weather-sunny": "hava: güneşli",
     "item.fish-spawn-rules.weather-rainy": "hava: yağmurlu",
+    "item.uncaught-fish": "{{count}} uncaught fish", // TODO
 
 
     /*********
@@ -708,6 +709,9 @@
 
     // progression mode
     "config.title.progression": "İlerleme modu",
+
+    "config.progression.show-uncaught-fish-spawn-rules.name": "Show uncaught fish spawn rules", // TODO
+    "config.progression.show-uncaught-fish-spawn-rules.desc": "Whether to show spawn conditions for fish you haven't caught yet.", // TODO
 
     "config.progression.show-unknown-gift-tastes.name": "Bilinmeyen hediye zevklerini göster",
     "config.progression.show-unknown-gift-tastes.desc": "NPC'lerin hediye zevklerini gösterirken bilinmeyenleri gösterip göstermeyeceği. Etkinleştirildiğinde, bilinmeyen hediye zevkleri gösterilecek.",

--- a/LookupAnything/i18n/uk.json
+++ b/LookupAnything/i18n/uk.json
@@ -417,6 +417,7 @@
     "item.fish-spawn-rules.time": "Час: {{times}}",
     "item.fish-spawn-rules.weather-sunny": "Сонячна погода",
     "item.fish-spawn-rules.weather-rainy": "Дощова погода",
+    "item.uncaught-fish": "{{count}} uncaught fish", // TODO
 
 
     /*********
@@ -711,6 +712,9 @@
     // progression mode
     // TODO
     "config.title.progression": "Режим прогресу",
+
+    "config.progression.show-uncaught-fish-spawn-rules.name": "Show uncaught fish spawn rules", // TODO
+    "config.progression.show-uncaught-fish-spawn-rules.desc": "Whether to show spawn conditions for fish you haven't caught yet.", // TODO
 
     "config.progression.show-unknown-gift-tastes.name": "Show unknown gift tastes",
     "config.progression.show-unknown-gift-tastes.desc": "Whether to show gift tastes you haven't learned about in-game yet (e.g. from dialogue text or experimenting).",

--- a/LookupAnything/i18n/vi.json
+++ b/LookupAnything/i18n/vi.json
@@ -416,6 +416,7 @@
     "item.fish-spawn-rules.time": "thời gian trong ngày: {{times}}",
     "item.fish-spawn-rules.weather-sunny": "thời tiết: nắng",
     "item.fish-spawn-rules.weather-rainy": "thời tiết: mưa",
+    "item.uncaught-fish": "{{count}} uncaught fish", // TODO
 
 
     /*********
@@ -709,6 +710,9 @@
 
     // progression mode
     "config.title.progression": "Chế độ tiến trình",
+
+    "config.progression.show-uncaught-fish-spawn-rules.name": "Show uncaught fish spawn rules", // TODO
+    "config.progression.show-uncaught-fish-spawn-rules.desc": "Whether to show spawn conditions for fish you haven't caught yet.", // TODO
 
     "config.progression.show-unknown-gift-tastes.name": "Hiển thị sở thích quà tặng chưa biết",
     "config.progression.show-unknown-gift-tastes.desc": "Có hiển thị những sở thích quà tặng mà bạn chưa tìm hiểu trong trò chơi hay không (ví dụ: từ văn bản đối thoại hoặc thử nghiệm).",

--- a/LookupAnything/i18n/zh.json
+++ b/LookupAnything/i18n/zh.json
@@ -415,6 +415,7 @@
     "item.fish-spawn-rules.time": "一天中出现时间： {{times}}",
     "item.fish-spawn-rules.weather-sunny": "天气：晴天",
     "item.fish-spawn-rules.weather-rainy": "天气：雨天",
+    "item.uncaught-fish": "{{count}} uncaught fish", // TODO
 
 
     /*********
@@ -708,6 +709,9 @@
 
     // progression mode (进度模式)
     "config.title.progression": "进度模式",
+
+    "config.progression.show-uncaught-fish-spawn-rules.name": "Show uncaught fish spawn rules", // TODO
+    "config.progression.show-uncaught-fish-spawn-rules.desc": "Whether to show spawn conditions for fish you haven't caught yet.", // TODO
 
     "config.progression.show-unknown-gift-tastes.name": "显示未知的礼物品味",
     "config.progression.show-unknown-gift-tastes.desc": "是否显示游戏中不知道的礼物品味（例如，从对话或实际送礼中）。",


### PR DESCRIPTION
Added a new Progression Mode option to hide fish spawn conditions for fish that the player hasn't caught yet.

For this to work, I refactored `TileSubject` and added a `ModConfig` field. Now, rather than passing individual fields from `ModConfig` (like passing `ShowPuzzleSolutions` to `CrystalCavePuzzleSubject`), we pass in the entire `ModConfig` object. This was necessary for passing the new config option to `FishSpawnRulesField`.

Expand this for screenshots:

<details>
<summary>Screenshots</summary>

The new option:

<img width="686" alt="image" src="https://github.com/user-attachments/assets/fb6742be-842d-47dd-b5f3-a2cc19f0c55f" />

A single fish's hidden spawn rules:

<img width="671" alt="image" src="https://github.com/user-attachments/assets/b33bd307-a045-464b-9499-ec46cdf74280" />

All fish in an area hidden:

<img width="660" alt="image" src="https://github.com/user-attachments/assets/e76b9f8b-3f1f-4aec-84bc-fe40352d8eb7" />

Some fish in an area hidden:

<img width="669" alt="image" src="https://github.com/user-attachments/assets/76cd1bc6-0777-4ddf-9315-5449e217c4e5" />


</details>