### PR TITLE
[Lookup Anything] Add support for golden animal cracker lookups

### DIFF
--- a/LookupAnything/Framework/Lookups/Buildings/BuildingSubject.cs
+++ b/LookupAnything/Framework/Lookups/Buildings/BuildingSubject.cs
@@ -180,9 +180,6 @@ internal class BuildingSubject : BaseSubject
                         // output
                         yield return new ItemIconField(this.GameHelper, I18n.Building_OutputReady(), pond.output.Value, this.Codex);
 
-                        // golden animal cracker
-                        yield return new GenericField(I18n.Building_FishPond_GoldenCracker(), this.Stringify(pond.goldenAnimalCracker.Value));
-
                         // drops
                         float chanceOfAnyDrop = pondData.BaseMinProduceChance >= pondData.BaseMaxProduceChance
                             ? pondData.BaseMinProduceChance
@@ -192,6 +189,9 @@ internal class BuildingSubject : BaseSubject
                         // quests
                         if (pondData.PopulationGates?.Any(gate => gate.Key > pond.lastUnlockedPopulationGate.Value) == true)
                             yield return new CheckboxListField(I18n.Building_FishPond_Quests(), new CheckboxList(this.GetPopulationGates(pond, pondData)));
+
+                        // golden animal cracker
+                        yield return new GenericField(I18n.Animal_GoldenCracker(), pond.goldenAnimalCracker.Value ? I18n.Animal_GoldenCracker_Applied() : I18n.Animal_GoldenCracker_None());
                     }
                     break;
 

--- a/LookupAnything/Framework/Lookups/Buildings/BuildingSubject.cs
+++ b/LookupAnything/Framework/Lookups/Buildings/BuildingSubject.cs
@@ -180,6 +180,9 @@ internal class BuildingSubject : BaseSubject
                         // output
                         yield return new ItemIconField(this.GameHelper, I18n.Building_OutputReady(), pond.output.Value, this.Codex);
 
+                        // golden animal cracker
+                        yield return new GenericField(I18n.Building_FishPond_GoldenCracker(), this.Stringify(pond.goldenAnimalCracker.Value));
+
                         // drops
                         float chanceOfAnyDrop = pondData.BaseMinProduceChance >= pondData.BaseMaxProduceChance
                             ? pondData.BaseMinProduceChance

--- a/LookupAnything/Framework/Lookups/Characters/FarmAnimalSubject.cs
+++ b/LookupAnything/Framework/Lookups/Characters/FarmAnimalSubject.cs
@@ -9,6 +9,7 @@ using Pathoschild.Stardew.LookupAnything.Framework.Fields;
 using StardewModdingAPI;
 using StardewModdingAPI.Utilities;
 using StardewValley;
+using StardewValley.GameData.FarmAnimals;
 
 namespace Pathoschild.Stardew.LookupAnything.Framework.Lookups.Characters;
 
@@ -44,6 +45,7 @@ internal class FarmAnimalSubject : BaseSubject
     public override IEnumerable<ICustomField> GetData()
     {
         FarmAnimal animal = this.Target;
+        FarmAnimalData? animalData = animal.GetAnimalData();
 
         // calculate maturity
         bool isFullyGrown = animal.isAdult();
@@ -68,6 +70,8 @@ internal class FarmAnimalSubject : BaseSubject
         yield return new GenericField(I18n.Animal_Mood(), animal.getMoodMessage());
         yield return new GenericField(I18n.Animal_Complaints(), this.GetMoodReason(animal));
         yield return new ItemIconField(this.GameHelper, I18n.Animal_ProduceReady(), CommonHelper.IsItemId(animal.currentProduce.Value, allowZero: false) ? ItemRegistry.Create(animal.currentProduce.Value) : null, this.Codex);
+        if (animalData?.CanEatGoldenCrackers ?? true)
+            yield return new GenericField(I18n.Animal_GoldenCracker(), this.Stringify(animal.hasEatenAnimalCracker.Value));
         if (!isFullyGrown)
             yield return new GenericField(I18n.Animal_Growth(), $"{I18n.Generic_Days(count: daysUntilGrown)} ({this.Stringify(dayOfMaturity)})");
         yield return new GenericField(I18n.Animal_SellsFor(), GenericField.GetSaleValueString(animal.getSellPrice(), 1));

--- a/LookupAnything/Framework/Lookups/Characters/FarmAnimalSubject.cs
+++ b/LookupAnything/Framework/Lookups/Characters/FarmAnimalSubject.cs
@@ -53,7 +53,7 @@ internal class FarmAnimalSubject : BaseSubject
         SDate? dayOfMaturity = null;
         if (!isFullyGrown)
         {
-            daysUntilGrown = animal.GetAnimalData().DaysToMature - animal.age.Value;
+            daysUntilGrown = animalData.DaysToMature - animal.age.Value;
             dayOfMaturity = SDate.Now().AddDays(daysUntilGrown);
         }
 
@@ -70,11 +70,13 @@ internal class FarmAnimalSubject : BaseSubject
         yield return new GenericField(I18n.Animal_Mood(), animal.getMoodMessage());
         yield return new GenericField(I18n.Animal_Complaints(), this.GetMoodReason(animal));
         yield return new ItemIconField(this.GameHelper, I18n.Animal_ProduceReady(), CommonHelper.IsItemId(animal.currentProduce.Value, allowZero: false) ? ItemRegistry.Create(animal.currentProduce.Value) : null, this.Codex);
-        if (animalData?.CanEatGoldenCrackers ?? true)
-            yield return new GenericField(I18n.Animal_GoldenCracker(), this.Stringify(animal.hasEatenAnimalCracker.Value));
         if (!isFullyGrown)
             yield return new GenericField(I18n.Animal_Growth(), $"{I18n.Generic_Days(count: daysUntilGrown)} ({this.Stringify(dayOfMaturity)})");
         yield return new GenericField(I18n.Animal_SellsFor(), GenericField.GetSaleValueString(animal.getSellPrice(), 1));
+
+        // bonuses
+        if (animalData?.CanEatGoldenCrackers ?? true)
+            yield return new GenericField(I18n.Animal_GoldenCracker(), animal.hasEatenAnimalCracker.Value ? I18n.Animal_GoldenCracker_Applied() : I18n.Animal_GoldenCracker_None());
 
         // internal type
         yield return new GenericField(I18n.InternalId(), animal.type.Value);

--- a/LookupAnything/i18n/de.json
+++ b/LookupAnything/i18n/de.json
@@ -185,6 +185,7 @@
     "animal.produce-ready": "Produkt fertig",
     "animal.growth": "Wachstum",
     "animal.sells-for": "Verkaufbar für",
+    "animal.golden-cracker": "Golden animal cracker", // also used for fish ponds // TODO
 
     // values
     "animal.complaints.hungry": "Wurde gestern nicht gefüttert",
@@ -193,6 +194,8 @@
     "animal.complaints.no-heater": "Keine Heizung im Winter",
     "animal.complaints.not-petted": "Wurde heute noch nicht gestreichelt",
     "animal.complaints.wild-animal-attack": "Wurde in der Nacht von einem wildem Tier angegriffen",
+    "animal.golden-cracker.none": "None. Add a golden animal cracker to double produced items.", // TODO
+    "animal.golden-cracker.applied": "Applied; produced items are doubled.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/default.json
+++ b/LookupAnything/i18n/default.json
@@ -185,6 +185,7 @@
     "animal.produce-ready": "Produce ready",
     "animal.growth": "Growth",
     "animal.sells-for": "Sells for",
+    "animal.golden-cracker": "Given animal cracker",
 
     // values
     "animal.complaints.hungry": "wasn't fed yesterday",
@@ -242,6 +243,7 @@
     "building.fish-pond.population": "Population",
     "building.fish-pond.drops": "Drops",
     "building.fish-pond.quests": "Quests",
+    "building.fish-pond.golden-cracker": "Given animal cracker",
 
     // values
     "building.fish-pond.population.empty": "Add a fish to start this pond",

--- a/LookupAnything/i18n/default.json
+++ b/LookupAnything/i18n/default.json
@@ -185,7 +185,7 @@
     "animal.produce-ready": "Produce ready",
     "animal.growth": "Growth",
     "animal.sells-for": "Sells for",
-    "animal.golden-cracker": "Given animal cracker",
+    "animal.golden-cracker": "Golden animal cracker", // also used for fish ponds
 
     // values
     "animal.complaints.hungry": "wasn't fed yesterday",
@@ -194,6 +194,8 @@
     "animal.complaints.no-heater": "no heater in winter",
     "animal.complaints.not-petted": "hasn't been petted today",
     "animal.complaints.wild-animal-attack": "attacked by wild animals during the night",
+    "animal.golden-cracker.none": "None. Add a golden animal cracker to double produced items.",
+    "animal.golden-cracker.applied": "Applied; produced items are doubled.",
 
 
     /*********
@@ -243,7 +245,6 @@
     "building.fish-pond.population": "Population",
     "building.fish-pond.drops": "Drops",
     "building.fish-pond.quests": "Quests",
-    "building.fish-pond.golden-cracker": "Given animal cracker",
 
     // values
     "building.fish-pond.population.empty": "Add a fish to start this pond",

--- a/LookupAnything/i18n/es.json
+++ b/LookupAnything/i18n/es.json
@@ -187,6 +187,7 @@
     "animal.produce-ready": "Producción lista",
     "animal.growth": "Crecimiento",
     "animal.sells-for": "Se vende por",
+    "animal.golden-cracker": "Golden animal cracker", // also used for fish ponds // TODO
 
     // values
     "animal.complaints.hungry": "No fue alimentado ayer",
@@ -195,6 +196,8 @@
     "animal.complaints.no-heater": "Sin calefacción en invierno",
     "animal.complaints.not-petted": "No ha sido acariciado hoy",
     "animal.complaints.wild-animal-attack": "Atacado por animales salvajes durante la noche",
+    "animal.golden-cracker.none": "None. Add a golden animal cracker to double produced items.", // TODO
+    "animal.golden-cracker.applied": "Applied; produced items are doubled.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/fr.json
+++ b/LookupAnything/i18n/fr.json
@@ -187,6 +187,7 @@
     "animal.produce-ready": "Produit prêt",
     "animal.growth": "Croissance",
     "animal.sells-for": "Valeur",
+    "animal.golden-cracker": "Golden animal cracker", // also used for fish ponds // TODO
 
     // values
     "animal.complaints.hungry": "n'a pas été nourri hier",
@@ -195,6 +196,8 @@
     "animal.complaints.no-heater": "n'est pas chauffé pendant l'hiver",
     "animal.complaints.not-petted": "n'a pas été carressé aujourd'hui",
     "animal.complaints.wild-animal-attack": "a été attaqué par des animaux sauvages pendant la nuit",
+    "animal.golden-cracker.none": "None. Add a golden animal cracker to double produced items.", // TODO
+    "animal.golden-cracker.applied": "Applied; produced items are doubled.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/hu.json
+++ b/LookupAnything/i18n/hu.json
@@ -187,6 +187,7 @@
     "animal.produce-ready": "Kész a termék",
     "animal.growth": "Növekedés",
     "animal.sells-for": "Ára",
+    "animal.golden-cracker": "Golden animal cracker", // also used for fish ponds // TODO
 
     // values
     "animal.complaints.hungry": "nem evett tegnap",
@@ -195,6 +196,8 @@
     "animal.complaints.no-heater": "nincs radiátor télen",
     "animal.complaints.not-petted": "nem kapott simogatást",
     "animal.complaints.wild-animal-attack": "vadállatok támadtak rá éjjel",
+    "animal.golden-cracker.none": "None. Add a golden animal cracker to double produced items.", // TODO
+    "animal.golden-cracker.applied": "Applied; produced items are doubled.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/it.json
+++ b/LookupAnything/i18n/it.json
@@ -185,6 +185,7 @@
     "animal.produce-ready": "Pronto alla produzione",
     "animal.growth": "Crescita",
     "animal.sells-for": "Valore",
+    "animal.golden-cracker": "Golden animal cracker", // also used for fish ponds // TODO
 
     // values
     "animal.complaints.hungry": "non è stato nutrito ieri",
@@ -193,6 +194,8 @@
     "animal.complaints.no-heater": "non ha il riscaldamento in inverno",
     "animal.complaints.not-petted": "non è ancora stato accarezzato oggi",
     "animal.complaints.wild-animal-attack": "attaccato da animali selvaggi questa notte",
+    "animal.golden-cracker.none": "None. Add a golden animal cracker to double produced items.", // TODO
+    "animal.golden-cracker.applied": "Applied; produced items are doubled.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/ja.json
+++ b/LookupAnything/i18n/ja.json
@@ -186,6 +186,7 @@
     "animal.produce-ready": "回収可能",
     "animal.growth": "成長",
     "animal.sells-for": "売値",
+    "animal.golden-cracker": "Golden animal cracker", // also used for fish ponds // TODO
 
     // values
     "animal.complaints.hungry": "昨日エサを食べることができなかった",
@@ -194,6 +195,8 @@
     "animal.complaints.no-heater": "冬なのにヒーターがない",
     "animal.complaints.not-petted": "まだなでられていない",
     "animal.complaints.wild-animal-attack": "夜に野生動物に襲われた",
+    "animal.golden-cracker.none": "None. Add a golden animal cracker to double produced items.", // TODO
+    "animal.golden-cracker.applied": "Applied; produced items are doubled.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/ko.json
+++ b/LookupAnything/i18n/ko.json
@@ -186,6 +186,7 @@
     "animal.produce-ready": "생산물 준비 완료",
     "animal.growth": "성장 단계",
     "animal.sells-for": "판매 가격: ",
+    "animal.golden-cracker": "Golden animal cracker", // also used for fish ponds // TODO
 
     // values
     "animal.complaints.hungry": "어제 먹이를 먹지 못함.",
@@ -194,6 +195,8 @@
     "animal.complaints.no-heater": "겨울에 난방기가 없음.",
     "animal.complaints.not-petted": "오늘 쓰다듬 받지 못함.",
     "animal.complaints.wild-animal-attack": "밤중에 야생 동물들에게 습격당함.",
+    "animal.golden-cracker.none": "None. Add a golden animal cracker to double produced items.", // TODO
+    "animal.golden-cracker.applied": "Applied; produced items are doubled.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/pl.json
+++ b/LookupAnything/i18n/pl.json
@@ -186,6 +186,7 @@
     "animal.produce-ready": "Produkt gotowy",
     "animal.growth": "Wiek",
     "animal.sells-for": "Sprzedaż za",
+    "animal.golden-cracker": "Golden animal cracker", // also used for fish ponds // TODO
 
     // values
     "animal.complaints.hungry": "nie było wczoraj karmione",
@@ -194,6 +195,8 @@
     "animal.complaints.no-heater": "brak ogrzewania zimą",
     "animal.complaints.not-petted": "nie zostało dzisiaj pogłaskane",
     "animal.complaints.wild-animal-attack": "zaatakowane przez dzikie zwierzęta w nocy",
+    "animal.golden-cracker.none": "None. Add a golden animal cracker to double produced items.", // TODO
+    "animal.golden-cracker.applied": "Applied; produced items are doubled.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/pt.json
+++ b/LookupAnything/i18n/pt.json
@@ -187,6 +187,7 @@
     "animal.produce-ready": "Produto pronto",
     "animal.growth": "Crescimento",
     "animal.sells-for": "Vende por",
+    "animal.golden-cracker": "Golden animal cracker", // also used for fish ponds // TODO
 
     // values
     "animal.complaints.hungry": "Não foi alimentado ontem",
@@ -195,6 +196,8 @@
     "animal.complaints.no-heater": "Sem aquecedor no inverno",
     "animal.complaints.not-petted": "Não recebeu carinho hoje",
     "animal.complaints.wild-animal-attack": "Foi atacado por animais selvagens durante a noite",
+    "animal.golden-cracker.none": "None. Add a golden animal cracker to double produced items.", // TODO
+    "animal.golden-cracker.applied": "Applied; produced items are doubled.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/ru.json
+++ b/LookupAnything/i18n/ru.json
@@ -185,6 +185,7 @@
     "animal.produce-ready": "Продукция готова",
     "animal.growth": "Рост",
     "animal.sells-for": "Продаётся за",
+    "animal.golden-cracker": "Golden animal cracker", // also used for fish ponds // TODO
 
     // values
     "animal.complaints.hungry": "Кушал вчера",
@@ -193,6 +194,8 @@
     "animal.complaints.no-heater": "Не обогревался зимой",
     "animal.complaints.not-petted": "Не проявлена забота сегодня",
     "animal.complaints.wild-animal-attack": "Атакован диким животным этой ночью",
+    "animal.golden-cracker.none": "None. Add a golden animal cracker to double produced items.", // TODO
+    "animal.golden-cracker.applied": "Applied; produced items are doubled.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/th.json
+++ b/LookupAnything/i18n/th.json
@@ -187,6 +187,7 @@
     "animal.produce-ready": "พร้อมให้ผลผลิต",
     "animal.growth": "การเติบโต",
     "animal.sells-for": "ราคาขาย",
+    "animal.golden-cracker": "Golden animal cracker", // also used for fish ponds // TODO
 
     // values
     "animal.complaints.hungry": "ไม่มีอะไรตกถึงท้อง ตั้งแต่เมื่อวาน",
@@ -195,6 +196,8 @@
     "animal.complaints.no-heater": "ไม่มีฮีตเตอร์ให้อบอุ่น ในอากาศหนาวเหน็บ",
     "animal.complaints.not-petted": "ยังไม่ถูกลูบหัวเลยนะวันนี้",
     "animal.complaints.wild-animal-attack": "ถูกโจมตีจากสัตว์ป่าเมื่อกลางดึกที่ผ่านมา",
+    "animal.golden-cracker.none": "None. Add a golden animal cracker to double produced items.", // TODO
+    "animal.golden-cracker.applied": "Applied; produced items are doubled.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/tr.json
+++ b/LookupAnything/i18n/tr.json
@@ -185,6 +185,7 @@
     "animal.produce-ready": "Ürün hazır",
     "animal.growth": "Büyüme",
     "animal.sells-for": "Karşılığında sat",
+    "animal.golden-cracker": "Golden animal cracker", // also used for fish ponds // TODO
 
     // values
     "animal.complaints.hungry": "dün beslenmedi",
@@ -193,6 +194,8 @@
     "animal.complaints.no-heater": "kış için ısıtıcı yok",
     "animal.complaints.not-petted": "bugün henüz sevilmedi",
     "animal.complaints.wild-animal-attack": "gece vahşi hayvanların saldırısına uğradı",
+    "animal.golden-cracker.none": "None. Add a golden animal cracker to double produced items.", // TODO
+    "animal.golden-cracker.applied": "Applied; produced items are doubled.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/uk.json
+++ b/LookupAnything/i18n/uk.json
@@ -187,6 +187,7 @@
     "animal.produce-ready": "Продукція готова",
     "animal.growth": "Ріст",
     "animal.sells-for": "Продається за",
+    "animal.golden-cracker": "Golden animal cracker", // also used for fish ponds // TODO
 
     // values
     "animal.complaints.hungry": "Вчора без їжі",
@@ -195,6 +196,8 @@
     "animal.complaints.no-heater": "Без обігріву взимку",
     "animal.complaints.not-petted": "Не пестили сьогодні",
     "animal.complaints.wild-animal-attack": "Атакували дикі тварини цієї ночі",
+    "animal.golden-cracker.none": "None. Add a golden animal cracker to double produced items.", // TODO
+    "animal.golden-cracker.applied": "Applied; produced items are doubled.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/vi.json
+++ b/LookupAnything/i18n/vi.json
@@ -186,6 +186,7 @@
     "animal.produce-ready": "Sản phẩm đã sẵn sàng",
     "animal.growth": "Trưởng thành",
     "animal.sells-for": "Giá bán",
+    "animal.golden-cracker": "Golden animal cracker", // also used for fish ponds // TODO
 
     // values
     "animal.complaints.hungry": "không được cho ăn hôm qua",
@@ -194,6 +195,8 @@
     "animal.complaints.no-heater": "không có lò sưởi vào mùa đông",
     "animal.complaints.not-petted": "chưa được vuốt ve hôm nay",
     "animal.complaints.wild-animal-attack": "bị tấn công bởi động vật hoang dã vào ban đêm",
+    "animal.golden-cracker.none": "None. Add a golden animal cracker to double produced items.", // TODO
+    "animal.golden-cracker.applied": "Applied; produced items are doubled.", // TODO
 
 
     /*********

--- a/LookupAnything/i18n/zh.json
+++ b/LookupAnything/i18n/zh.json
@@ -185,6 +185,7 @@
     "animal.produce-ready": "动物制品",
     "animal.growth": "生长",
     "animal.sells-for": "出售",
+    "animal.golden-cracker": "Golden animal cracker", // also used for fish ponds // TODO
 
     // values (数值)
     "animal.complaints.hungry": "昨天没有喂食",
@@ -193,6 +194,8 @@
     "animal.complaints.no-heater": "冬天没有暖气",
     "animal.complaints.not-petted": "今天还没有被爱抚",
     "animal.complaints.wild-animal-attack": "夜晚被野生动物攻击了",
+    "animal.golden-cracker.none": "None. Add a golden animal cracker to double produced items.", // TODO
+    "animal.golden-cracker.applied": "Applied; produced items are doubled.", // TODO
 
 
     /*********


### PR DESCRIPTION
- Adds a field to farm animal and fish pond lookups to display whether the target has been fed a Golden Animal Cracker.
- Animals that cannot receive crackers as per their data (such as pigs) will not have this field displayed
- Adds 2 new translation keys (in `default.json` only)

(I use `BarleyZP` as my name for my Stardew mods, so if my user ends up mentioned in any changelogs, please use that name!)

<img width="700" height="404" alt="farmanimal-craacker" src="https://github.com/user-attachments/assets/543c1684-7b6d-4f01-bcd7-815daea67e04" />
<img width="647" height="368" alt="fishpond-cracker" src="https://github.com/user-attachments/assets/086301ce-0294-4bf1-8ebb-e15335fc8cb8" />
<img width="665" height="384" alt="pig-nocracker" src="https://github.com/user-attachments/assets/b59bb7bc-da82-401a-aa4e-aa373d958f6a" />