### PR TITLE
[LookupAnything] Add support for item query style fish pond drops introduced in 1.6.9

### DIFF
--- a/Common/CommonHelper.cs
+++ b/Common/CommonHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -119,13 +120,48 @@ internal static class CommonHelper
     }
 
     /****
-    ** Fonts
+    ** Display text
     ****/
     /// <summary>Get the dimensions of a space character.</summary>
     /// <param name="font">The font to measure.</param>
     public static float GetSpaceWidth(SpriteFont font)
     {
         return font.MeasureString("A B").X - font.MeasureString("AB").X;
+    }
+
+    /// <summary>Get a user-friendly percentage number without the '%' symbol, like <c>15</c> for 15%.</summary>
+    /// <param name="chance">The probability to represent, as a value between 0 (never) and 1 (always).</param>
+    public static string GetFormattedPercentageNumber(float chance)
+    {
+        float percent = chance * 100;
+
+        switch (percent)
+        {
+            // snap to valid value
+            case <= 0:
+                return "0";
+            case >= 100:
+                return "100";
+
+            // if less than 1%, round to one significant figure
+            case < 1f:
+                for (int precision = 3; precision < 28; precision++)
+                {
+                    decimal result = Math.Round((decimal)percent, precision);
+                    if (result > 0)
+                        return result.ToString("0.".PadRight(precision + 2, '#'));
+                }
+
+                return percent.ToString(CultureInfo.InvariantCulture);
+
+            // if less than 2%, round to one decimal place
+            case < 1.95f:
+                return percent.ToString("#.#");
+
+            // else round to nearest integer
+            default:
+                return percent.ToString("#");
+        }
     }
 
     /****

--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -157,20 +157,10 @@ internal class DataParser
             IList<ItemQueryResult> itemQueryResults = ItemQueryResolver.TryResolve(drop, new ItemQueryContext(), ItemQuerySearchMode.AllOfTypeItem);
 
             float chance = drop.Chance * (1f / itemQueryResults.Count);
-            // edge case, each drop chance is < 0.01 and would display as 0%
-            if (chance < 0.01)
+            foreach (ItemQueryResult result in itemQueryResults)
             {
-                yield return new FishPondDropData(drop.RequiredPopulation, drop.Precedence, ItemRegistry.Create($"{drop.Id}-{drop.ItemId}"), drop.MinStack, drop.MaxStack, drop.Chance, drop.Condition);
-            }
-            else
-            {
-                foreach (ItemQueryResult res in itemQueryResults)
-                {
-                    if (res.Item is Item item)
-                    {
-                        yield return new FishPondDropData(drop.RequiredPopulation, drop.Precedence, item, drop.MinStack, drop.MaxStack, chance, drop.Condition);
-                    }
-                }
+                if (result.Item is Item item)
+                    yield return new FishPondDropData(drop.RequiredPopulation, drop.Precedence, item, drop.MinStack, drop.MaxStack, chance, drop.Condition);
             }
         }
     }

--- a/LookupAnything/DataParser.cs
+++ b/LookupAnything/DataParser.cs
@@ -154,11 +154,23 @@ internal class DataParser
             if (drop is null)
                 continue;
 
-            string[] itemIds = this.GetItemSpawnFieldIds(drop.RandomItemId, drop.ItemId);
-            foreach (string itemId in itemIds)
+            IList<ItemQueryResult> itemQueryResults = ItemQueryResolver.TryResolve(drop, new ItemQueryContext(), ItemQuerySearchMode.AllOfTypeItem);
+
+            float chance = drop.Chance * (1f / itemQueryResults.Count);
+            // edge case, each drop chance is < 0.01 and would display as 0%
+            if (chance < 0.01)
             {
-                float chance = drop.Chance * (1f / itemIds.Length);
-                yield return new FishPondDropData(drop.RequiredPopulation, itemId, drop.MinStack, drop.MaxStack, chance, drop.Condition);
+                yield return new FishPondDropData(drop.RequiredPopulation, drop.Precedence, ItemRegistry.Create($"{drop.Id}-{drop.ItemId}"), drop.MinStack, drop.MaxStack, drop.Chance, drop.Condition);
+            }
+            else
+            {
+                foreach (ItemQueryResult res in itemQueryResults)
+                {
+                    if (res.Item is Item item)
+                    {
+                        yield return new FishPondDropData(drop.RequiredPopulation, drop.Precedence, item, drop.MinStack, drop.MaxStack, chance, drop.Condition);
+                    }
+                }
             }
         }
     }
@@ -791,20 +803,6 @@ internal class DataParser
         }
 
         return recipes.ToArray();
-    }
-
-    /// <summary>Get the item IDs that can be produced by item spawn fields.</summary>
-    /// <param name="randomItemIds">The item IDs to randomly choose from. If set, this overrides <paramref name="itemId"/>.</param>
-    /// <param name="itemId">The item ID to produce by default.</param>
-    public string[] GetItemSpawnFieldIds(List<string?>? randomItemIds, string? itemId)
-    {
-        if (randomItemIds is not null)
-            return randomItemIds.Where(id => id is not null).ToArray()!;
-
-        if (itemId is not null)
-            return [itemId];
-
-        return [];
     }
 
 

--- a/LookupAnything/Framework/Data/FishPondDropData.cs
+++ b/LookupAnything/Framework/Data/FishPondDropData.cs
@@ -23,16 +23,17 @@ internal record FishPondDropData : ItemDropData
     ** Public methods
     *********/
     /// <summary>Construct an instance.</summary>
-    /// <param name="minPopulation">The minimum population needed for the item to drop.</param>
-    /// <param name="itemID">The unqualified item ID.</param>
-    /// <param name="minDrop">The minimum number to drop.</param>
-    /// <param name="maxDrop">The maximum number to drop.</param>
-    /// <param name="probability">The probability that the item will be dropped.</param>
-    /// <param name="conditions">If set, a game state query which indicates when this entry should be applied.</param>
-    public FishPondDropData(int minPopulation, int precedence, Item samppleItem, int minDrop, int maxDrop, float probability, string? conditions)
-        : base(samppleItem.QualifiedItemId, minDrop, maxDrop, probability, conditions)
+    /// <param name="minPopulation"><inheritdoc cref="MinPopulation" path="/summary"/></param>
+    /// <param name="precedence"><inheritdoc cref="Precedence" path="/summary"/></param>
+    /// <param name="sampleItem"><inheritdoc cref="SampleItem" path="/summary"/></param>
+    /// <param name="minDrop"><inheritdoc cref="ItemDropData.MinDrop" path="/summary"/></param>
+    /// <param name="maxDrop"><inheritdoc cref="ItemDropData.MaxDrop" path="/summary"/></param>
+    /// <param name="probability"><inheritdoc cref="ItemDropData.Probability" path="/summary"/></param>
+    /// <param name="conditions"><inheritdoc cref="ItemDropData.Conditions" path="/summary"/></param>
+    public FishPondDropData(int minPopulation, int precedence, Item sampleItem, int minDrop, int maxDrop, float probability, string? conditions)
+        : base(sampleItem.QualifiedItemId, minDrop, maxDrop, probability, conditions)
     {
-        this.SampleItem = samppleItem;
+        this.SampleItem = sampleItem;
         this.MinPopulation = Math.Max(minPopulation, 1); // rule only applies if the pond has at least one fish, so assume minimum of 1 to avoid player confusion
         this.Precedence = precedence;
     }

--- a/LookupAnything/Framework/Data/FishPondDropData.cs
+++ b/LookupAnything/Framework/Data/FishPondDropData.cs
@@ -1,4 +1,5 @@
 using System;
+using StardewValley;
 
 namespace Pathoschild.Stardew.LookupAnything.Framework.Data;
 
@@ -8,8 +9,14 @@ internal record FishPondDropData : ItemDropData
     /*********
     ** Accessors
     *********/
+    /// <summary>An instance of the produced item.</summary>
+    public Item SampleItem { get; }
+
     /// <summary>The minimum population needed for the item to drop.</summary>
     public int MinPopulation { get; }
+
+    /// <summary>Order by which drops are checked, lower is earlier.</summary>
+    public int Precedence { get; }
 
 
     /*********
@@ -22,9 +29,11 @@ internal record FishPondDropData : ItemDropData
     /// <param name="maxDrop">The maximum number to drop.</param>
     /// <param name="probability">The probability that the item will be dropped.</param>
     /// <param name="conditions">If set, a game state query which indicates when this entry should be applied.</param>
-    public FishPondDropData(int minPopulation, string itemID, int minDrop, int maxDrop, float probability, string? conditions)
-        : base(itemID, minDrop, maxDrop, probability, conditions)
+    public FishPondDropData(int minPopulation, int precedence, Item samppleItem, int minDrop, int maxDrop, float probability, string? conditions)
+        : base(samppleItem.QualifiedItemId, minDrop, maxDrop, probability, conditions)
     {
+        this.SampleItem = samppleItem;
         this.MinPopulation = Math.Max(minPopulation, 1); // rule only applies if the pond has at least one fish, so assume minimum of 1 to avoid player confusion
+        this.Precedence = precedence;
     }
 }

--- a/LookupAnything/Framework/Fields/FishPondDropsField.cs
+++ b/LookupAnything/Framework/Fields/FishPondDropsField.cs
@@ -51,7 +51,7 @@ internal class FishPondDropsField : GenericField
     {
         this.GameHelper = gameHelper;
         this.Codex = codex;
-        this.Drops = this.GetEntries(currentPopulation, data, fish, gameHelper).OrderBy(data => new ValueTuple<int, int>(data.Precedence, -data.MinPopulation)).ToArray();
+        this.Drops = this.GetEntries(currentPopulation, data, fish, gameHelper).OrderBy(drop => drop.Precedence).ThenByDescending(drop => drop.MinPopulation).ToArray();
         this.HasValue = this.Drops.Any();
         this.Preface = preface;
     }

--- a/LookupAnything/Framework/Fields/FishPondDropsField.cs
+++ b/LookupAnything/Framework/Fields/FishPondDropsField.cs
@@ -126,7 +126,7 @@ internal class FishPondDropsField : GenericField
 
                 // draw text
                 float textIndent = position.X + innerIndent + iconSize.X + 5;
-                string text = I18n.Generic_PercentChanceOf(percent: (int)(Math.Round(drop.Probability, 4) * 100), label: drop.SampleItem.DisplayName);
+                string text = I18n.Generic_PercentChanceOf(percent: CommonHelper.GetFormattedPercentageNumber(drop.Probability), label: drop.SampleItem.DisplayName);
                 if (drop.MinDrop != drop.MaxDrop)
                     text += $" ({I18n.Generic_Range(min: drop.MinDrop, max: drop.MaxDrop)})";
                 else if (drop.MinDrop > 1)

--- a/LookupAnything/Framework/Fields/FishPondDropsField.cs
+++ b/LookupAnything/Framework/Fields/FishPondDropsField.cs
@@ -51,7 +51,7 @@ internal class FishPondDropsField : GenericField
     {
         this.GameHelper = gameHelper;
         this.Codex = codex;
-        this.Drops = this.GetEntries(currentPopulation, data, fish, gameHelper).ToArray();
+        this.Drops = this.GetEntries(currentPopulation, data, fish, gameHelper).OrderBy(data => new ValueTuple<int, int>(data.Precedence, -data.MinPopulation)).ToArray();
         this.HasValue = this.Drops.Any();
         this.Preface = preface;
     }
@@ -190,14 +190,13 @@ internal class FishPondDropsField : GenericField
                     continue; // can never match for this fish
 
                 if (conditions != drop.Conditions)
-                    drop = new FishPondDropData(drop.MinPopulation, drop.ItemId, drop.MinDrop, drop.MaxDrop, drop.Probability, conditions);
+                    drop = new FishPondDropData(drop.MinPopulation, drop.Precedence, drop.SampleItem, drop.MinDrop, drop.MaxDrop, drop.Probability, conditions);
             }
 
             // build drop record
             bool isUnlocked = currentPopulation >= drop.MinPopulation;
-            Item item = ItemRegistry.Create(drop.ItemId);
-            SpriteInfo? sprite = gameHelper.GetSprite(item);
-            yield return new FishPondDrop(drop, item, sprite, isUnlocked);
+            SpriteInfo? sprite = gameHelper.GetSprite(drop.SampleItem);
+            yield return new FishPondDrop(drop, drop.SampleItem, sprite, isUnlocked);
         }
     }
 

--- a/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
+++ b/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
@@ -76,7 +76,7 @@ internal class FishSpawnRulesField : CheckboxListField
         : base(label)
     {
         this.CheckboxLists = spawnConditions;
-        this.HasValue = this.CheckboxLists.Any();
+        this.HasValue = this.CheckboxLists.Any(checkboxList => checkboxList.Checkboxes.Any());
     }
 
     /// <summary>Get the formatted checkbox conditions for all fish in a location.</summary>

--- a/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
+++ b/LookupAnything/Framework/Fields/FishSpawnRulesField.cs
@@ -76,7 +76,7 @@ internal class FishSpawnRulesField : CheckboxListField
         : base(label)
     {
         this.CheckboxLists = spawnConditions;
-        this.HasValue = this.CheckboxLists.Any(checkboxList => checkboxList.Checkboxes.Any());
+        this.HasValue = this.CheckboxLists.Any(checkboxList => checkboxList.Checkboxes.Length > 0);
     }
 
     /// <summary>Get the formatted checkbox conditions for all fish in a location.</summary>

--- a/LookupAnything/Framework/Fields/ItemDropListField.cs
+++ b/LookupAnything/Framework/Fields/ItemDropListField.cs
@@ -100,7 +100,7 @@ internal class ItemDropListField : GenericField
             spriteBatch.DrawSpriteWithin(sprite, position.X, position.Y + height, iconSize, shouldFade ? Color.White * 0.5f : Color.White);
 
             // draw text
-            string text = isGuaranteed ? item.DisplayName : I18n.Generic_PercentChanceOf(percent: (decimal)(Math.Round(drop.Probability, 4) * 100), label: item.DisplayName);
+            string text = isGuaranteed ? item.DisplayName : I18n.Generic_PercentChanceOf(percent: CommonHelper.GetFormattedPercentageNumber(drop.Probability), label: item.DisplayName);
             if (drop.MinDrop != drop.MaxDrop)
                 text += $" ({I18n.Generic_Range(min: drop.MinDrop, max: drop.MaxDrop)})";
             else if (drop.MinDrop > 1)

--- a/LookupAnything/Framework/Fields/Models/FishPondDrop.cs
+++ b/LookupAnything/Framework/Fields/Models/FishPondDrop.cs
@@ -10,9 +10,6 @@ internal record FishPondDrop : FishPondDropData
     /*********
     ** Accessors
     *********/
-    /// <summary>An instance of the produced item.</summary>
-    public Item SampleItem { get; }
-
     /// <summary>The sprite icon to draw.</summary>
     public SpriteInfo? Sprite { get; }
 
@@ -29,9 +26,8 @@ internal record FishPondDrop : FishPondDropData
     /// <param name="sprite">The sprite icon to draw.</param>
     /// <param name="isUnlocked">Whether the item has been unlocked for the current fish pond.</param>
     public FishPondDrop(FishPondDropData data, Item sampleItem, SpriteInfo? sprite, bool isUnlocked)
-        : base(data.MinPopulation, data.ItemId, data.MinDrop, data.MaxDrop, data.Probability, data.Conditions)
+        : base(data.MinPopulation, data.Precedence, sampleItem, data.MinDrop, data.MaxDrop, data.Probability, data.Conditions)
     {
-        this.SampleItem = sampleItem;
         this.Sprite = sprite;
         this.IsUnlocked = isUnlocked;
     }

--- a/Tests.Common/CommonTests/CommonHelperTests.cs
+++ b/Tests.Common/CommonTests/CommonHelperTests.cs
@@ -1,0 +1,58 @@
+using NUnit.Framework;
+using Pathoschild.Stardew.Common;
+
+namespace Pathoschild.Stardew.Tests.Common.CommonTests;
+
+/// <summary>Unit tests for <see cref="CommonHelper"/>.</summary>
+[TestFixture]
+class CommonHelperTests
+{
+    /*********
+    ** Unit tests
+    *********/
+    /****
+    ** GetFormattedPercentageNumber
+    ****/
+    [Test(Description = $"Assert that {nameof(CommonHelper.GetFormattedPercentageNumber)} snaps out-of-range values to 0 or 100.")]
+    [TestCase(-1f, ExpectedResult = "0")]
+    [TestCase(0f, ExpectedResult = "0")]
+    [TestCase(1f, ExpectedResult = "100")]
+    [TestCase(2f, ExpectedResult = "100")]
+    public string GetFormattedPercentageNumber_OutOfRangeValues_SnapToValidValue(float chance)
+    {
+        return CommonHelper.GetFormattedPercentageNumber(chance);
+    }
+
+    [Test]
+    [TestCase(0.021f, ExpectedResult = "2")]
+    [TestCase(0.025f, ExpectedResult = "3")]
+    [TestCase(0.1f, ExpectedResult = "10")]
+    [TestCase(0.5f, ExpectedResult = "50")]
+    [TestCase(0.99f, ExpectedResult = "99")]
+    [TestCase(0.995f, ExpectedResult = "100")]
+    public string GetFormattedPercentageNumber_2PercentOrMore_RoundsToNearestInteger(float chance)
+    {
+        return CommonHelper.GetFormattedPercentageNumber(chance);
+    }
+
+    [Test]
+    [TestCase(0.01f, ExpectedResult = "1")]
+    [TestCase(0.014f, ExpectedResult = "1.4")]
+    [TestCase(0.015f, ExpectedResult = "1.5")]
+    [TestCase(0.0194f, ExpectedResult = "1.9")]
+    [TestCase(0.0195f, ExpectedResult = "2")]
+    public string GetFormattedPercentageNumber_Between1And2Percent_RoundsToOneDecimal(float chance)
+    {
+        return CommonHelper.GetFormattedPercentageNumber(chance);
+    }
+
+    [Test]
+    [TestCase(0.000_01f, ExpectedResult = "0.001")]
+    [TestCase(0.000_000_014f, ExpectedResult = "0.000001")]
+    [TestCase(0.000_000_015f, ExpectedResult = "0.000002")]
+    [TestCase(0.000_000_000_000_000_000_000_000_000_15f, ExpectedResult = "0.00000000000000000000000002")]
+    public string GetFormattedPercentageNumber_Below1Percent_RoundsToFirstSignificantDigit(float chance)
+    {
+        return CommonHelper.GetFormattedPercentageNumber(chance);
+    }
+}


### PR DESCRIPTION
Also fixes spawn rules reporting wrong HasValue and always appearing on items.

![image](https://github.com/user-attachments/assets/8a600113-203c-4718-adad-5ce94b0ae883)
