### PR TITLE
[Content Patcher] Forward patch priorities to SMAPI instead of collapsing to Exclusive/Default

### DIFF
--- a/ContentPatcher/Framework/PatchManager.cs
+++ b/ContentPatcher/Framework/PatchManager.cs
@@ -461,56 +461,62 @@ internal class PatchManager
         where T : notnull
     {
         IAssetName assetName = e.NameWithoutLocale;
-        // split loaders into exclusive (must check) and non-exclusive (forward to SMAPI)
-        const int exclusivePriority = (int)AssetLoadPriority.Exclusive;
-        IPatch[] exclusiveLoaders = loaders.Where(p => p.Priority == exclusivePriority).ToArray<IPatch>();
-        IPatch[] nonExclusiveLoaders = loaders.Where(p => p.Priority != exclusivePriority).ToArray<IPatch>();
 
-        // let SMAPI handle order for non-exclusive loads, but check that their FromFiles exist
-        foreach (LoadPatch candidate in nonExclusiveLoaders)
+        // validate & select loader by priority
+        LoadPatch? loader = null;
+        foreach (LoadPatch candidate in loaders)
         {
+            // skip if patch is invalid
             if (!candidate.FromAssetExists())
             {
                 this.Monitor.Log($"Can't apply load \"{candidate.Path}\" to {candidate.TargetAsset}: the {nameof(PatchConfig.FromFile)} file '{candidate.FromAsset}' doesn't exist.", LogLevel.Warn);
                 continue;
             }
-            e.LoadFrom(
-                load: () => this.ApplyLoad<T>(candidate, assetName)!, // only returns null when invalid, in which case there's no other way to abort
-                priority: (AssetLoadPriority)candidate.Priority,
-                onBehalfOf: candidate.ContentPack.Manifest.UniqueID
-            );
+
+            // skip if we already found a better match
+            if (loader?.Priority > candidate.Priority)
+                continue;
+
+            // abort if we have multiple exclusive patches
+            const int exclusivePriority = (int)AssetLoadPriority.Exclusive;
+            if (candidate.Priority is exclusivePriority && loader?.Priority == exclusivePriority)
+            {
+                IPatch[] exclusiveLoaders = loaders.Where(p => p.Priority == exclusivePriority).ToArray<IPatch>();
+                string[] modNames = exclusiveLoaders.Select(p => p.ContentPack.Manifest.Name).Distinct().OrderByHuman().ToArray();
+                string[] patchNames = exclusiveLoaders.Select(p => p.Path.ToString()).OrderByHuman().ToArray();
+                switch (modNames.Length)
+                {
+                    case 1:
+                        this.Monitor.Log($"'{modNames[0]}' has multiple patches with the '{nameof(AssetLoadPriority.Exclusive)}' priority which load the '{assetName}' asset at the same time ({string.Join(", ", patchNames)}). None will be applied. You should report this to the content pack author.", LogLevel.Error);
+                        break;
+
+                    case 2:
+                        this.Monitor.Log($"Two content packs want to load the '{assetName}' asset with the '{nameof(AssetLoadPriority.Exclusive)}' priority ({string.Join(" and ", modNames)}). Neither will be applied. You should remove one of the content packs, or ask the authors about compatibility.", LogLevel.Error);
+                        this.Monitor.Log($"Affected patches: {string.Join(", ", patchNames)}");
+                        break;
+
+                    default:
+                        this.Monitor.Log($"Multiple content packs want to load the '{assetName}' asset with the '{nameof(AssetLoadPriority.Exclusive)}' priority ({string.Join(", ", modNames)}). None will be applied. You should remove some of the content packs, or ask the authors about compatibility.", LogLevel.Error);
+                        this.Monitor.Log($"Affected patches: {string.Join(", ", patchNames)}");
+                        break;
+                }
+
+                loader = null;
+                break;
+            }
+
+            // else best match so far
+            loader = candidate;
         }
 
-        // apply the one exclusive load, or abort if there is more than one
-        if (exclusiveLoaders.Length == 1)
+        // apply selected load patch
+        if (loader != null)
         {
-            LoadPatch loader = (LoadPatch)exclusiveLoaders[0];
             e.LoadFrom(
                 load: () => this.ApplyLoad<T>(loader, assetName)!, // only returns null when invalid, in which case there's no other way to abort
-                priority: AssetLoadPriority.Exclusive,
+                priority: (AssetLoadPriority)loader.Priority,
                 onBehalfOf: loader.ContentPack.Manifest.UniqueID
             );
-        }
-        else if (exclusiveLoaders.Length > 1)
-        {
-            string[] modNames = exclusiveLoaders.Select(p => p.ContentPack.Manifest.Name).Distinct().OrderByHuman().ToArray();
-            string[] patchNames = exclusiveLoaders.Select(p => p.Path.ToString()).OrderByHuman().ToArray();
-            switch (modNames.Length)
-            {
-                case 1:
-                    this.Monitor.Log($"'{modNames[0]}' has multiple patches with the '{nameof(AssetLoadPriority.Exclusive)}' priority which load the '{assetName}' asset at the same time ({string.Join(", ", patchNames)}). None will be applied. You should report this to the content pack author.", LogLevel.Error);
-                    break;
-
-                case 2:
-                    this.Monitor.Log($"Two content packs want to load the '{assetName}' asset with the '{nameof(AssetLoadPriority.Exclusive)}' priority ({string.Join(" and ", modNames)}). Neither will be applied. You should remove one of the content packs, or ask the authors about compatibility.", LogLevel.Error);
-                    this.Monitor.Log($"Affected patches: {string.Join(", ", patchNames)}");
-                    break;
-
-                default:
-                    this.Monitor.Log($"Multiple content packs want to load the '{assetName}' asset with the '{nameof(AssetLoadPriority.Exclusive)}' priority ({string.Join(", ", modNames)}). None will be applied. You should remove some of the content packs, or ask the authors about compatibility.", LogLevel.Error);
-                    this.Monitor.Log($"Affected patches: {string.Join(", ", patchNames)}");
-                    break;
-            }
         }
 
         // apply edit patches
@@ -520,10 +526,12 @@ internal class PatchManager
             foreach (List<IPatch> group in editGroups)
             {
                 List<IPatch> patches = group; // avoid capturing foreach variable in the deferred callback
+                IPatch samplePatch = patches[0];
+
                 e.Edit(
                     apply: data => this.ApplyEdits<T>(patches, data),
-                    priority: (AssetEditPriority)patches[0].Priority,
-                    onBehalfOf: patches[0].ContentPack.Manifest.UniqueID
+                    priority: (AssetEditPriority)samplePatch.Priority,
+                    onBehalfOf: samplePatch.ContentPack.Manifest.UniqueID
                 );
             }
         }
@@ -665,16 +673,13 @@ internal class PatchManager
         List<List<IPatch>> groups = [];
 
         string? lastModId = null;
-        int? lastPriority = null;
         List<IPatch> group = [];
         foreach (IPatch patch in patches.OrderBy(p => p.Priority))
         {
             string modId = patch.ContentPack.Manifest.UniqueID;
-            // start a new group when modId changes or when priority changes
-            if (modId != lastModId || patch.Priority != lastPriority)
+            if (modId != lastModId)
             {
                 lastModId = modId;
-                lastPriority = patch.Priority;
                 if (group.Count > 0)
                 {
                     groups.Add(group);

--- a/ContentPatcher/Framework/PatchManager.cs
+++ b/ContentPatcher/Framework/PatchManager.cs
@@ -461,62 +461,56 @@ internal class PatchManager
         where T : notnull
     {
         IAssetName assetName = e.NameWithoutLocale;
+        // split loaders into exclusive (must check) and non-exclusive (forward to SMAPI)
+        const int exclusivePriority = (int)AssetLoadPriority.Exclusive;
+        IPatch[] exclusiveLoaders = loaders.Where(p => p.Priority == exclusivePriority).ToArray<IPatch>();
+        IPatch[] nonExclusiveLoaders = loaders.Where(p => p.Priority != exclusivePriority).ToArray<IPatch>();
 
-        // validate & select loader by priority
-        LoadPatch? loader = null;
-        foreach (LoadPatch candidate in loaders)
+        // let SMAPI handle order for non-exclusive loads, but check that their FromFiles exist
+        foreach (LoadPatch candidate in nonExclusiveLoaders)
         {
-            // skip if patch is invalid
             if (!candidate.FromAssetExists())
             {
                 this.Monitor.Log($"Can't apply load \"{candidate.Path}\" to {candidate.TargetAsset}: the {nameof(PatchConfig.FromFile)} file '{candidate.FromAsset}' doesn't exist.", LogLevel.Warn);
                 continue;
             }
-
-            // skip if we already found a better match
-            if (loader?.Priority > candidate.Priority)
-                continue;
-
-            // abort if we have multiple exclusive patches
-            const int exclusivePriority = (int)AssetLoadPriority.Exclusive;
-            if (candidate.Priority is exclusivePriority && loader?.Priority == exclusivePriority)
-            {
-                IPatch[] exclusiveLoaders = loaders.Where(p => p.Priority == exclusivePriority).ToArray<IPatch>();
-                string[] modNames = exclusiveLoaders.Select(p => p.ContentPack.Manifest.Name).Distinct().OrderByHuman().ToArray();
-                string[] patchNames = exclusiveLoaders.Select(p => p.Path.ToString()).OrderByHuman().ToArray();
-                switch (modNames.Length)
-                {
-                    case 1:
-                        this.Monitor.Log($"'{modNames[0]}' has multiple patches with the '{nameof(AssetLoadPriority.Exclusive)}' priority which load the '{assetName}' asset at the same time ({string.Join(", ", patchNames)}). None will be applied. You should report this to the content pack author.", LogLevel.Error);
-                        break;
-
-                    case 2:
-                        this.Monitor.Log($"Two content packs want to load the '{assetName}' asset with the '{nameof(AssetLoadPriority.Exclusive)}' priority ({string.Join(" and ", modNames)}). Neither will be applied. You should remove one of the content packs, or ask the authors about compatibility.", LogLevel.Error);
-                        this.Monitor.Log($"Affected patches: {string.Join(", ", patchNames)}");
-                        break;
-
-                    default:
-                        this.Monitor.Log($"Multiple content packs want to load the '{assetName}' asset with the '{nameof(AssetLoadPriority.Exclusive)}' priority ({string.Join(", ", modNames)}). None will be applied. You should remove some of the content packs, or ask the authors about compatibility.", LogLevel.Error);
-                        this.Monitor.Log($"Affected patches: {string.Join(", ", patchNames)}");
-                        break;
-                }
-
-                loader = null;
-                break;
-            }
-
-            // else best match so far
-            loader = candidate;
+            e.LoadFrom(
+                load: () => this.ApplyLoad<T>(candidate, assetName)!, // only returns null when invalid, in which case there's no other way to abort
+                priority: (AssetLoadPriority)candidate.Priority,
+                onBehalfOf: candidate.ContentPack.Manifest.UniqueID
+            );
         }
 
-        // apply selected load patch
-        if (loader != null)
+        // apply the one exclusive load, or abort if there is more than one
+        if (exclusiveLoaders.Length == 1)
         {
+            LoadPatch loader = (LoadPatch)exclusiveLoaders[0];
             e.LoadFrom(
                 load: () => this.ApplyLoad<T>(loader, assetName)!, // only returns null when invalid, in which case there's no other way to abort
                 priority: AssetLoadPriority.Exclusive,
                 onBehalfOf: loader.ContentPack.Manifest.UniqueID
             );
+        }
+        else if (exclusiveLoaders.Length > 1)
+        {
+            string[] modNames = exclusiveLoaders.Select(p => p.ContentPack.Manifest.Name).Distinct().OrderByHuman().ToArray();
+            string[] patchNames = exclusiveLoaders.Select(p => p.Path.ToString()).OrderByHuman().ToArray();
+            switch (modNames.Length)
+            {
+                case 1:
+                    this.Monitor.Log($"'{modNames[0]}' has multiple patches with the '{nameof(AssetLoadPriority.Exclusive)}' priority which load the '{assetName}' asset at the same time ({string.Join(", ", patchNames)}). None will be applied. You should report this to the content pack author.", LogLevel.Error);
+                    break;
+
+                case 2:
+                    this.Monitor.Log($"Two content packs want to load the '{assetName}' asset with the '{nameof(AssetLoadPriority.Exclusive)}' priority ({string.Join(" and ", modNames)}). Neither will be applied. You should remove one of the content packs, or ask the authors about compatibility.", LogLevel.Error);
+                    this.Monitor.Log($"Affected patches: {string.Join(", ", patchNames)}");
+                    break;
+
+                default:
+                    this.Monitor.Log($"Multiple content packs want to load the '{assetName}' asset with the '{nameof(AssetLoadPriority.Exclusive)}' priority ({string.Join(", ", modNames)}). None will be applied. You should remove some of the content packs, or ask the authors about compatibility.", LogLevel.Error);
+                    this.Monitor.Log($"Affected patches: {string.Join(", ", patchNames)}");
+                    break;
+            }
         }
 
         // apply edit patches
@@ -528,7 +522,7 @@ internal class PatchManager
                 List<IPatch> patches = group; // avoid capturing foreach variable in the deferred callback
                 e.Edit(
                     apply: data => this.ApplyEdits<T>(patches, data),
-                    priority: AssetEditPriority.Default,
+                    priority: (AssetEditPriority)patches[0].Priority,
                     onBehalfOf: patches[0].ContentPack.Manifest.UniqueID
                 );
             }
@@ -671,13 +665,16 @@ internal class PatchManager
         List<List<IPatch>> groups = [];
 
         string? lastModId = null;
+        int? lastPriority = null;
         List<IPatch> group = [];
         foreach (IPatch patch in patches.OrderBy(p => p.Priority))
         {
             string modId = patch.ContentPack.Manifest.UniqueID;
-            if (modId != lastModId)
+            // start a new group when modId changes or when priority changes
+            if (modId != lastModId || patch.Priority != lastPriority)
             {
                 lastModId = modId;
+                lastPriority = patch.Priority;
                 if (group.Count > 0)
                 {
                     groups.Add(group);


### PR DESCRIPTION
This PR modifies how patch priority is applied.

For Load patches, instead of selecting only the highest-priority patch on an asset and always giving it to SMAPI with `AssetLoadPriority.Exclusive`, all non-exclusive loads and up to one exclusive load are forwarded to SMAPI at the same priority level they already have. If there is more than one exclusive load for an asset, the existing behavior of erroring out now and not forwarding those patches still applies, with the same errors as before, depending on how many patches/content packs provided the loads.

For Edit patches, instead of sorting all patches by priority and giving them all to SMAPI with `AssetEditPriority.Default`, the sorting function also breaks into new groups when the current priority value changes, so each group has a consistent mod id and priority. Then each group is given to SMAPI with the priority value it has.

The effect is to allow CP patches to fully interface with the priority system, instead of working only within CP. In 2.6.1, all Content Patcher loads are Exclusive and all edits are Default, no matter what priority content pack authors specify. This prevents, e.g., a Content Patcher edit ever being able to apply after a SMAPI mod's edit that specifies a priority like `Default + 1`. With this change, if a CP pack uses `Default + 2` or `Late` or similar, it will apply after a SMAPI mod's `Default + 1`, which to me is the expected behavior. Or, for another example, if a SMAPI mod requests an `Exclusive` load on an asset, and a CP mod requests one at `Low`, in 2.6.1 SMAPI will barf because both loads are actually exclusive, which I consider a counterintuitive result. With the change, the load proceeds normally and the SMAPI load is chosen.