### PR TITLE
Show total sell value of chest

### DIFF
--- a/ChestsAnywhere/Menus/Overlays/BaseChestOverlay.cs
+++ b/ChestsAnywhere/Menus/Overlays/BaseChestOverlay.cs
@@ -222,6 +222,23 @@ internal abstract class BaseChestOverlay : BaseOverlay, IStorageOverlay
 
             // edit button
             this.EditButton.draw(batch, Color.White * navOpacity, 1f);
+
+            // total sell value
+            {
+                int totalSellPrice = this.Chest.Container.Inventory
+                    .Where(item => item != null)
+                    .Sum(item => Utility.getSellToStorePriceOfItem(item));
+                batch.DrawTextBlock(
+                    Game1.smallFont,
+                    totalSellPrice.ToString(),
+                    new Vector2(
+                        this.EditButton.bounds.X + this.EditButton.bounds.Width,
+                        this.ChestDropdown.bounds.Y
+                    ),
+                    bounds.Width,
+                    Color.White * navOpacity
+                );
+            }
         }
 
         // edit mode


### PR DESCRIPTION
Combines the functionality of [CJB Show Item Sell Price](https://www.nexusmods.com/stardewvalley/mods/5) and this mod. When you have a shipping bin full of random bits and bobs, it's useful to know if it'll make enough money for whatever you have planned for the next day.

I'm a software developer, but don't have prior experience with C#, .NET or Stardew modding, so apologies in advance if the code does not follow best practices :sweat_smile: 

![Screenshot from 2025-04-10 11-46-56](https://github.com/user-attachments/assets/98dec29a-5173-442a-9ac7-620eabd53b06)
![Screenshot from 2025-04-10 11-46-49](https://github.com/user-attachments/assets/f4ec9339-3196-47eb-ad54-4bbbfee1c30c)
![Screenshot from 2025-04-10 11-46-44](https://github.com/user-attachments/assets/66f6eed7-d1ef-43f5-86c2-2c5fdf7d8ae6)
