### PR TITLE
[Tractor] pickaxe: configurable clear fertilized dirt

### DIFF
--- a/TractorMod/Framework/Attachments/PickaxeAttachment.cs
+++ b/TractorMod/Framework/Attachments/PickaxeAttachment.cs
@@ -85,12 +85,11 @@ internal class PickaxeAttachment : BaseAttachment
         if (tileFeature is HoeDirt dirt && tileObj is null)
         {
             // clear tilled dirt
-            if (this.Config.ClearDirt && dirt.crop == null && !dirt.HasFertilizer())
-                return this.UseToolOnTile(tool, tile, player, location);
-
-            // clear fertilized dirt
-            if (this.Config.ClearFertilizedDirt && dirt.crop == null && dirt.HasFertilizer())
-                return this.UseToolOnTile(tool, tile, player, location);
+            if (dirt.crop is null)
+            {
+                if (dirt.HasFertilizer() ? this.Config.ClearDirtWithFertilizer : this.Config.ClearDirt)
+                    return this.UseToolOnTile(tool, tile, player, location);
+            }
 
             // clear dead crops
             if (this.Config.ClearDeadCrops && dirt.crop != null && dirt.crop.dead.Value)

--- a/TractorMod/Framework/Attachments/PickaxeAttachment.cs
+++ b/TractorMod/Framework/Attachments/PickaxeAttachment.cs
@@ -85,7 +85,11 @@ internal class PickaxeAttachment : BaseAttachment
         if (tileFeature is HoeDirt dirt && tileObj is null)
         {
             // clear tilled dirt
-            if (this.Config.ClearDirt && dirt.crop == null)
+            if (this.Config.ClearDirt && dirt.crop == null && !dirt.HasFertilizer())
+                return this.UseToolOnTile(tool, tile, player, location);
+
+            // clear fertilized dirt
+            if (this.Config.ClearFertilizedDirt && dirt.crop == null && dirt.HasFertilizer())
                 return this.UseToolOnTile(tool, tile, player, location);
 
             // clear dead crops

--- a/TractorMod/Framework/Config/PickAxeConfig.cs
+++ b/TractorMod/Framework/Config/PickAxeConfig.cs
@@ -12,6 +12,9 @@ internal class PickAxeConfig
     /// <summary>Whether to clear tilled dirt.</summary>
     public bool ClearDirt { get; set; } = true;
 
+    /// <summary>Whether to clear tilled dirt with fertilizer.</summary>
+    public bool ClearFertilizedDirt { get; set; } = false;
+
     /// <summary>Whether to clear placed flooring.</summary>
     public bool ClearFlooring { get; set; } = false;
 

--- a/TractorMod/Framework/Config/PickAxeConfig.cs
+++ b/TractorMod/Framework/Config/PickAxeConfig.cs
@@ -9,11 +9,11 @@ internal class PickAxeConfig
     /// <summary>Whether to clear dead crops.</summary>
     public bool ClearDeadCrops { get; set; } = true;
 
-    /// <summary>Whether to clear tilled dirt.</summary>
+    /// <summary>Whether to clear tilled dirt which doesn't have any fertilizer.</summary>
     public bool ClearDirt { get; set; } = true;
 
-    /// <summary>Whether to clear tilled dirt with fertilizer.</summary>
-    public bool ClearFertilizedDirt { get; set; } = false;
+    /// <summary>Whether to clear tilled dirt which has fertilizer.</summary>
+    public bool ClearDirtWithFertilizer { get; set; } = false;
 
     /// <summary>Whether to clear placed flooring.</summary>
     public bool ClearFlooring { get; set; } = false;

--- a/TractorMod/Framework/GenericModConfigMenuIntegrationForTractor.cs
+++ b/TractorMod/Framework/GenericModConfigMenuIntegrationForTractor.cs
@@ -261,16 +261,16 @@ internal class GenericModConfigMenuIntegrationForTractor : IGenericModConfigMenu
                 set: (config, value) => config.StandardAttachments.PickAxe.ClearDeadCrops = value
             )
             .AddCheckbox(
-                name: I18n.Config_ClearTilledDirt_Name,
-                tooltip: I18n.Config_ClearTilledDirt_Tooltip,
+                name: I18n.Config_ClearDirtWithoutFertilizer_Name,
+                tooltip: I18n.Config_ClearDirtWithoutFertilizer_Tooltip,
                 get: config => config.StandardAttachments.PickAxe.ClearDirt,
                 set: (config, value) => config.StandardAttachments.PickAxe.ClearDirt = value
             )
             .AddCheckbox(
-                name: I18n.Config_ClearFertilizedDirt_Name,
-                tooltip: I18n.Config_ClearFertilizedDirt_Tooltip,
-                get: config => config.StandardAttachments.PickAxe.ClearFertilizedDirt,
-                set: (config, value) => config.StandardAttachments.PickAxe.ClearFertilizedDirt = value
+                name: I18n.Config_ClearDirtWithFertilizer_Name,
+                tooltip: I18n.Config_ClearDirtWithFertilizer_Tooltip,
+                get: config => config.StandardAttachments.PickAxe.ClearDirtWithFertilizer,
+                set: (config, value) => config.StandardAttachments.PickAxe.ClearDirtWithFertilizer = value
             )
             .AddCheckbox(
                 name: I18n.Config_ClearWeeds_Name,

--- a/TractorMod/Framework/GenericModConfigMenuIntegrationForTractor.cs
+++ b/TractorMod/Framework/GenericModConfigMenuIntegrationForTractor.cs
@@ -267,6 +267,12 @@ internal class GenericModConfigMenuIntegrationForTractor : IGenericModConfigMenu
                 set: (config, value) => config.StandardAttachments.PickAxe.ClearDirt = value
             )
             .AddCheckbox(
+                name: I18n.Config_ClearFertilizedDirt_Name,
+                tooltip: I18n.Config_ClearFertilizedDirt_Tooltip,
+                get: config => config.StandardAttachments.PickAxe.ClearFertilizedDirt,
+                set: (config, value) => config.StandardAttachments.PickAxe.ClearFertilizedDirt = value
+            )
+            .AddCheckbox(
                 name: I18n.Config_ClearWeeds_Name,
                 tooltip: I18n.Config_ClearWeeds_Tooltip,
                 get: config => config.StandardAttachments.PickAxe.ClearWeeds,

--- a/TractorMod/i18n/de.json
+++ b/TractorMod/i18n/de.json
@@ -183,6 +183,9 @@
     "config.clear-tilled-dirt.name": "Entferne gepflügten Erde",
     "config.clear-tilled-dirt.tooltip": "Ob gepflügter Erde wieder zu normaler Erde werden soll",
 
+    "config.clear-fertilized-dirt.name": "Gedüngte Erde entfernen",
+    "config.clear-fertilized-dirt.tooltip": "Ob gedüngte Erde entfernt werden soll.",
+
 
     /****
     ** Mining

--- a/TractorMod/i18n/de.json
+++ b/TractorMod/i18n/de.json
@@ -183,8 +183,9 @@
     "config.clear-tilled-dirt.name": "Entferne gepflügten Erde",
     "config.clear-tilled-dirt.tooltip": "Ob gepflügter Erde wieder zu normaler Erde werden soll",
 
-    "config.clear-fertilized-dirt.name": "Gedüngte Erde entfernen",
-    "config.clear-fertilized-dirt.tooltip": "Ob gedüngte Erde entfernt werden soll.",
+    // TODO
+    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
+    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
 
 
     /****

--- a/TractorMod/i18n/de.json
+++ b/TractorMod/i18n/de.json
@@ -180,12 +180,12 @@
     "config.dig-seed-spots.name": "Saatfleck ausgraben",
     "config.dig-seed-spots.tooltip": "Ob Saatflecken ausgegraben werden sollen.",
 
-    "config.clear-tilled-dirt.name": "Entferne gepflügten Erde",
-    "config.clear-tilled-dirt.tooltip": "Ob gepflügter Erde wieder zu normaler Erde werden soll",
+    "config.clear-dirt-without-fertilizer.name": "Entferne gepflügten Erde",
+    "config.clear-dirt-without-fertilizer.tooltip": "Ob gepflügter Erde wieder zu normaler Erde werden soll",
 
     // TODO
-    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
-    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
+    "config.clear-dirt-with-fertilizer.name": "Clear Tilled Dirt (Fertilized)",
+    "config.clear-dirt-with-fertilizer.tooltip": "Whether to clear tilled dirt which has fertilizer.",
 
 
     /****

--- a/TractorMod/i18n/default.json
+++ b/TractorMod/i18n/default.json
@@ -183,6 +183,8 @@
     "config.clear-tilled-dirt.name": "Clear Tilled Dirt",
     "config.clear-tilled-dirt.tooltip": "Whether to clear tilled dirt.",
 
+    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
+    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
 
     /****
     ** Mining

--- a/TractorMod/i18n/default.json
+++ b/TractorMod/i18n/default.json
@@ -180,11 +180,11 @@
     "config.dig-seed-spots.name": "Dig Seed Spots",
     "config.dig-seed-spots.tooltip": "Whether to dig up seed spots.",
 
-    "config.clear-tilled-dirt.name": "Clear Tilled Dirt",
-    "config.clear-tilled-dirt.tooltip": "Whether to clear tilled dirt.",
+    "config.clear-dirt-without-fertilizer.name": "Clear Tilled Dirt (Unfertilized)",
+    "config.clear-dirt-without-fertilizer.tooltip": "Whether to clear tilled dirt which doesn't have fertilizer.",
 
-    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
-    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
+    "config.clear-dirt-with-fertilizer.name": "Clear Tilled Dirt (Fertilized)",
+    "config.clear-dirt-with-fertilizer.tooltip": "Whether to clear tilled dirt which has fertilizer.",
 
     /****
     ** Mining

--- a/TractorMod/i18n/es.json
+++ b/TractorMod/i18n/es.json
@@ -186,12 +186,12 @@
     "config.dig-seed-spots.name": "Dig Seed Spots",
     "config.dig-seed-spots.tooltip": "Whether to dig up seed spots.",
 
-    "config.clear-tilled-dirt.name": "Limpiar tierra labrada",
-    "config.clear-tilled-dirt.tooltip": "Si se limpia la tierra labrada.",
+    "config.clear-dirt-without-fertilizer.name": "Limpiar tierra labrada",
+    "config.clear-dirt-without-fertilizer.tooltip": "Si se limpia la tierra labrada.",
 
     // TODO
-    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
-    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
+    "config.clear-dirt-with-fertilizer.name": "Clear Tilled Dirt (Fertilized)",
+    "config.clear-dirt-with-fertilizer.tooltip": "Whether to clear tilled dirt which has fertilizer.",
 
 
     /****

--- a/TractorMod/i18n/es.json
+++ b/TractorMod/i18n/es.json
@@ -189,6 +189,9 @@
     "config.clear-tilled-dirt.name": "Limpiar tierra labrada",
     "config.clear-tilled-dirt.tooltip": "Si se limpia la tierra labrada.",
 
+    "config.clear-fertilized-dirt.name": "Limpiar tierra fertilizada",
+    "config.clear-fertilized-dirt.tooltip": "Si se debe limpiar la tierra fertilizada.",
+
 
     /****
     ** Mining

--- a/TractorMod/i18n/es.json
+++ b/TractorMod/i18n/es.json
@@ -189,8 +189,9 @@
     "config.clear-tilled-dirt.name": "Limpiar tierra labrada",
     "config.clear-tilled-dirt.tooltip": "Si se limpia la tierra labrada.",
 
-    "config.clear-fertilized-dirt.name": "Limpiar tierra fertilizada",
-    "config.clear-fertilized-dirt.tooltip": "Si se debe limpiar la tierra fertilizada.",
+    // TODO
+    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
+    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
 
 
     /****

--- a/TractorMod/i18n/fr.json
+++ b/TractorMod/i18n/fr.json
@@ -187,12 +187,12 @@
     "config.dig-seed-spots.name": "Dig Seed Spots",
     "config.dig-seed-spots.tooltip": "Whether to dig up seed spots.",
 
-    "config.clear-tilled-dirt.name": "Déblayer terre labourée",
-    "config.clear-tilled-dirt.tooltip": "S'il faut déblayer une terre labourée.",
+    "config.clear-dirt-without-fertilizer.name": "Déblayer terre labourée",
+    "config.clear-dirt-without-fertilizer.tooltip": "S'il faut déblayer une terre labourée.",
 
     // TODO
-    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
-    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
+    "config.clear-dirt-with-fertilizer.name": "Clear Tilled Dirt (Fertilized)",
+    "config.clear-dirt-with-fertilizer.tooltip": "Whether to clear tilled dirt which has fertilizer.",
 
 
     /****

--- a/TractorMod/i18n/fr.json
+++ b/TractorMod/i18n/fr.json
@@ -190,8 +190,9 @@
     "config.clear-tilled-dirt.name": "Déblayer terre labourée",
     "config.clear-tilled-dirt.tooltip": "S'il faut déblayer une terre labourée.",
 
-    "config.clear-fertilized-dirt.name": "Déblayer la terre fertilisée",
-    "config.clear-fertilized-dirt.tooltip": "S'il faut déblayer la terre fertilisée.",
+    // TODO
+    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
+    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
 
 
     /****

--- a/TractorMod/i18n/fr.json
+++ b/TractorMod/i18n/fr.json
@@ -190,6 +190,9 @@
     "config.clear-tilled-dirt.name": "Déblayer terre labourée",
     "config.clear-tilled-dirt.tooltip": "S'il faut déblayer une terre labourée.",
 
+    "config.clear-fertilized-dirt.name": "Déblayer la terre fertilisée",
+    "config.clear-fertilized-dirt.tooltip": "S'il faut déblayer la terre fertilisée.",
+
 
     /****
     ** Mining

--- a/TractorMod/i18n/hu.json
+++ b/TractorMod/i18n/hu.json
@@ -189,8 +189,9 @@
     "config.clear-tilled-dirt.name": "Megművelt föld tisztítása",
     "config.clear-tilled-dirt.tooltip": "A megművelt föld eltávolítása.",
 
-    "config.clear-fertilized-dirt.name": "Trágyázott föld tisztítása",
-    "config.clear-fertilized-dirt.tooltip": "A trágyázott föld eltávolítása.",
+    // TODO
+    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
+    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
 
 
     /****

--- a/TractorMod/i18n/hu.json
+++ b/TractorMod/i18n/hu.json
@@ -186,12 +186,12 @@
     "config.dig-seed-spots.name": "Dig Seed Spots",
     "config.dig-seed-spots.tooltip": "Whether to dig up seed spots.",
 
-    "config.clear-tilled-dirt.name": "Megművelt föld tisztítása",
-    "config.clear-tilled-dirt.tooltip": "A megművelt föld eltávolítása.",
+    "config.clear-dirt-without-fertilizer.name": "Megművelt föld tisztítása",
+    "config.clear-dirt-without-fertilizer.tooltip": "A megművelt föld eltávolítása.",
 
     // TODO
-    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
-    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
+    "config.clear-dirt-with-fertilizer.name": "Clear Tilled Dirt (Fertilized)",
+    "config.clear-dirt-with-fertilizer.tooltip": "Whether to clear tilled dirt which has fertilizer.",
 
 
     /****

--- a/TractorMod/i18n/hu.json
+++ b/TractorMod/i18n/hu.json
@@ -189,6 +189,9 @@
     "config.clear-tilled-dirt.name": "Megművelt föld tisztítása",
     "config.clear-tilled-dirt.tooltip": "A megművelt föld eltávolítása.",
 
+    "config.clear-fertilized-dirt.name": "Trágyázott föld tisztítása",
+    "config.clear-fertilized-dirt.tooltip": "A trágyázott föld eltávolítása.",
+
 
     /****
     ** Mining (Bányászás)

--- a/TractorMod/i18n/it.json
+++ b/TractorMod/i18n/it.json
@@ -183,8 +183,9 @@
     "config.clear-tilled-dirt.name": "Elimina terra dissodata",
     "config.clear-tilled-dirt.tooltip": "Scegli se vuoi eliminare la terra dissodata.",
 
-    "config.clear-fertilized-dirt.name": "Elimina terra fertilizzata",
-    "config.clear-fertilized-dirt.tooltip": "Scegli se vuoi eliminare la terra fertilizzata.",
+    // TODO
+    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
+    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
 
 
     /****

--- a/TractorMod/i18n/it.json
+++ b/TractorMod/i18n/it.json
@@ -183,6 +183,9 @@
     "config.clear-tilled-dirt.name": "Elimina terra dissodata",
     "config.clear-tilled-dirt.tooltip": "Scegli se vuoi eliminare la terra dissodata.",
 
+    "config.clear-fertilized-dirt.name": "Elimina terra fertilizzata",
+    "config.clear-fertilized-dirt.tooltip": "Scegli se vuoi eliminare la terra fertilizzata.",
+
 
     /****
     ** Mining

--- a/TractorMod/i18n/it.json
+++ b/TractorMod/i18n/it.json
@@ -180,12 +180,12 @@
     "config.dig-seed-spots.name": "Scava nei punti di semina",
     "config.dig-seed-spots.tooltip": "Scegli se vuoi scavare nei punti di semina.",
 
-    "config.clear-tilled-dirt.name": "Elimina terra dissodata",
-    "config.clear-tilled-dirt.tooltip": "Scegli se vuoi eliminare la terra dissodata.",
+    "config.clear-dirt-without-fertilizer.name": "Elimina terra dissodata",
+    "config.clear-dirt-without-fertilizer.tooltip": "Scegli se vuoi eliminare la terra dissodata.",
 
     // TODO
-    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
-    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
+    "config.clear-dirt-with-fertilizer.name": "Clear Tilled Dirt (Fertilized)",
+    "config.clear-dirt-with-fertilizer.tooltip": "Whether to clear tilled dirt which has fertilizer.",
 
 
     /****

--- a/TractorMod/i18n/ja.json
+++ b/TractorMod/i18n/ja.json
@@ -184,6 +184,9 @@
     "config.clear-tilled-dirt.name": "耕した土を戻す",
     "config.clear-tilled-dirt.tooltip": "耕した土をもとに戻す。",
 
+    "config.clear-fertilized-dirt.name": "肥料がまかれた土を戻す",
+    "config.clear-fertilized-dirt.tooltip": "肥料がまかれた土をもとに戻す。",
+
 
     /****
     ** Mining

--- a/TractorMod/i18n/ja.json
+++ b/TractorMod/i18n/ja.json
@@ -181,12 +181,12 @@
     "config.dig-seed-spots.name": "タネポイントを掘り起こす",
     "config.dig-seed-spots.tooltip": "タネポイントを掘り起こす。",
 
-    "config.clear-tilled-dirt.name": "耕した土を戻す",
-    "config.clear-tilled-dirt.tooltip": "耕した土をもとに戻す。",
+    "config.clear-dirt-without-fertilizer.name": "耕した土を戻す",
+    "config.clear-dirt-without-fertilizer.tooltip": "耕した土をもとに戻す。",
 
     // TODO
-    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
-    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
+    "config.clear-dirt-with-fertilizer.name": "Clear Tilled Dirt (Fertilized)",
+    "config.clear-dirt-with-fertilizer.tooltip": "Whether to clear tilled dirt which has fertilizer.",
 
 
     /****

--- a/TractorMod/i18n/ja.json
+++ b/TractorMod/i18n/ja.json
@@ -184,8 +184,9 @@
     "config.clear-tilled-dirt.name": "耕した土を戻す",
     "config.clear-tilled-dirt.tooltip": "耕した土をもとに戻す。",
 
-    "config.clear-fertilized-dirt.name": "肥料がまかれた土を戻す",
-    "config.clear-fertilized-dirt.tooltip": "肥料がまかれた土をもとに戻す。",
+    // TODO
+    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
+    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
 
 
     /****

--- a/TractorMod/i18n/ko.json
+++ b/TractorMod/i18n/ko.json
@@ -183,8 +183,9 @@
     "config.clear-tilled-dirt.name": "경작 된 땅 제거",
     "config.clear-tilled-dirt.tooltip": "곡괭이로 경작된 땅을 제거 할 수 있습니다.",
 
-    "config.clear-fertilized-dirt.name": "비료 뿌린 땅 제거",
-    "config.clear-fertilized-dirt.tooltip": "비료가 뿌려진 땅을 제거합니다.",
+    // TODO
+    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
+    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
 
 
     /****

--- a/TractorMod/i18n/ko.json
+++ b/TractorMod/i18n/ko.json
@@ -183,6 +183,9 @@
     "config.clear-tilled-dirt.name": "경작 된 땅 제거",
     "config.clear-tilled-dirt.tooltip": "곡괭이로 경작된 땅을 제거 할 수 있습니다.",
 
+    "config.clear-fertilized-dirt.name": "비료 뿌린 땅 제거",
+    "config.clear-fertilized-dirt.tooltip": "비료가 뿌려진 땅을 제거합니다.",
+
 
     /****
     ** Mining

--- a/TractorMod/i18n/ko.json
+++ b/TractorMod/i18n/ko.json
@@ -180,12 +180,12 @@
     "config.dig-seed-spots.name": "씨앗 발굴",
     "config.dig-seed-spots.tooltip": "씨앗 발견시 호미로 팔 수 있습니다.",
 
-    "config.clear-tilled-dirt.name": "경작 된 땅 제거",
-    "config.clear-tilled-dirt.tooltip": "곡괭이로 경작된 땅을 제거 할 수 있습니다.",
+    "config.clear-dirt-without-fertilizer.name": "경작 된 땅 제거",
+    "config.clear-dirt-without-fertilizer.tooltip": "곡괭이로 경작된 땅을 제거 할 수 있습니다.",
 
     // TODO
-    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
-    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
+    "config.clear-dirt-with-fertilizer.name": "Clear Tilled Dirt (Fertilized)",
+    "config.clear-dirt-with-fertilizer.tooltip": "Whether to clear tilled dirt which has fertilizer.",
 
 
     /****

--- a/TractorMod/i18n/pl.json
+++ b/TractorMod/i18n/pl.json
@@ -195,6 +195,9 @@
     "config.clear-tilled-dirt.name": "Clear Tilled Dirt",
     "config.clear-tilled-dirt.tooltip": "Whether to clear tilled dirt.",
 
+    "config.clear-fertilized-dirt.name": "Usuń użyźnioną glebę",
+    "config.clear-fertilized-dirt.tooltip": "Określa, czy usuwać użyźnioną glebę.",
+
 
     /****
     ** Mining

--- a/TractorMod/i18n/pl.json
+++ b/TractorMod/i18n/pl.json
@@ -195,8 +195,8 @@
     "config.clear-tilled-dirt.name": "Clear Tilled Dirt",
     "config.clear-tilled-dirt.tooltip": "Whether to clear tilled dirt.",
 
-    "config.clear-fertilized-dirt.name": "Usuń użyźnioną glebę",
-    "config.clear-fertilized-dirt.tooltip": "Określa, czy usuwać użyźnioną glebę.",
+    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
+    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
 
 
     /****

--- a/TractorMod/i18n/pl.json
+++ b/TractorMod/i18n/pl.json
@@ -192,11 +192,11 @@
     "config.dig-seed-spots.name": "Dig Seed Spots",
     "config.dig-seed-spots.tooltip": "Whether to dig up seed spots.",
 
-    "config.clear-tilled-dirt.name": "Clear Tilled Dirt",
-    "config.clear-tilled-dirt.tooltip": "Whether to clear tilled dirt.",
+    "config.clear-dirt-without-fertilizer.name": "Clear Tilled Dirt (Unfertilized)",
+    "config.clear-dirt-without-fertilizer.tooltip": "Whether to clear tilled dirt which doesn't have fertilizer.",
 
-    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
-    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
+    "config.clear-dirt-with-fertilizer.name": "Clear Tilled Dirt (Fertilized)",
+    "config.clear-dirt-with-fertilizer.tooltip": "Whether to clear tilled dirt which has fertilizer.",
 
 
     /****

--- a/TractorMod/i18n/pt.json
+++ b/TractorMod/i18n/pt.json
@@ -187,12 +187,12 @@
     "config.dig-seed-spots.name": "Dig Seed Spots",
     "config.dig-seed-spots.tooltip": "Whether to dig up seed spots.",
 
-    "config.clear-tilled-dirt.name": "Limpar Terra Arada",
-    "config.clear-tilled-dirt.tooltip": "Se deve limpar a terra arada.",
+    "config.clear-dirt-without-fertilizer.name": "Limpar Terra Arada",
+    "config.clear-dirt-without-fertilizer.tooltip": "Se deve limpar a terra arada.",
 
     // TODO
-    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
-    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
+    "config.clear-dirt-with-fertilizer.name": "Clear Tilled Dirt (Fertilized)",
+    "config.clear-dirt-with-fertilizer.tooltip": "Whether to clear tilled dirt which has fertilizer.",
 
 
     /****

--- a/TractorMod/i18n/pt.json
+++ b/TractorMod/i18n/pt.json
@@ -190,8 +190,9 @@
     "config.clear-tilled-dirt.name": "Limpar Terra Arada",
     "config.clear-tilled-dirt.tooltip": "Se deve limpar a terra arada.",
 
-    "config.clear-fertilized-dirt.name": "Limpar Terra Fertilizad",
-    "config.clear-fertilized-dirt.tooltip": "Se deve limpar a terra fertilizada.",
+    // TODO
+    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
+    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
 
 
     /****

--- a/TractorMod/i18n/pt.json
+++ b/TractorMod/i18n/pt.json
@@ -190,6 +190,9 @@
     "config.clear-tilled-dirt.name": "Limpar Terra Arada",
     "config.clear-tilled-dirt.tooltip": "Se deve limpar a terra arada.",
 
+    "config.clear-fertilized-dirt.name": "Limpar Terra Fertilizad",
+    "config.clear-fertilized-dirt.tooltip": "Se deve limpar a terra fertilizada.",
+
 
     /****
     ** Mining

--- a/TractorMod/i18n/ru.json
+++ b/TractorMod/i18n/ru.json
@@ -189,6 +189,9 @@
     "config.clear-tilled-dirt.name": "Очистка вспаханной земли",
     "config.clear-tilled-dirt.tooltip": "Очищает вспаханную землю от сорняков.",
 
+    "config.clear-fertilized-dirt.name": "Очистка удобренной земли",
+    "config.clear-fertilized-dirt.tooltip": "Будет ли очищаться удобренная земля.",
+
 
     /****
     ** Mining

--- a/TractorMod/i18n/ru.json
+++ b/TractorMod/i18n/ru.json
@@ -189,8 +189,9 @@
     "config.clear-tilled-dirt.name": "Очистка вспаханной земли",
     "config.clear-tilled-dirt.tooltip": "Очищает вспаханную землю от сорняков.",
 
-    "config.clear-fertilized-dirt.name": "Очистка удобренной земли",
-    "config.clear-fertilized-dirt.tooltip": "Будет ли очищаться удобренная земля.",
+    // TODO
+    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
+    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
 
 
     /****

--- a/TractorMod/i18n/ru.json
+++ b/TractorMod/i18n/ru.json
@@ -186,12 +186,12 @@
     "config.dig-seed-spots.name": "Dig Seed Spots",
     "config.dig-seed-spots.tooltip": "Whether to dig up seed spots.",
 
-    "config.clear-tilled-dirt.name": "Очистка вспаханной земли",
-    "config.clear-tilled-dirt.tooltip": "Очищает вспаханную землю от сорняков.",
+    "config.clear-dirt-without-fertilizer.name": "Очистка вспаханной земли",
+    "config.clear-dirt-without-fertilizer.tooltip": "Очищает вспаханную землю от сорняков.",
 
     // TODO
-    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
-    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
+    "config.clear-dirt-with-fertilizer.name": "Clear Tilled Dirt (Fertilized)",
+    "config.clear-dirt-with-fertilizer.tooltip": "Whether to clear tilled dirt which has fertilizer.",
 
 
     /****

--- a/TractorMod/i18n/th.json
+++ b/TractorMod/i18n/th.json
@@ -188,6 +188,9 @@
     "config.clear-tilled-dirt.name": "ขจัดพื้นดิน",
     "config.clear-tilled-dirt.tooltip": "รวมถึงขจัดดินที่ไถพรวน",
 
+    "config.clear-fertilized-dirt.name": "ขจัดดินที่ใส่ปุ๋ยแล้ว",
+    "config.clear-fertilized-dirt.tooltip": "ว่าจะขจัดดินที่ใส่ปุ๋ยแล้วหรือไม่",
+
 
     /****
     ** Mining

--- a/TractorMod/i18n/th.json
+++ b/TractorMod/i18n/th.json
@@ -185,12 +185,12 @@
     "config.dig-seed-spots.name": "Dig Seed Spots",
     "config.dig-seed-spots.tooltip": "Whether to dig up seed spots.",
 
-    "config.clear-tilled-dirt.name": "ขจัดพื้นดิน",
-    "config.clear-tilled-dirt.tooltip": "รวมถึงขจัดดินที่ไถพรวน",
+    "config.clear-dirt-without-fertilizer.name": "ขจัดพื้นดิน",
+    "config.clear-dirt-without-fertilizer.tooltip": "รวมถึงขจัดดินที่ไถพรวน",
 
     // TODO
-    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
-    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
+    "config.clear-dirt-with-fertilizer.name": "Clear Tilled Dirt (Fertilized)",
+    "config.clear-dirt-with-fertilizer.tooltip": "Whether to clear tilled dirt which has fertilizer.",
 
 
     /****

--- a/TractorMod/i18n/th.json
+++ b/TractorMod/i18n/th.json
@@ -188,8 +188,9 @@
     "config.clear-tilled-dirt.name": "ขจัดพื้นดิน",
     "config.clear-tilled-dirt.tooltip": "รวมถึงขจัดดินที่ไถพรวน",
 
-    "config.clear-fertilized-dirt.name": "ขจัดดินที่ใส่ปุ๋ยแล้ว",
-    "config.clear-fertilized-dirt.tooltip": "ว่าจะขจัดดินที่ใส่ปุ๋ยแล้วหรือไม่",
+    // TODO
+    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
+    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
 
 
     /****

--- a/TractorMod/i18n/tr.json
+++ b/TractorMod/i18n/tr.json
@@ -180,12 +180,12 @@
     "config.dig-seed-spots.name": "Tohum Noktalarını Kaz",
     "config.dig-seed-spots.tooltip": "Tohum noktalarının kazılıp kazılmayacağı.",
 
-    "config.clear-tilled-dirt.name": "İşlenmiş Toprağı Temizle",
-    "config.clear-tilled-dirt.tooltip": "İşlenmiş toprağın temizlenip temizlenmeyeceği.",
+    "config.clear-dirt-without-fertilizer.name": "İşlenmiş Toprağı Temizle",
+    "config.clear-dirt-without-fertilizer.tooltip": "İşlenmiş toprağın temizlenip temizlenmeyeceği.",
 
     // TODO
-    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
-    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
+    "config.clear-dirt-with-fertilizer.name": "Clear Tilled Dirt (Fertilized)",
+    "config.clear-dirt-with-fertilizer.tooltip": "Whether to clear tilled dirt which has fertilizer.",
 
 
     /****

--- a/TractorMod/i18n/tr.json
+++ b/TractorMod/i18n/tr.json
@@ -183,6 +183,9 @@
     "config.clear-tilled-dirt.name": "İşlenmiş Toprağı Temizle",
     "config.clear-tilled-dirt.tooltip": "İşlenmiş toprağın temizlenip temizlenmeyeceği.",
 
+    "config.clear-fertilized-dirt.name": "Gübreli Toprağı Temizle",
+    "config.clear-fertilized-dirt.tooltip": "Gübreli toprağın temizlenip temizlenmeyeceği.",
+
 
     /****
     ** Mining

--- a/TractorMod/i18n/tr.json
+++ b/TractorMod/i18n/tr.json
@@ -183,8 +183,9 @@
     "config.clear-tilled-dirt.name": "İşlenmiş Toprağı Temizle",
     "config.clear-tilled-dirt.tooltip": "İşlenmiş toprağın temizlenip temizlenmeyeceği.",
 
-    "config.clear-fertilized-dirt.name": "Gübreli Toprağı Temizle",
-    "config.clear-fertilized-dirt.tooltip": "Gübreli toprağın temizlenip temizlenmeyeceği.",
+    // TODO
+    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
+    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
 
 
     /****

--- a/TractorMod/i18n/uk.json
+++ b/TractorMod/i18n/uk.json
@@ -190,6 +190,9 @@
     "config.clear-tilled-dirt.name": "Перекопати оброблений ґрунт",
     "config.clear-tilled-dirt.tooltip": "Переконування обробленого ґрунту.",
 
+    "config.clear-fertilized-dirt.name": "Очистити удобрену землю",
+    "config.clear-fertilized-dirt.tooltip": "Чи очищати удобрену зорану землю.",
+
 
     /****
     ** Mining

--- a/TractorMod/i18n/uk.json
+++ b/TractorMod/i18n/uk.json
@@ -190,8 +190,9 @@
     "config.clear-tilled-dirt.name": "Перекопати оброблений ґрунт",
     "config.clear-tilled-dirt.tooltip": "Переконування обробленого ґрунту.",
 
-    "config.clear-fertilized-dirt.name": "Очистити удобрену землю",
-    "config.clear-fertilized-dirt.tooltip": "Чи очищати удобрену зорану землю.",
+    // TODO
+    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
+    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
 
 
     /****

--- a/TractorMod/i18n/uk.json
+++ b/TractorMod/i18n/uk.json
@@ -187,12 +187,12 @@
     "config.dig-seed-spots.name": "Dig Seed Spots",
     "config.dig-seed-spots.tooltip": "Whether to dig up seed spots.",
 
-    "config.clear-tilled-dirt.name": "Перекопати оброблений ґрунт",
-    "config.clear-tilled-dirt.tooltip": "Переконування обробленого ґрунту.",
+    "config.clear-dirt-without-fertilizer.name": "Перекопати оброблений ґрунт",
+    "config.clear-dirt-without-fertilizer.tooltip": "Переконування обробленого ґрунту.",
 
     // TODO
-    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
-    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
+    "config.clear-dirt-with-fertilizer.name": "Clear Tilled Dirt (Fertilized)",
+    "config.clear-dirt-with-fertilizer.tooltip": "Whether to clear tilled dirt which has fertilizer.",
 
 
     /****

--- a/TractorMod/i18n/vi.json
+++ b/TractorMod/i18n/vi.json
@@ -184,6 +184,9 @@
     "config.clear-tilled-dirt.name": "Dọn dẹp Đất đã cày",
     "config.clear-tilled-dirt.tooltip": "Có dọn dẹp đất đã cày hay không.",
 
+    "config.clear-fertilized-dirt.name": "Dọn dẹp Đất đã bón phân",
+    "config.clear-fertilized-dirt.tooltip": "Có dọn dẹp đất đã cày và đã bón phân hay không.",
+
 
     /****
     ** Mining

--- a/TractorMod/i18n/vi.json
+++ b/TractorMod/i18n/vi.json
@@ -184,8 +184,9 @@
     "config.clear-tilled-dirt.name": "Dọn dẹp Đất đã cày",
     "config.clear-tilled-dirt.tooltip": "Có dọn dẹp đất đã cày hay không.",
 
-    "config.clear-fertilized-dirt.name": "Dọn dẹp Đất đã bón phân",
-    "config.clear-fertilized-dirt.tooltip": "Có dọn dẹp đất đã cày và đã bón phân hay không.",
+    // TODO
+    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
+    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
 
 
     /****

--- a/TractorMod/i18n/vi.json
+++ b/TractorMod/i18n/vi.json
@@ -181,12 +181,12 @@
     "config.dig-seed-spots.name": "Đào Địa điểm Hạt giống",
     "config.dig-seed-spots.tooltip": "Có đào địa điểm hạt giống hay không.",
 
-    "config.clear-tilled-dirt.name": "Dọn dẹp Đất đã cày",
-    "config.clear-tilled-dirt.tooltip": "Có dọn dẹp đất đã cày hay không.",
+    "config.clear-dirt-without-fertilizer.name": "Dọn dẹp Đất đã cày",
+    "config.clear-dirt-without-fertilizer.tooltip": "Có dọn dẹp đất đã cày hay không.",
 
     // TODO
-    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
-    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
+    "config.clear-dirt-with-fertilizer.name": "Clear Tilled Dirt (Fertilized)",
+    "config.clear-dirt-with-fertilizer.tooltip": "Whether to clear tilled dirt which has fertilizer.",
 
 
     /****

--- a/TractorMod/i18n/zh.json
+++ b/TractorMod/i18n/zh.json
@@ -184,8 +184,9 @@
     "config.clear-tilled-dirt.name": "填平耕地",
     "config.clear-tilled-dirt.tooltip": "是否填平已耕的地块。",
 
-    "config.clear-fertilized-dirt.name": "填平施肥过的耕地",
-    "config.clear-fertilized-dirt.tooltip": "是否填平施肥过的耕地。",
+    // TODO
+    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
+    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
 
 
     /****

--- a/TractorMod/i18n/zh.json
+++ b/TractorMod/i18n/zh.json
@@ -181,12 +181,12 @@
     "config.dig-seed-spots.name": "挖掘种子斑点",
     "config.dig-seed-spots.tooltip": "是否挖掘种子斑点。",
 
-    "config.clear-tilled-dirt.name": "填平耕地",
-    "config.clear-tilled-dirt.tooltip": "是否填平已耕的地块。",
+    "config.clear-dirt-without-fertilizer.name": "填平耕地",
+    "config.clear-dirt-without-fertilizer.tooltip": "是否填平已耕的地块。",
 
     // TODO
-    "config.clear-fertilized-dirt.name": "Clear Fertilized Dirt",
-    "config.clear-fertilized-dirt.tooltip": "Whether to clear fertilized dirt.",
+    "config.clear-dirt-with-fertilizer.name": "Clear Tilled Dirt (Fertilized)",
+    "config.clear-dirt-with-fertilizer.tooltip": "Whether to clear tilled dirt which has fertilizer.",
 
 
     /****

--- a/TractorMod/i18n/zh.json
+++ b/TractorMod/i18n/zh.json
@@ -184,6 +184,9 @@
     "config.clear-tilled-dirt.name": "填平耕地",
     "config.clear-tilled-dirt.tooltip": "是否填平已耕的地块。",
 
+    "config.clear-fertilized-dirt.name": "填平施肥过的耕地",
+    "config.clear-fertilized-dirt.tooltip": "是否填平施肥过的耕地。",
+
 
     /****
     ** Mining


### PR DESCRIPTION
### Background

For farming works, I need to reap the plants then get my seeds

Sometimes I would get my pickaxe out by mistake and the fertilized dirt got cleared immediately which is kinda frustrating

---

### This commit

added a feature that not clear fertilized dirt by default, and corresponding logic to clear them with a new config

The translations for config were generated by LLM, I can not check them all

---

### Test

manually, according to `pale / fertilized tilled dirt` & `config on / off` combinations

passed on my machine with vanilla game+mods bundle in the repo only