### PR TITLE
[ContentPatcher] Add preview images and pages config schema

### DIFF
--- a/Common/Integrations/GenericModConfigMenu/GenericModConfigMenuIntegration.cs
+++ b/Common/Integrations/GenericModConfigMenu/GenericModConfigMenuIntegration.cs
@@ -1,6 +1,9 @@
 using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
 using StardewModdingAPI.Utilities;
+using StardewValley;
 
 namespace Pathoschild.Stardew.Common.Integrations.GenericModConfigMenu;
 
@@ -232,6 +235,51 @@ internal class GenericModConfigMenuIntegration<TConfig> : BaseIntegration<IGener
                 setValue: val => set(this.GetConfig(), val)
             );
         }
+
+        return this;
+    }
+
+
+    /// <summary>Add an image to the form</summary>
+    /// <param name="texture">Texture to display</param>
+    /// <param name="texturePixelArea">Texture source area to display</param>
+    /// <param name="scale">Draw scale, default <see cref="Game1.pixelZoom"/></param>
+    /// <param name="enable">Whether the field is enabled.</param>
+    public GenericModConfigMenuIntegration<TConfig> AddImage(Func<Texture2D> texture, Rectangle? texturePixelArea = null, int scale = Game1.pixelZoom, bool enable = true)
+    {
+        this.AssertLoaded();
+
+        if (enable)
+        {
+            this.ModApi.AddImage(
+                mod: this.ConsumerManifest,
+                texture: texture,
+                texturePixelArea: texturePixelArea,
+                scale: scale
+            );
+        }
+
+        return this;
+    }
+
+
+    /// <summary>Add a subpage to the form</summary>
+    /// <param name="pageId">Unique id of page</param>
+    /// <param name="title">The label text to show in page link and page title.</param>
+    /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field.</param>
+    /// <param name="pageContent">Callback that adds the child config options</param>
+    /// <param name="enable">Whether the field is enabled.</param>
+    public GenericModConfigMenuIntegration<TConfig> AddPage(string pageId, Func<string> title, Func<string>? tooltip, Action<GenericModConfigMenuIntegration<TConfig>> pageContent, bool enable = true)
+    {
+        this.AssertLoaded();
+
+        if (!enable)
+            return this;
+
+        this.ModApi.AddPageLink(this.ConsumerManifest, pageId, title, tooltip);
+        this.ModApi.AddPage(this.ConsumerManifest, pageId, title);
+        pageContent(this);
+        this.ModApi.AddPage(this.ConsumerManifest, "");
 
         return this;
     }

--- a/Common/Integrations/GenericModConfigMenu/IGenericModConfigMenuApi.cs
+++ b/Common/Integrations/GenericModConfigMenu/IGenericModConfigMenuApi.cs
@@ -1,6 +1,9 @@
 using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
 using StardewModdingAPI.Utilities;
+using StardewValley;
 
 namespace Pathoschild.Stardew.Common.Integrations.GenericModConfigMenu;
 
@@ -34,6 +37,14 @@ public interface IGenericModConfigMenuApi
     /// <param name="mod">The mod's manifest.</param>
     /// <param name="text">The paragraph text to display.</param>
     void AddParagraph(IManifest mod, Func<string> text);
+
+
+    /// <summary>Add an image at the current position in the form.</summary>
+    /// <param name="mod">The mod's manifest.</param>
+    /// <param name="texture">The image texture to display.</param>
+    /// <param name="texturePixelArea">The pixel area within the texture to display, or <c>null</c> to show the entire image.</param>
+    /// <param name="scale">The zoom factor to apply to the image.</param>
+    void AddImage(IManifest mod, Func<Texture2D> texture, Rectangle? texturePixelArea = null, int scale = Game1.pixelZoom);
 
     /// <summary>Add a boolean option at the current position in the form.</summary>
     /// <param name="mod">The mod's manifest.</param>
@@ -89,4 +100,22 @@ public interface IGenericModConfigMenuApi
     /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
     /// <param name="fieldId">The unique field ID for use with <c>OnFieldChanged</c>, or <c>null</c> to auto-generate a randomized ID.</param>
     void AddKeybindList(IManifest mod, Func<KeybindList> getValue, Action<KeybindList> setValue, Func<string> name, Func<string>? tooltip = null, string? fieldId = null);
+
+    /****
+    ** Multi-page management
+    ****/
+    /// <summary>Start a new page in the mod's config UI, or switch to that page if it already exists. All options registered after this will be part of that page.</summary>
+    /// <param name="mod">The mod's manifest.</param>
+    /// <param name="pageId">The unique page ID.</param>
+    /// <param name="pageTitle">The page title shown in its UI, or <c>null</c> to show the <paramref name="pageId"/> value.</param>
+    /// <remarks>You must also call <see cref="AddPageLink"/> to make the page accessible. This is only needed to set up a multi-page config UI. If you don't call this method, all options will be part of the mod's main config UI instead.</remarks>
+    void AddPage(IManifest mod, string pageId, Func<string>? pageTitle = null);
+
+    /// <summary>Add a link to a page added via <see cref="AddPage"/> at the current position in the form.</summary>
+    /// <param name="mod">The mod's manifest.</param>
+    /// <param name="pageId">The unique ID of the page to open when the link is clicked.</param>
+    /// <param name="text">The link text shown in the form.</param>
+    /// <param name="tooltip">The tooltip text shown when the cursor hovers on the link, or <c>null</c> to disable the tooltip.</param>
+    void AddPageLink(IManifest mod, string pageId, Func<string> text, Func<string>? tooltip = null);
+
 }

--- a/ContentPatcher/Framework/ConfigFileHandler.cs
+++ b/ContentPatcher/Framework/ConfigFileHandler.cs
@@ -161,7 +161,9 @@ internal class ConfigFileHandler
                 allowBlank: field.AllowBlank,
                 allowMultiple: field.AllowMultiple,
                 description: field.Description,
-                section: field.Section
+                section: field.Section,
+                page: field.Page,
+                previewImages: field.PreviewImages
             );
         }
 

--- a/ContentPatcher/Framework/ConfigModels/ConfigField.cs
+++ b/ContentPatcher/Framework/ConfigModels/ConfigField.cs
@@ -31,6 +31,11 @@ internal class ConfigField
     /// <summary>An optional section key to group related fields.</summary>
     public string? Section { get; }
 
+    /// <summary>An optional page key to group related fields.</summary>
+    public string? Page { get; }
+
+    /// <summary>An optional list of preview image definitions that will be displayed on the config menu.</summary>
+    public IList<ConfigPreviewImage>? PreviewImages { get; }
 
     /*********
     ** Public methods
@@ -43,7 +48,8 @@ internal class ConfigField
     /// <param name="allowMultiple">Whether the player can specify multiple values for this field.</param>
     /// <param name="description">An optional explanation of the config field for players.</param>
     /// <param name="section">An optional section key to group related fields.</param>
-    public ConfigField(IInvariantSet? allowValues, IInvariantSet? defaultValues, IInvariantSet? value, bool allowBlank, bool allowMultiple, string? description, string? section)
+    public ConfigField(IInvariantSet? allowValues, IInvariantSet? defaultValues, IInvariantSet? value, bool allowBlank, bool allowMultiple, string? description, string? section,
+        string? page, IList<ConfigPreviewImage>? previewImages)
     {
         this.AllowValues = allowValues ?? InvariantSets.Empty;
         this.DefaultValues = defaultValues ?? InvariantSets.Empty;
@@ -52,6 +58,8 @@ internal class ConfigField
         this.AllowMultiple = allowMultiple;
         this.Description = description;
         this.Section = section;
+        this.Page = page;
+        this.PreviewImages = previewImages;
     }
 
     /// <summary>Get whether the field represents a boolean value.</summary>

--- a/ContentPatcher/Framework/ConfigModels/ConfigPreviewImage.cs
+++ b/ContentPatcher/Framework/ConfigModels/ConfigPreviewImage.cs
@@ -1,0 +1,24 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
+using StardewValley;
+
+namespace ContentPatcher.Framework.ConfigModels;
+
+/// <summary>
+/// Config preview image model
+/// </summary>
+/// <param name="Target"></param>
+/// <param name="SourceRect"></param>
+public record ConfigPreviewImage(string Target, Rectangle? SourceRect, int Scale = Game1.pixelZoom)
+{
+    private IAssetName? AssetName = null;
+
+    public Texture2D GetPreviewTexture(IGameContentHelper gameContentHelper)
+    {
+        this.AssetName ??= gameContentHelper.ParseAssetName(this.Target);
+        if (gameContentHelper.DoesAssetExist<Texture2D>(this.AssetName))
+            return gameContentHelper.Load<Texture2D>(this.AssetName);
+        return Game1.staminaRect;
+    }
+}

--- a/ContentPatcher/Framework/ConfigModels/ConfigSchemaFieldConfig.cs
+++ b/ContentPatcher/Framework/ConfigModels/ConfigSchemaFieldConfig.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace ContentPatcher.Framework.ConfigModels;
 
 /// <summary>The raw schema for a field in the <c>config.json</c> file.</summary>
@@ -24,6 +26,11 @@ internal class ConfigSchemaFieldConfig
     /// <summary>An optional section key to group related fields.</summary>
     public string? Section { get; }
 
+    /// <summary>An optional page key to group related fields.</summary>
+    public string? Page { get; }
+
+    /// <summary>An optional list of preview image definitions that will be displayed on the config menu.</summary>
+    public IList<ConfigPreviewImage>? PreviewImages { get; }
 
     /*********
     ** Accessors
@@ -35,7 +42,7 @@ internal class ConfigSchemaFieldConfig
     /// <param name="allowMultiple">Whether the player can specify multiple values for this field.</param>
     /// <param name="description">An optional explanation of the config field for players.</param>
     /// <param name="section">An optional section key to group related fields.</param>
-    public ConfigSchemaFieldConfig(string allowValues, string @default, bool allowBlank, bool allowMultiple, string description, string section)
+    public ConfigSchemaFieldConfig(string allowValues, string @default, bool allowBlank, bool allowMultiple, string description, string section, string page, IList<ConfigPreviewImage>? previewImages)
     {
         this.AllowValues = allowValues;
         this.Default = @default;
@@ -43,5 +50,7 @@ internal class ConfigSchemaFieldConfig
         this.AllowMultiple = allowMultiple;
         this.Description = description;
         this.Section = section;
+        this.Page = page;
+        this.PreviewImages = previewImages;
     }
 }

--- a/ContentPatcher/Framework/GenericModConfigMenuIntegrationForContentPack.cs
+++ b/ContentPatcher/Framework/GenericModConfigMenuIntegrationForContentPack.cs
@@ -48,7 +48,7 @@ internal class GenericModConfigMenuIntegrationForContentPack : IGenericModConfig
     public void Register(TConfigMenu menu, IMonitor monitor)
     {
         // get fields by section
-        InvariantDictionary<InvariantDictionary<InvariantDictionary<ConfigField>>> fieldsByPageBySection = new() { [""] = new() };
+        InvariantDictionary<InvariantDictionary<InvariantDictionary<ConfigField>>> fieldsByPageBySection = [];
         foreach (var (name, config) in this.Config)
         {
             string pageId = config.Page?.Trim() ?? "";
@@ -195,7 +195,7 @@ internal class GenericModConfigMenuIntegrationForContentPack : IGenericModConfig
         }
 
         // image for preview image
-        if (field.PreviewImages?.Any() ?? false)
+        if (field.PreviewImages != null)
         {
             foreach (var image in field.PreviewImages)
             {

--- a/ContentPatcher/Framework/GenericModConfigMenuIntegrationForContentPack.cs
+++ b/ContentPatcher/Framework/GenericModConfigMenuIntegrationForContentPack.cs
@@ -25,6 +25,9 @@ internal class GenericModConfigMenuIntegrationForContentPack : IGenericModConfig
     /// <summary>Parse a comma-delimited set of case-insensitive condition values.</summary>
     private readonly Func<string, IInvariantSet> ParseCommaDelimitedField;
 
+    /// <summary>Game content helper.</summary>
+    private readonly IGameContentHelper GameContent;
+
 
     /*********
     ** Public methods
@@ -33,41 +36,49 @@ internal class GenericModConfigMenuIntegrationForContentPack : IGenericModConfig
     /// <param name="contentPack">The content pack whose config is being managed.</param>
     /// <param name="parseCommaDelimitedField">The Generic Mod Config Menu integration.</param>
     /// <param name="config">The config model.</param>
-    public GenericModConfigMenuIntegrationForContentPack(IContentPack contentPack, Func<string, IInvariantSet> parseCommaDelimitedField, InvariantDictionary<ConfigField> config)
+    public GenericModConfigMenuIntegrationForContentPack(IContentPack contentPack, Func<string, IInvariantSet> parseCommaDelimitedField, InvariantDictionary<ConfigField> config, IGameContentHelper gameContent)
     {
         this.ContentPack = contentPack;
         this.Config = config;
         this.ParseCommaDelimitedField = parseCommaDelimitedField;
+        this.GameContent = gameContent;
     }
 
     /// <inheritdoc />
     public void Register(TConfigMenu menu, IMonitor monitor)
     {
-        menu.Register();
-
         // get fields by section
-        InvariantDictionary<InvariantDictionary<ConfigField>> fieldsBySection = new() { [""] = new() };
+        InvariantDictionary<InvariantDictionary<InvariantDictionary<ConfigField>>> fieldsByPageBySection = new() { [""] = new() };
         foreach (var (name, config) in this.Config)
         {
-            string sectionId = config.Section?.Trim() ?? "";
+            string pageId = config.Page?.Trim() ?? "";
+            if (!fieldsByPageBySection.TryGetValue(pageId, out InvariantDictionary<InvariantDictionary<ConfigField>>? page))
+                fieldsByPageBySection[pageId] = page = new();
 
-            if (!fieldsBySection.TryGetValue(sectionId, out InvariantDictionary<ConfigField>? section))
-                fieldsBySection[sectionId] = section = new();
+            string sectionId = config.Section?.Trim() ?? "";
+            if (!page.TryGetValue(sectionId, out InvariantDictionary<ConfigField>? section))
+                page[sectionId] = section = new();
 
             section[name] = config;
         }
 
+        // no configs to show, exit
+        if (fieldsByPageBySection.Count == 0)
+            return;
+
+        menu.Register();
+
         // add section/field elements
-        foreach ((string sectionId, InvariantDictionary<ConfigField> fields) in fieldsBySection)
+        foreach ((string pageId, InvariantDictionary<InvariantDictionary<ConfigField>> pages) in fieldsByPageBySection.OrderBy(kv => kv.Key))
         {
-            if (!fields.Any())
-                continue;
-
-            if (sectionId != "")
-                this.AddSection(menu, sectionId);
-
-            foreach ((string name, ConfigField config) in fields)
-                this.AddField(menu, name, config);
+            if (pageId == "")
+            {
+                this.AddPageElements(menu, pages);
+            }
+            else
+            {
+                this.AddPage(menu, pageId, pages);
+            }
         }
     }
 
@@ -182,6 +193,19 @@ internal class GenericModConfigMenuIntegrationForContentPack : IGenericModConfig
                 formatAllowedValue: GetValueText
             );
         }
+
+        // image for preview image
+        if (field.PreviewImages?.Any() ?? false)
+        {
+            foreach (var image in field.PreviewImages)
+            {
+                menu.AddImage(
+                    texture: () => image.GetPreviewTexture(this.GameContent),
+                    texturePixelArea: image.SourceRect,
+                    scale: image.Scale
+                );
+            }
+        }
     }
 
     /// <summary>Register a config menu section with Generic Mod Config Menu.</summary>
@@ -193,6 +217,31 @@ internal class GenericModConfigMenuIntegrationForContentPack : IGenericModConfig
             text: () => this.TryTranslate($"config.section.{name}.name", name),
             tooltip: () => this.TryTranslate($"config.section.{name}.description", null)
         );
+    }
+
+    private void AddPage(TConfigMenu menu, string pageId, InvariantDictionary<InvariantDictionary<ConfigField>> pages)
+    {
+        menu.AddPage(
+            pageId,
+            title: () => this.TryTranslate($"config.page.{pageId}.name", pageId),
+            tooltip: () => this.TryTranslate($"config.page.{pageId}.description", null),
+            (pageMenu) => this.AddPageElements(pageMenu, pages)
+        );
+    }
+
+    private void AddPageElements(TConfigMenu menu, InvariantDictionary<InvariantDictionary<ConfigField>> pages)
+    {
+        foreach ((string sectionId, InvariantDictionary<ConfigField> fields) in pages)
+        {
+            if (!fields.Any())
+                continue;
+
+            if (sectionId != "")
+                this.AddSection(menu, sectionId);
+
+            foreach ((string name, ConfigField config) in fields)
+                this.AddField(menu, name, config);
+        }
     }
 
     /// <summary>Get a translation if it exists, else get the fallback text.</summary>

--- a/ContentPatcher/ModEntry.cs
+++ b/ContentPatcher/ModEntry.cs
@@ -320,7 +320,7 @@ internal class ModEntry : Mod
                 if (!api.IsLoaded)
                     break;
 
-                var configMenu = new GenericModConfigMenuIntegrationForContentPack(contentPack.ContentPack, this.ParseCommaDelimitedField, config);
+                var configMenu = new GenericModConfigMenuIntegrationForContentPack(contentPack.ContentPack, this.ParseCommaDelimitedField, config, this.Helper.GameContent);
                 configMenu.Register(api, this.Monitor);
             }
         }


### PR DESCRIPTION
Adds new features to CP config schema

Preview Images: content pack can specify a model which defines a preview image to show
- Target: asset target of a Texture2D
- SourceRect: source rectangle
- Scale: draw scale

Pages: content pack can specify a string page id
- Sections go inside pages
- The page title/description is translated with these keys:
  - `config.page.{pageId}.name`
  - `config.page.{pageId}.description`
 
Sample pack:
[[CP] Config Preview Image.zip](https://github.com/user-attachments/files/19919199/CP.Config.Preview.Image.zip)

