### PR TITLE
[Content Patcher] patch export: Use DataLoader to guess the type of Data assets 

### DIFF
--- a/ContentPatcher/Framework/Commands/Commands/ExportCommand.cs
+++ b/ContentPatcher/Framework/Commands/Commands/ExportCommand.cs
@@ -346,6 +346,7 @@ internal class ExportCommand : BaseCommand
     {
         IAssetName assetName = this.ContentHelper.ParseAssetName(asset);
 
+        // based on path
         if (assetName.IsDirectlyUnderPath("Maps"))
             return [typeof(Map), typeof(Texture2D)];
 
@@ -364,20 +365,20 @@ internal class ExportCommand : BaseCommand
             assetName.IsDirectlyUnderPath("Characters/Dialogue")
             || assetName.IsDirectlyUnderPath("Characters/schedules")
             || assetName.IsDirectlyUnderPath("Data/Events")
-            || assetName.IsDirectlyUnderPath("Data/festivals")
+            || assetName.IsDirectlyUnderPath("Data/Festivals")
         )
             return [typeof(Dictionary<string, string>)];
 
+        // based on DataLoader method
         if (assetName.IsDirectlyUnderPath("Data"))
         {
             string name = assetName.BaseName["Data/".Length..];
-            // No vanilla data asset has `_` in its name, but DataLoader uses it in a few places for subfolder assets, eg 'Festivals_FestivalDates'
-            if (name.Contains('_')) return null;
-            var reflectionType = typeof(DataLoader).GetMethods().FirstOrDefault(type => type.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
-            if (reflectionType != null)
-            {
-                return [reflectionType.ReturnType];
-            }
+            if (name.Contains('_'))
+                return null; // no vanilla data asset has `_` in its name, but DataLoader uses it for subfolders like 'Festivals_FestivalDates'
+
+            MethodInfo? method = typeof(DataLoader).GetMethod(name, BindingFlags.Public | BindingFlags.Static | BindingFlags.IgnoreCase);
+            if (method != null)
+                return [method.ReturnType];
         }
 
         return null;

--- a/ContentPatcher/Framework/Commands/Commands/ExportCommand.cs
+++ b/ContentPatcher/Framework/Commands/Commands/ExportCommand.cs
@@ -368,6 +368,18 @@ internal class ExportCommand : BaseCommand
         )
             return [typeof(Dictionary<string, string>)];
 
+        if (assetName.IsDirectlyUnderPath("Data"))
+        {
+            string name = assetName.BaseName["Data/".Length..];
+            // No vanilla data asset has `_` in its name, but DataLoader uses it in a few places for subfolder assets, eg 'Festivals_FestivalDates'
+            if (name.Contains('_')) return null;
+            var reflectionType = typeof(DataLoader).GetMethods().FirstOrDefault(type => type.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
+            if (reflectionType != null)
+            {
+                return [reflectionType.ReturnType];
+            }
+        }
+
         return null;
     }
 


### PR DESCRIPTION
This fixes errors when Content Patcher (or other mods) are handling the load of non-propagated vanilla assets and rely on the caller type being correct.

Example logs with this active:
https://smapi.io/log/101b626527f8496399be999bbb62bd95?Levels=trace%7Edebug%7Einfo%7Ewarn%7Eerror%7Ealert%7Ecritical&Page=8&PerPage=1000
(This was prior to the handler being case insensitive)
Initially had nothing loading Data/FishPondData so command runs fine, but I added an empty load patch to a random content pack and it stopped working when the wrong case (i.e. my logic wasn't changing the type away from object).

https://smapi.io/log/9b9ea334479443d79201663b20017311?Levels=trace%7Edebug%7Einfo%7Ewarn%7Eerror%7Ealert%7Ecritical&Page=7&PerPage=1000
(this is 1:1 what the current PR is)