### PR TITLE
Preserve property references when tokens are in the name

### DIFF
--- a/ContentPatcher/Framework/TokenParser.cs
+++ b/ContentPatcher/Framework/TokenParser.cs
@@ -25,8 +25,8 @@ internal class TokenParser
     /// <summary>Handles parsing raw strings into tokens.</summary>
     private readonly Lexer Lexer = Lexer.Instance;
 
-    /// <summary>Stores the Reflection accessors to the JProperty _name field</summary>
-    private static FieldInfo JPropertyName;
+    /// <summary>The private <c>_name</c> field on <see cref="JProperty"/> instances, used to update tokenized property names.</summary>
+    private static readonly FieldInfo PropertyNameField;
 
 
     /*********
@@ -48,9 +48,12 @@ internal class TokenParser
     /*********
     ** Public methods
     *********/
+    /// <summary>Initialize static fields.</summary>
     static TokenParser()
     {
-        JPropertyName = typeof(JProperty).GetField("_name", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        TokenParser.PropertyNameField =
+            typeof(JProperty).GetField("_name", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"Failed to initialize token parser: required field '{nameof(JProperty)}._name' not found");
     }
 
     /// <summary>Construct an instance.</summary>
@@ -279,13 +282,12 @@ internal class TokenParser
                 break;
 
             case JObject objToken:
-                foreach (JProperty p in objToken.Properties().ToArray())
+                foreach (JProperty property in objToken.Properties().ToArray())
                 {
-                    JProperty property = p;
-                    LogPathBuilder localPath = path.With(p.Name);
+                    LogPathBuilder localPath = path.With(property.Name);
 
                     // resolve property name
-                    if (!this.TryInjectJsonProxyField(property.Name, assumeModIds, val => JPropertyName.SetValue(property, val), localPath.With("key"), out error, out TokenizableProxy? proxyName))
+                    if (!this.TryInjectJsonProxyField(property.Name, assumeModIds, val => TokenParser.PropertyNameField.SetValue(property, val), localPath.With("key"), out error, out TokenizableProxy? proxyName))
                         return false;
                     fields.Add(proxyName);
 

--- a/ContentPatcher/Framework/TokenParser.cs
+++ b/ContentPatcher/Framework/TokenParser.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Reflection;
 using ContentPatcher.Framework.Conditions;
 using ContentPatcher.Framework.Lexing;
 using ContentPatcher.Framework.Lexing.LexTokens;
@@ -24,6 +25,9 @@ internal class TokenParser
     /// <summary>Handles parsing raw strings into tokens.</summary>
     private readonly Lexer Lexer = Lexer.Instance;
 
+    /// <summary>Stores the Reflection accessors to the JProperty _name field</summary>
+    private static FieldInfo JPropertyName;
+
 
     /*********
     ** Accessors
@@ -44,6 +48,11 @@ internal class TokenParser
     /*********
     ** Public methods
     *********/
+    static TokenParser()
+    {
+        JPropertyName = typeof(JProperty).GetField("_name", BindingFlags.NonPublic | BindingFlags.Instance)!;
+    }
+
     /// <summary>Construct an instance.</summary>
     /// <param name="tokenContext">The tokens available for this content pack.</param>
     /// <param name="forMod">The manifest for the content pack being parsed.</param>
@@ -276,7 +285,7 @@ internal class TokenParser
                     LogPathBuilder localPath = path.With(p.Name);
 
                     // resolve property name
-                    if (!this.TryInjectJsonProxyField(property.Name, assumeModIds, val => property = this.ReplaceJsonProperty(property, new JProperty(val, property.Value)), localPath.With("key"), out error, out TokenizableProxy? proxyName))
+                    if (!this.TryInjectJsonProxyField(property.Name, assumeModIds, val => JPropertyName.SetValue(property, val), localPath.With("key"), out error, out TokenizableProxy? proxyName))
                         return false;
                     fields.Add(proxyName);
 
@@ -344,15 +353,5 @@ internal class TokenParser
             setValue(tokenStr.Value!);
         parsed = null;
         return true;
-    }
-
-    /// <summary>Replace a JSON property with a new one.</summary>
-    /// <param name="oldProperty">The JSON property to replace.</param>
-    /// <param name="newProperty">The new JSON property to inject.</param>
-    /// <returns>Returns the injected property.</returns>
-    private JProperty ReplaceJsonProperty(JProperty oldProperty, JProperty newProperty)
-    {
-        oldProperty.Replace(newProperty);
-        return newProperty;
     }
 }


### PR DESCRIPTION
Fixes #1056

Example patch:
```json
{
    "Action": "EditData",
    "Target": "{{PATH}}/Data",
    "Entries": {
         "SimpleDictionary": {
            "UntokenisedKey_SimpleDictionary": "{{PATH}}/String",
            "{{KEY}}_SimpleDictionary": "{{PATH}}/String"
        }
    }
}
```

When the nested key (`{{KEY}}_SimpleDictionary`) contains tokens (that are mutable) it will save a Setter method as a contextual so that when the token changes, it knows to replace the JProperty with a new one with the correct new name.

The problem is, the code for handling when the value contains a token does the same thing, though doesn't replace the JProperty it just sets the value.

When the key changes (i.e. resolves its first value) it will call that setter, replacing the JProperty and now the setter on the value is pointing to an unmounted JProperty and is for all intents and purposes a noop.

This change preserves the property reference by using reflection to set the name instead of replacing the property.