### PR TITLE
Change NPC "English name" to "internal name" in Content Patcher token docs

### DIFF
--- a/ContentPatcher/docs/author-guide/tokens.md
+++ b/ContentPatcher/docs/author-guide/tokens.md
@@ -1,4 +1,4 @@
-[author guide](../author-guide.md)
+← [author guide](../author-guide.md)
 
 This document lists the tokens available in Content Patcher packs.
 

--- a/ContentPatcher/docs/author-guide/tokens.md
+++ b/ContentPatcher/docs/author-guide/tokens.md
@@ -1,4 +1,4 @@
-← [author guide](../author-guide.md)
+[author guide](../author-guide.md)
 
 This document lists the tokens available in Content Patcher packs.
 

--- a/ContentPatcher/docs/author-guide/tokens.md
+++ b/ContentPatcher/docs/author-guide/tokens.md
@@ -1,4 +1,4 @@
-﻿← [author guide](../author-guide.md)
+← [author guide](../author-guide.md)
 
 This document lists the tokens available in Content Patcher packs.
 
@@ -608,7 +608,7 @@ child.
 <td>
 
 The player's heart level with a given NPC. You can specify the character name as an input argument
-(using their English name regardless of translations), like this:
+(using their internal name regardless of translations), like this:
 
 ```js
 "When": {
@@ -625,7 +625,7 @@ The player's heart level with a given NPC. You can specify the character name as
 <td>
 
 The player's relationship with a given NPC or player. You can specify the character name as part
-of the key (using their English name regardless of translations), like this:
+of the key (using their internal name regardless of translations), like this:
 
 ```js
 "When": {
@@ -652,7 +652,7 @@ Divorced | The player married and then divorced them.
 <td>Roommate</td>
 <td>
 
-The name of the [current or specified player](#target-player)'s NPC roommate (using their English
+The name of the [current or specified player](#target-player)'s NPC roommate (using their internal
 name regardless of translations).
 
 </td>
@@ -664,7 +664,7 @@ name regardless of translations).
 <td>Spouse</td>
 <td>
 
-The name of the [current or specified player](#target-player)'s NPC spouse (using their English
+The name of the [current or specified player](#target-player)'s NPC spouse (using their internal
 name regardless of translations).
 
 </td>


### PR DESCRIPTION
Hi!

(First time creating a pull request for a repo that is not mine, so hopefully I did it correctly!)

I was checking the docs for Content Patcher for my mod, and I noticed that in the tokens.md, the tokens "Hearts", "Relationship", "Roommate", and "Spouse" were referring to the NPC's English name. However, the code is (or, at least, looks like it does; haven't checked that, as my C# knowledge is very poor) checking for the NPC's internal name, no matter what the [display name](https://stardewvalleywiki.com/Modding:NPC_data#Basic_info) is. Therefore, I changed that in the docs, so instead of "(using their English name regardless of translations)", it will be "(using their internal name regardless of translations)".

For any questions regarding this, please ping *@dennis001_81324* (that's me) on SV Discord.

Feel free to adapt, change, not accept, or do whatever you want with my pull request!

StrojvedouciDenis