### PR TITLE
[DataLayers] Feature: UI peek

### DIFF
--- a/Common/CommonHelper.cs
+++ b/Common/CommonHelper.cs
@@ -268,7 +268,8 @@ internal static class CommonHelper
     /// <param name="contentPos">The pixel position at which the content begins.</param>
     /// <param name="bounds">The scroll's outer bounds.</param>
     /// <param name="padding">The padding between the content and border.</param>
-    public static void DrawScroll(SpriteBatch spriteBatch, in Vector2 position, in Vector2 contentSize, out Vector2 contentPos, out Rectangle bounds, int padding = 5)
+    /// <param name="alpha">The opacity level of the scroll when drawn.</param>
+    public static void DrawScroll(SpriteBatch spriteBatch, in Vector2 position, in Vector2 contentSize, out Vector2 contentPos, out Rectangle bounds, int padding = 5, float alpha = 1)
     {
         CommonHelper.DrawContentBox(
             spriteBatch: spriteBatch,
@@ -286,7 +287,8 @@ internal static class CommonHelper
             contentSize: contentSize,
             contentPos: out contentPos,
             bounds: out bounds,
-            padding: padding
+            padding: padding,
+            alpha: alpha
         );
     }
 
@@ -307,26 +309,27 @@ internal static class CommonHelper
     /// <param name="contentPos">The pixel position at which the content begins.</param>
     /// <param name="bounds">The box's outer bounds.</param>
     /// <param name="padding">The padding between the content and border.</param>
-    public static void DrawContentBox(SpriteBatch spriteBatch, Texture2D texture, in Rectangle background, in Rectangle top, in Rectangle right, in Rectangle bottom, in Rectangle left, in Rectangle topLeft, in Rectangle topRight, in Rectangle bottomRight, in Rectangle bottomLeft, in Vector2 position, in Vector2 contentSize, out Vector2 contentPos, out Rectangle bounds, int padding)
+    /// <param name="alpha">The opacity level of the box when drawn.</param>
+    public static void DrawContentBox(SpriteBatch spriteBatch, Texture2D texture, in Rectangle background, in Rectangle top, in Rectangle right, in Rectangle bottom, in Rectangle left, in Rectangle topLeft, in Rectangle topRight, in Rectangle bottomRight, in Rectangle bottomLeft, in Vector2 position, in Vector2 contentSize, out Vector2 contentPos, out Rectangle bounds, int padding, float alpha = 1)
     {
         CommonHelper.GetContentBoxDimensions(topLeft, contentSize, padding, out int innerWidth, out int innerHeight, out int outerWidth, out int outerHeight, out int cornerWidth, out int cornerHeight);
         int x = (int)position.X;
         int y = (int)position.Y;
 
         // draw scroll background
-        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth, y + cornerHeight, innerWidth, innerHeight), background, Color.White);
+        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth, y + cornerHeight, innerWidth, innerHeight), background, Color.White * alpha);
 
         // draw borders
-        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth, y, innerWidth, cornerHeight), top, Color.White);
-        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth, y + cornerHeight + innerHeight, innerWidth, cornerHeight), bottom, Color.White);
-        spriteBatch.Draw(texture, new Rectangle(x, y + cornerHeight, cornerWidth, innerHeight), left, Color.White);
-        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth + innerWidth, y + cornerHeight, cornerWidth, innerHeight), right, Color.White);
+        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth, y, innerWidth, cornerHeight), top, Color.White * alpha);
+        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth, y + cornerHeight + innerHeight, innerWidth, cornerHeight), bottom, Color.White * alpha);
+        spriteBatch.Draw(texture, new Rectangle(x, y + cornerHeight, cornerWidth, innerHeight), left, Color.White * alpha);
+        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth + innerWidth, y + cornerHeight, cornerWidth, innerHeight), right, Color.White * alpha);
 
         // draw corners
-        spriteBatch.Draw(texture, new Rectangle(x, y, cornerWidth, cornerHeight), topLeft, Color.White);
-        spriteBatch.Draw(texture, new Rectangle(x, y + cornerHeight + innerHeight, cornerWidth, cornerHeight), bottomLeft, Color.White);
-        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth + innerWidth, y, cornerWidth, cornerHeight), topRight, Color.White);
-        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth + innerWidth, y + cornerHeight + innerHeight, cornerWidth, cornerHeight), bottomRight, Color.White);
+        spriteBatch.Draw(texture, new Rectangle(x, y, cornerWidth, cornerHeight), topLeft, Color.White * alpha);
+        spriteBatch.Draw(texture, new Rectangle(x, y + cornerHeight + innerHeight, cornerWidth, cornerHeight), bottomLeft, Color.White * alpha);
+        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth + innerWidth, y, cornerWidth, cornerHeight), topRight, Color.White * alpha);
+        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth + innerWidth, y + cornerHeight + innerHeight, cornerWidth, cornerHeight), bottomRight, Color.White * alpha);
 
         // set out params
         contentPos = new Vector2(x + cornerWidth + padding, y + cornerHeight + padding);

--- a/Common/CommonHelper.cs
+++ b/Common/CommonHelper.cs
@@ -315,21 +315,24 @@ internal static class CommonHelper
         CommonHelper.GetContentBoxDimensions(topLeft, contentSize, padding, out int innerWidth, out int innerHeight, out int outerWidth, out int outerHeight, out int cornerWidth, out int cornerHeight);
         int x = (int)position.X;
         int y = (int)position.Y;
+        Color color = alpha < 1
+            ? Color.White * alpha
+            : Color.White;
 
         // draw scroll background
-        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth, y + cornerHeight, innerWidth, innerHeight), background, Color.White * alpha);
+        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth, y + cornerHeight, innerWidth, innerHeight), background, color);
 
         // draw borders
-        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth, y, innerWidth, cornerHeight), top, Color.White * alpha);
-        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth, y + cornerHeight + innerHeight, innerWidth, cornerHeight), bottom, Color.White * alpha);
-        spriteBatch.Draw(texture, new Rectangle(x, y + cornerHeight, cornerWidth, innerHeight), left, Color.White * alpha);
-        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth + innerWidth, y + cornerHeight, cornerWidth, innerHeight), right, Color.White * alpha);
+        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth, y, innerWidth, cornerHeight), top, color);
+        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth, y + cornerHeight + innerHeight, innerWidth, cornerHeight), bottom, color);
+        spriteBatch.Draw(texture, new Rectangle(x, y + cornerHeight, cornerWidth, innerHeight), left, color);
+        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth + innerWidth, y + cornerHeight, cornerWidth, innerHeight), right, color);
 
         // draw corners
-        spriteBatch.Draw(texture, new Rectangle(x, y, cornerWidth, cornerHeight), topLeft, Color.White * alpha);
-        spriteBatch.Draw(texture, new Rectangle(x, y + cornerHeight + innerHeight, cornerWidth, cornerHeight), bottomLeft, Color.White * alpha);
-        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth + innerWidth, y, cornerWidth, cornerHeight), topRight, Color.White * alpha);
-        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth + innerWidth, y + cornerHeight + innerHeight, cornerWidth, cornerHeight), bottomRight, Color.White * alpha);
+        spriteBatch.Draw(texture, new Rectangle(x, y, cornerWidth, cornerHeight), topLeft, color);
+        spriteBatch.Draw(texture, new Rectangle(x, y + cornerHeight + innerHeight, cornerWidth, cornerHeight), bottomLeft, color);
+        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth + innerWidth, y, cornerWidth, cornerHeight), topRight, color);
+        spriteBatch.Draw(texture, new Rectangle(x + cornerWidth + innerWidth, y + cornerHeight + innerHeight, cornerWidth, cornerHeight), bottomRight, color);
 
         // set out params
         contentPos = new Vector2(x + cornerWidth + padding, y + cornerHeight + padding);

--- a/DataLayers/Framework/Components/LegendComponent.cs
+++ b/DataLayers/Framework/Components/LegendComponent.cs
@@ -81,16 +81,20 @@ internal class LegendComponent : ClickableComponent
     /// <param name="spriteBatch">The sprite batch being rendered.</param>
     public void Draw(SpriteBatch spriteBatch)
     {
-        // calculate dimensions
+        // precalculate values
         int leftOffset = this.bounds.X;
         int topOffset = this.bounds.Y;
+        float alpha = this.Opacity;
+        Color textColor = alpha < 1
+            ? Game1.textColor * alpha
+            : Game1.textColor;
 
         // draw overlay label
         {
-            CommonHelper.DrawScroll(spriteBatch, new Vector2(leftOffset, topOffset), new Vector2(this.BoxContentWidth, this.LabelTextSize.Y), out Vector2 contentPos, out Rectangle scrollBounds, padding: this.ScrollPadding, alpha: this.Opacity);
+            CommonHelper.DrawScroll(spriteBatch, new Vector2(leftOffset, topOffset), new Vector2(this.BoxContentWidth, this.LabelTextSize.Y), out Vector2 contentPos, out Rectangle scrollBounds, padding: this.ScrollPadding, alpha: alpha);
 
             contentPos += new Vector2((this.BoxContentWidth - this.LabelTextSize.X) / 2f, 0); // center label in box
-            spriteBatch.DrawString(Game1.smallFont, this.LayerName, contentPos, Game1.textColor * this.Opacity);
+            spriteBatch.DrawString(Game1.smallFont, this.LayerName, contentPos, textColor);
 
             topOffset += scrollBounds.Height + this.Padding;
         }
@@ -98,15 +102,15 @@ internal class LegendComponent : ClickableComponent
         // draw legend
         if (this.Legend.Any())
         {
-            CommonHelper.DrawScroll(spriteBatch, new Vector2(leftOffset, topOffset), new Vector2(this.BoxContentWidth, this.Legend.Length * this.LegendColorSize), out Vector2 contentPos, out Rectangle _, padding: this.ScrollPadding, alpha: this.Opacity);
+            CommonHelper.DrawScroll(spriteBatch, new Vector2(leftOffset, topOffset), new Vector2(this.BoxContentWidth, this.Legend.Length * this.LegendColorSize), out Vector2 contentPos, out Rectangle _, padding: this.ScrollPadding, alpha: alpha);
             for (int i = 0; i < this.Legend.Length; i++)
             {
                 LegendEntry value = this.Legend[i];
                 int legendX = (int)contentPos.X;
                 int legendY = (int)(contentPos.Y + i * this.LegendColorSize);
 
-                spriteBatch.DrawLine(legendX, legendY, new Vector2(this.LegendColorSize), value.Color * this.Opacity);
-                spriteBatch.DrawString(Game1.smallFont, value.Name, new Vector2(legendX + this.LegendColorSize + this.LegendColorPadding, legendY + 2), Game1.textColor * this.Opacity);
+                spriteBatch.DrawLine(legendX, legendY, new Vector2(this.LegendColorSize), value.Color * alpha);
+                spriteBatch.DrawString(Game1.smallFont, value.Name, new Vector2(legendX + this.LegendColorSize + this.LegendColorPadding, legendY + 2), textColor);
             }
         }
     }

--- a/DataLayers/Framework/Components/LegendComponent.cs
+++ b/DataLayers/Framework/Components/LegendComponent.cs
@@ -49,6 +49,11 @@ internal class LegendComponent : ClickableComponent
     /// <summary>The height of the data layer name text.</summary>
     private Point LabelTextSize;
 
+    /// <summary>The current alpha level applied to the top-left boxes when drawn.</summary>
+    private float Opacity = 1;
+
+    /// <summary>The alpha level applied to the top-left boxes on mouse-over.</summary>
+    private readonly float MinimumOpacity = 0.2f;
 
 
     /*********
@@ -81,10 +86,10 @@ internal class LegendComponent : ClickableComponent
 
         // draw overlay label
         {
-            CommonHelper.DrawScroll(spriteBatch, new Vector2(leftOffset, topOffset), new Vector2(this.BoxContentWidth, this.LabelTextSize.Y), out Vector2 contentPos, out Rectangle scrollBounds, padding: this.ScrollPadding);
+            CommonHelper.DrawScroll(spriteBatch, new Vector2(leftOffset, topOffset), new Vector2(this.BoxContentWidth, this.LabelTextSize.Y), out Vector2 contentPos, out Rectangle scrollBounds, padding: this.ScrollPadding, alpha: this.Opacity);
 
             contentPos += new Vector2((this.BoxContentWidth - this.LabelTextSize.X) / 2f, 0); // center label in box
-            spriteBatch.DrawString(Game1.smallFont, this.LayerName, contentPos, Color.Black);
+            spriteBatch.DrawString(Game1.smallFont, this.LayerName, contentPos, Game1.textColor * this.Opacity);
 
             topOffset += scrollBounds.Height + this.Padding;
         }
@@ -92,17 +97,26 @@ internal class LegendComponent : ClickableComponent
         // draw legend
         if (this.Legend.Any())
         {
-            CommonHelper.DrawScroll(spriteBatch, new Vector2(leftOffset, topOffset), new Vector2(this.BoxContentWidth, this.Legend.Length * this.LegendColorSize), out Vector2 contentPos, out Rectangle _, padding: this.ScrollPadding);
+            CommonHelper.DrawScroll(spriteBatch, new Vector2(leftOffset, topOffset), new Vector2(this.BoxContentWidth, this.Legend.Length * this.LegendColorSize), out Vector2 contentPos, out Rectangle _, padding: this.ScrollPadding, alpha: this.Opacity);
             for (int i = 0; i < this.Legend.Length; i++)
             {
                 LegendEntry value = this.Legend[i];
                 int legendX = (int)contentPos.X;
                 int legendY = (int)(contentPos.Y + i * this.LegendColorSize);
 
-                spriteBatch.DrawLine(legendX, legendY, new Vector2(this.LegendColorSize), value.Color);
-                spriteBatch.DrawString(Game1.smallFont, value.Name, new Vector2(legendX + this.LegendColorSize + this.LegendColorPadding, legendY + 2), Color.Black);
+                spriteBatch.DrawLine(legendX, legendY, new Vector2(this.LegendColorSize), value.Color * this.Opacity);
+                spriteBatch.DrawString(Game1.smallFont, value.Name, new Vector2(legendX + this.LegendColorSize + this.LegendColorPadding, legendY + 2), Game1.textColor * this.Opacity);
             }
         }
+    }
+
+    /// <summary>Update the UI on new tick.</summary>
+    public void Update()
+    {
+        // update opacity
+        bool isHovered = this.bounds.Contains(Game1.getMousePosition(true));
+        float rate = (float)(0.75f / Game1.currentGameTime.ElapsedGameTime.TotalMilliseconds);
+        this.Opacity = Math.Clamp(this.Opacity + rate * (isHovered ? -1 : 1), this.MinimumOpacity, 1f);
     }
 
 

--- a/DataLayers/Framework/Components/LegendComponent.cs
+++ b/DataLayers/Framework/Components/LegendComponent.cs
@@ -65,13 +65,14 @@ internal class LegendComponent : ClickableComponent
     /// <param name="layers">The data layers to render.</param>
     /// <param name="layerName">The current layer name to display.</param>
     /// <param name="legend">The legend values to display.</param>
-    public LegendComponent(int x, int y, ILayer[] layers, string layerName, LegendEntry[] legend)
+    public LegendComponent(int x, int y, ILayer[] layers, string layerName, LegendEntry[] legend, float minimumOpacity)
         : base(new Rectangle(x, y, 0, 0), nameof(LegendComponent))
     {
         this.LayerName = layerName;
         this.Legend = legend;
         this.LegendColorSize = (int)Game1.smallFont.MeasureString("X").Y;
         this.BoxContentWidth = this.GetMaxContentWidth(layers, this.LegendColorSize);
+        this.MinimumOpacity = minimumOpacity;
 
         this.ReinitializeComponents();
     }

--- a/DataLayers/Framework/Components/LegendComponent.cs
+++ b/DataLayers/Framework/Components/LegendComponent.cs
@@ -49,11 +49,11 @@ internal class LegendComponent : ClickableComponent
     /// <summary>The height of the data layer name text.</summary>
     private Point LabelTextSize;
 
-    /// <summary>The current alpha level applied to the top-left boxes when drawn.</summary>
-    private float Opacity = 1;
+    /// <summary>The current opacity to set for the top-left boxes when drawn, as a value between 0 (transparent) and 1 (opaque).</summary>
+    private float Alpha = 1;
 
-    /// <summary>The alpha level applied to the top-left boxes on mouse-over.</summary>
-    private readonly float MinimumOpacity = 0.2f;
+    /// <summary>The opacity to set for the top-left boxes when the cursor overlaps it, as a value between 0 (transparent) and 1 (opaque).</summary>
+    private readonly float AlphaOnHover;
 
 
     /*********
@@ -65,14 +65,16 @@ internal class LegendComponent : ClickableComponent
     /// <param name="layers">The data layers to render.</param>
     /// <param name="layerName">The current layer name to display.</param>
     /// <param name="legend">The legend values to display.</param>
-    public LegendComponent(int x, int y, ILayer[] layers, string layerName, LegendEntry[] legend, float minimumOpacity)
+    /// <param name="alphaOnHover">The opacity to set for the top-left boxes when the cursor overlaps it, as a value between 0 (transparent) and 1 (opaque).</param>
+    public LegendComponent(int x, int y, ILayer[] layers, string layerName, LegendEntry[] legend, float alphaOnHover)
         : base(new Rectangle(x, y, 0, 0), nameof(LegendComponent))
     {
         this.LayerName = layerName;
         this.Legend = legend;
+        this.AlphaOnHover = alphaOnHover;
+
         this.LegendColorSize = (int)Game1.smallFont.MeasureString("X").Y;
         this.BoxContentWidth = this.GetMaxContentWidth(layers, this.LegendColorSize);
-        this.MinimumOpacity = minimumOpacity;
 
         this.ReinitializeComponents();
     }
@@ -84,7 +86,7 @@ internal class LegendComponent : ClickableComponent
         // precalculate values
         int leftOffset = this.bounds.X;
         int topOffset = this.bounds.Y;
-        float alpha = this.Opacity;
+        float alpha = this.Alpha;
         Color textColor = alpha < 1
             ? Game1.textColor * alpha
             : Game1.textColor;
@@ -121,7 +123,7 @@ internal class LegendComponent : ClickableComponent
         // update opacity
         bool isHovered = this.bounds.Contains(Game1.getMousePosition(true));
         float rate = (float)(0.75f / Game1.currentGameTime.ElapsedGameTime.TotalMilliseconds);
-        this.Opacity = Math.Clamp(this.Opacity + rate * (isHovered ? -1 : 1), this.MinimumOpacity, 1f);
+        this.Alpha = Math.Clamp(this.Alpha + rate * (isHovered ? -1 : 1), this.AlphaOnHover, 1f);
     }
 
 

--- a/DataLayers/Framework/DataLayerOverlay.cs
+++ b/DataLayers/Framework/DataLayerOverlay.cs
@@ -79,8 +79,8 @@ internal class DataLayerOverlay : BaseOverlay
     /// <summary>Whether the game was paused last time the menu was updated.</summary>
     private bool WasPaused;
 
-    /// <summary>The alpha level set on <see cref="Legend"/> on mouse-over.</summary>
-    private readonly float LegendOpacityOnMouseOver;
+    /// <summary>The legend opacity to set when the cursor overlaps it, as a value between 0 (transparent) and 1 (opaque).</summary>
+    private readonly float LegendAlphaOnHover;
 
     /*****
     ** Components
@@ -113,7 +113,8 @@ internal class DataLayerOverlay : BaseOverlay
     /// <param name="drawOverlay">Get whether the overlay should be drawn.</param>
     /// <param name="combineOverlappingBorders">When two groups of the same color overlap, draw one border around their edges instead of their individual borders.</param>
     /// <param name="showGrid">Whether to show a tile grid when a layer is open.</param>
-    public DataLayerOverlay(IModEvents events, IInputHelper inputHelper, IReflectionHelper reflection, IReadOnlyList<ILayer> layers, Func<bool> drawOverlay, bool combineOverlappingBorders, bool showGrid, float legendOpacityOnMouseOver)
+    /// <param name="legendAlphaOnHover">The legend opacity to set when the cursor overlaps it, as a value between 0 (transparent) and 1 (opaque).</param>
+    public DataLayerOverlay(IModEvents events, IInputHelper inputHelper, IReflectionHelper reflection, IReadOnlyList<ILayer> layers, Func<bool> drawOverlay, bool combineOverlappingBorders, bool showGrid, float legendAlphaOnHover)
         : base(events, inputHelper, reflection, assumeUiMode: true)
     {
         if (!layers.Any())
@@ -123,7 +124,7 @@ internal class DataLayerOverlay : BaseOverlay
         this.DrawOverlay = drawOverlay;
         this.CombineOverlappingBorders = combineOverlappingBorders;
         this.ShowGrid = showGrid;
-        this.LegendOpacityOnMouseOver = legendOpacityOnMouseOver;
+        this.LegendAlphaOnHover = legendAlphaOnHover;
 
         this.SetLayer(this.Layers.First());
     }
@@ -318,9 +319,7 @@ internal class DataLayerOverlay : BaseOverlay
     {
         // update top-left UI when visible
         if (this.DrawOverlay() && Game1.displayHUD)
-        {
             this.Legend.Update();
-        }
     }
 
     /// <summary>Reinitialize the UI components.</summary>
@@ -337,7 +336,7 @@ internal class DataLayerOverlay : BaseOverlay
         Rectangle rightArrow = CommonSprites.Icons.RightArrow;
 
         this.PrevButton = new ClickableTextureComponent(new Rectangle(this.LeftMargin, this.TopMargin + 10, leftArrow.Width, leftArrow.Height), CommonSprites.Icons.Sheet, leftArrow, 1);
-        this.Legend = new LegendComponent(this.PrevButton.bounds.Right + this.ArrowPadding, topMargin, this.Layers, this.CurrentLayer.Name, this.LegendEntries, this.LegendOpacityOnMouseOver);
+        this.Legend = new LegendComponent(this.PrevButton.bounds.Right + this.ArrowPadding, topMargin, this.Layers, this.CurrentLayer.Name, this.LegendEntries, this.LegendAlphaOnHover);
         this.NextButton = new ClickableTextureComponent(new Rectangle(this.Legend.bounds.Right + this.ArrowPadding, this.TopMargin + 10, rightArrow.Width, rightArrow.Height), CommonSprites.Icons.Sheet, rightArrow, 1);
     }
 

--- a/DataLayers/Framework/DataLayerOverlay.cs
+++ b/DataLayers/Framework/DataLayerOverlay.cs
@@ -79,6 +79,9 @@ internal class DataLayerOverlay : BaseOverlay
     /// <summary>Whether the game was paused last time the menu was updated.</summary>
     private bool WasPaused;
 
+    /// <summary>The alpha level set on <see cref="Legend"/> on mouse-over.</summary>
+    private readonly float LegendOpacityOnMouseOver;
+
     /*****
     ** Components
     *****/
@@ -110,7 +113,7 @@ internal class DataLayerOverlay : BaseOverlay
     /// <param name="drawOverlay">Get whether the overlay should be drawn.</param>
     /// <param name="combineOverlappingBorders">When two groups of the same color overlap, draw one border around their edges instead of their individual borders.</param>
     /// <param name="showGrid">Whether to show a tile grid when a layer is open.</param>
-    public DataLayerOverlay(IModEvents events, IInputHelper inputHelper, IReflectionHelper reflection, IReadOnlyList<ILayer> layers, Func<bool> drawOverlay, bool combineOverlappingBorders, bool showGrid)
+    public DataLayerOverlay(IModEvents events, IInputHelper inputHelper, IReflectionHelper reflection, IReadOnlyList<ILayer> layers, Func<bool> drawOverlay, bool combineOverlappingBorders, bool showGrid, float legendOpacityOnMouseOver)
         : base(events, inputHelper, reflection, assumeUiMode: true)
     {
         if (!layers.Any())
@@ -120,6 +123,7 @@ internal class DataLayerOverlay : BaseOverlay
         this.DrawOverlay = drawOverlay;
         this.CombineOverlappingBorders = combineOverlappingBorders;
         this.ShowGrid = showGrid;
+        this.LegendOpacityOnMouseOver = legendOpacityOnMouseOver;
 
         this.SetLayer(this.Layers.First());
     }
@@ -333,7 +337,7 @@ internal class DataLayerOverlay : BaseOverlay
         Rectangle rightArrow = CommonSprites.Icons.RightArrow;
 
         this.PrevButton = new ClickableTextureComponent(new Rectangle(this.LeftMargin, this.TopMargin + 10, leftArrow.Width, leftArrow.Height), CommonSprites.Icons.Sheet, leftArrow, 1);
-        this.Legend = new LegendComponent(this.PrevButton.bounds.Right + this.ArrowPadding, topMargin, this.Layers, this.CurrentLayer.Name, this.LegendEntries);
+        this.Legend = new LegendComponent(this.PrevButton.bounds.Right + this.ArrowPadding, topMargin, this.Layers, this.CurrentLayer.Name, this.LegendEntries, this.LegendOpacityOnMouseOver);
         this.NextButton = new ClickableTextureComponent(new Rectangle(this.Legend.bounds.Right + this.ArrowPadding, this.TopMargin + 10, rightArrow.Width, rightArrow.Height), CommonSprites.Icons.Sheet, rightArrow, 1);
     }
 

--- a/DataLayers/Framework/DataLayerOverlay.cs
+++ b/DataLayers/Framework/DataLayerOverlay.cs
@@ -309,6 +309,16 @@ internal class DataLayerOverlay : BaseOverlay
         }
     }
 
+    /// <inheritdoc />
+    protected override void Update()
+    {
+        // update top-left UI when visible
+        if (this.DrawOverlay() && Game1.displayHUD)
+        {
+            this.Legend.Update();
+        }
+    }
+
     /// <summary>Reinitialize the UI components.</summary>
     [MemberNotNull(nameof(DataLayerOverlay.Legend), nameof(DataLayerOverlay.NextButton), nameof(DataLayerOverlay.PrevButton))]
     private void ReinitializeComponents()

--- a/DataLayers/Framework/GenericModConfigMenuIntegrationForDataLayers.cs
+++ b/DataLayers/Framework/GenericModConfigMenuIntegrationForDataLayers.cs
@@ -61,6 +61,16 @@ internal class GenericModConfigMenuIntegrationForDataLayers : IGenericModConfigM
                 allowedValues: this.ColorRegistry.SchemeIds.ToArray(),
                 formatAllowedValue: key => I18n.GetByKey($"config.color-schemes.{key}").Default(key)
             )
+            .AddNumberField(
+                name: I18n.Config_LegendOpacity_Name,
+                tooltip: I18n.Config_LegendOpacity_Desc,
+                get: config => config.LegendOpacityOnMouseOver,
+                set: (config, value) => config.LegendOpacityOnMouseOver = value,
+                min: 0,
+                max: 1,
+                interval: 0.05f
+            )
+
 
             .AddSectionTitle(I18n.Config_Section_MainControls)
             .AddKeyBinding(

--- a/DataLayers/Framework/GenericModConfigMenuIntegrationForDataLayers.cs
+++ b/DataLayers/Framework/GenericModConfigMenuIntegrationForDataLayers.cs
@@ -62,10 +62,10 @@ internal class GenericModConfigMenuIntegrationForDataLayers : IGenericModConfigM
                 formatAllowedValue: key => I18n.GetByKey($"config.color-schemes.{key}").Default(key)
             )
             .AddNumberField(
-                name: I18n.Config_LegendOpacity_Name,
-                tooltip: I18n.Config_LegendOpacity_Desc,
-                get: config => config.LegendOpacityOnMouseOver,
-                set: (config, value) => config.LegendOpacityOnMouseOver = value,
+                name: I18n.Config_LegendAlphaOnHover_Name,
+                tooltip: I18n.Config_LegendAlphaOnHover_Desc,
+                get: config => config.LegendAlphaOnHover,
+                set: (config, value) => config.LegendAlphaOnHover = value,
                 min: 0,
                 max: 1,
                 interval: 0.05f

--- a/DataLayers/Framework/ModConfig.cs
+++ b/DataLayers/Framework/ModConfig.cs
@@ -20,6 +20,9 @@ internal class ModConfig
     /// <summary>The color scheme in <see cref="ColorScheme.AssetName"/> to use.</summary>
     public string ColorScheme { get; set; } = "Default";
 
+    /// <summary><see cref="Components.LegendComponent.Opacity"/> set when mouse cursor overlaps the component.</summary>
+    public float LegendOpacityOnMouseOver { get; set; } = 0.2f;
+
     /// <summary>The key bindings.</summary>
     public ModConfigKeys Controls { get; set; } = new();
 

--- a/DataLayers/Framework/ModConfig.cs
+++ b/DataLayers/Framework/ModConfig.cs
@@ -20,8 +20,8 @@ internal class ModConfig
     /// <summary>The color scheme in <see cref="ColorScheme.AssetName"/> to use.</summary>
     public string ColorScheme { get; set; } = "Default";
 
-    /// <summary><see cref="Components.LegendComponent.Opacity"/> set when mouse cursor overlaps the component.</summary>
-    public float LegendOpacityOnMouseOver { get; set; } = 0.2f;
+    /// <summary>The legend opacity to set when the cursor overlaps it, as a value between 0 (transparent) and 1 (opaque).</summary>
+    public float LegendAlphaOnHover { get; set; } = 0.2f;
 
     /// <summary>The key bindings.</summary>
     public ModConfigKeys Controls { get; set; } = new();

--- a/DataLayers/ModEntry.cs
+++ b/DataLayers/ModEntry.cs
@@ -208,7 +208,7 @@ internal class ModEntry : Mod
         }
         else
         {
-            this.CurrentOverlay.Value = new DataLayerOverlay(this.Helper.Events, this.Helper.Input, this.Helper.Reflection, this.LayerRegistry.GetLayers(), this.CanOverlayNow, this.Config.CombineOverlappingBorders, this.Config.ShowGrid, this.Config.LegendOpacityOnMouseOver);
+            this.CurrentOverlay.Value = new DataLayerOverlay(this.Helper.Events, this.Helper.Input, this.Helper.Reflection, this.LayerRegistry.GetLayers(), this.CanOverlayNow, this.Config.CombineOverlappingBorders, this.Config.ShowGrid, this.Config.LegendAlphaOnHover);
             this.CurrentOverlay.Value.TrySetLayer(this.LastLayerId);
         }
     }

--- a/DataLayers/ModEntry.cs
+++ b/DataLayers/ModEntry.cs
@@ -208,7 +208,7 @@ internal class ModEntry : Mod
         }
         else
         {
-            this.CurrentOverlay.Value = new DataLayerOverlay(this.Helper.Events, this.Helper.Input, this.Helper.Reflection, this.LayerRegistry.GetLayers(), this.CanOverlayNow, this.Config.CombineOverlappingBorders, this.Config.ShowGrid);
+            this.CurrentOverlay.Value = new DataLayerOverlay(this.Helper.Events, this.Helper.Input, this.Helper.Reflection, this.LayerRegistry.GetLayers(), this.CanOverlayNow, this.Config.CombineOverlappingBorders, this.Config.ShowGrid, this.Config.LegendOpacityOnMouseOver);
             this.CurrentOverlay.Value.TrySetLayer(this.LastLayerId);
         }
     }

--- a/DataLayers/i18n/de.json
+++ b/DataLayers/i18n/de.json
@@ -93,6 +93,10 @@
     "config.color-schene.desc": "Das anzuwendende Farbschema, welches die Farben für alle Datenebenen ändert.",
     "config.color-schemes.default": "Standardfarben",
 
+    // TODO
+    "config.legend-alpha-on-hover.name": "Legend opacity on hover",
+    "config.legend-alpha-on-hover.desc": "How see-through the legend info box should be when the cursor is over it, as a value between 0 (transparent) and 1 (opaque).",
+
     // main controls
     "config.toggle-layer-key.name": "Toggle data layers",
     "config.toggle-layer-key.desc": "The key binding which shows or hides the data layer overlay.",

--- a/DataLayers/i18n/default.json
+++ b/DataLayers/i18n/default.json
@@ -93,6 +93,9 @@
     "config.color-schene.desc": "The color scheme to apply, which changes the colors throughout all the data layers.",
     "config.color-schemes.default": "default colors",
 
+    "config.legend-opacity.name": "Legend min. opacity",
+    "config.legend-opacity.desc": "The opacity set on the legend info box on mouse-over.",
+
     // main controls
     "config.toggle-layer-key.name": "Toggle data layers",
     "config.toggle-layer-key.desc": "The key binding which shows or hides the data layer overlay.",

--- a/DataLayers/i18n/default.json
+++ b/DataLayers/i18n/default.json
@@ -93,8 +93,8 @@
     "config.color-schene.desc": "The color scheme to apply, which changes the colors throughout all the data layers.",
     "config.color-schemes.default": "default colors",
 
-    "config.legend-opacity.name": "Legend min. opacity",
-    "config.legend-opacity.desc": "The opacity set on the legend info box on mouse-over.",
+    "config.legend-alpha-on-hover.name": "Legend opacity on hover",
+    "config.legend-alpha-on-hover.desc": "How see-through the legend info box should be when the cursor is over it, as a value between 0 (transparent) and 1 (opaque).",
 
     // main controls
     "config.toggle-layer-key.name": "Toggle data layers",

--- a/DataLayers/i18n/es.json
+++ b/DataLayers/i18n/es.json
@@ -94,6 +94,10 @@
     "config.color-schene.desc": "The color scheme to apply, which changes the colors throughout all the data layers.",
     "config.color-schemes.default": "default colors",
 
+    // TODO
+    "config.legend-alpha-on-hover.name": "Legend opacity on hover",
+    "config.legend-alpha-on-hover.desc": "How see-through the legend info box should be when the cursor is over it, as a value between 0 (transparent) and 1 (opaque).",
+
     // main controls
     "config.toggle-layer-key.name": "Toggle data layers",
     "config.toggle-layer-key.desc": "The key binding which shows or hides the data layer overlay.",

--- a/DataLayers/i18n/fr.json
+++ b/DataLayers/i18n/fr.json
@@ -94,6 +94,10 @@
     "config.color-schene.desc": "The color scheme to apply, which changes the colors throughout all the data layers.",
     "config.color-schemes.default": "default colors",
 
+    // TODO
+    "config.legend-alpha-on-hover.name": "Legend opacity on hover",
+    "config.legend-alpha-on-hover.desc": "How see-through the legend info box should be when the cursor is over it, as a value between 0 (transparent) and 1 (opaque).",
+
     // main controls
     "config.toggle-layer-key.name": "Toggle data layers",
     "config.toggle-layer-key.desc": "The key binding which shows or hides the data layer overlay.",

--- a/DataLayers/i18n/hu.json
+++ b/DataLayers/i18n/hu.json
@@ -94,6 +94,10 @@
     "config.color-schene.desc": "The color scheme to apply, which changes the colors throughout all the data layers.",
     "config.color-schemes.default": "default colors",
 
+    // TODO
+    "config.legend-alpha-on-hover.name": "Legend opacity on hover",
+    "config.legend-alpha-on-hover.desc": "How see-through the legend info box should be when the cursor is over it, as a value between 0 (transparent) and 1 (opaque).",
+
     // main controls
     "config.toggle-layer-key.name": "Toggle data layers",
     "config.toggle-layer-key.desc": "The key binding which shows or hides the data layer overlay.",

--- a/DataLayers/i18n/it.json
+++ b/DataLayers/i18n/it.json
@@ -93,6 +93,10 @@
     "config.color-schene.desc": "Lo schema di colori da applicare, che modifica i colori di tutti i livelli di dati.",
     "config.color-schemes.default": "colori predefiniti",
 
+    // TODO
+    "config.legend-alpha-on-hover.name": "Legend opacity on hover",
+    "config.legend-alpha-on-hover.desc": "How see-through the legend info box should be when the cursor is over it, as a value between 0 (transparent) and 1 (opaque).",
+
     // main controls
     "config.toggle-layer-key.name": "Alterna livelli di dati",
     "config.toggle-layer-key.desc": "Il tasto che mostra o nasconde la sovrapposizione del livello di dati.",

--- a/DataLayers/i18n/ja.json
+++ b/DataLayers/i18n/ja.json
@@ -93,6 +93,10 @@
     "config.color-schene.desc": "適用する配色で、すべてのデータレイヤー全体の色を変更する。",
     "config.color-schemes.default": "標準の色",
 
+    // TODO
+    "config.legend-alpha-on-hover.name": "Legend opacity on hover",
+    "config.legend-alpha-on-hover.desc": "How see-through the legend info box should be when the cursor is over it, as a value between 0 (transparent) and 1 (opaque).",
+
     // main controls
     "config.toggle-layer-key.name": "データレイヤーの切り替え",
     "config.toggle-layer-key.desc": "データレイヤーのオーバーレイを表示または非表示にするキー。",

--- a/DataLayers/i18n/ko.json
+++ b/DataLayers/i18n/ko.json
@@ -93,6 +93,10 @@
     "config.color-schene.desc": "모든 데이터 레이어에 적용할 색 구성을 변경합니다.",
     "config.color-schemes.default": "기본 색상",
 
+    // TODO
+    "config.legend-alpha-on-hover.name": "Legend opacity on hover",
+    "config.legend-alpha-on-hover.desc": "How see-through the legend info box should be when the cursor is over it, as a value between 0 (transparent) and 1 (opaque).",
+
     // main controls
     "config.toggle-layer-key.name": "데이터 레이어 활성키",
     "config.toggle-layer-key.desc": "데이터 레이어를 열고 닫는 단축키 설정",

--- a/DataLayers/i18n/pl.json
+++ b/DataLayers/i18n/pl.json
@@ -94,6 +94,10 @@
     "config.color-schene.desc": "The color scheme to apply, which changes the colors throughout all the data layers.",
     "config.color-schemes.default": "default colors",
 
+    // TODO
+    "config.legend-alpha-on-hover.name": "Legend opacity on hover",
+    "config.legend-alpha-on-hover.desc": "How see-through the legend info box should be when the cursor is over it, as a value between 0 (transparent) and 1 (opaque).",
+
     // main controls
     "config.toggle-layer-key.name": "Toggle data layers",
     "config.toggle-layer-key.desc": "The key binding which shows or hides the data layer overlay.",

--- a/DataLayers/i18n/pt.json
+++ b/DataLayers/i18n/pt.json
@@ -94,6 +94,10 @@
     "config.color-schene.desc": "The color scheme to apply, which changes the colors throughout all the data layers.",
     "config.color-schemes.default": "default colors",
 
+    // TODO
+    "config.legend-alpha-on-hover.name": "Legend opacity on hover",
+    "config.legend-alpha-on-hover.desc": "How see-through the legend info box should be when the cursor is over it, as a value between 0 (transparent) and 1 (opaque).",
+
     // main controls
     "config.toggle-layer-key.name": "Toggle data layers",
     "config.toggle-layer-key.desc": "The key binding which shows or hides the data layer overlay.",

--- a/DataLayers/i18n/ru.json
+++ b/DataLayers/i18n/ru.json
@@ -94,6 +94,10 @@
     "config.color-schene.desc": "The color scheme to apply, which changes the colors throughout all the data layers.",
     "config.color-schemes.default": "default colors",
 
+    // TODO
+    "config.legend-alpha-on-hover.name": "Legend opacity on hover",
+    "config.legend-alpha-on-hover.desc": "How see-through the legend info box should be when the cursor is over it, as a value between 0 (transparent) and 1 (opaque).",
+
     // main controls
     "config.toggle-layer-key.name": "Toggle data layers",
     "config.toggle-layer-key.desc": "The key binding which shows or hides the data layer overlay.",

--- a/DataLayers/i18n/th.json
+++ b/DataLayers/i18n/th.json
@@ -94,6 +94,10 @@
     "config.color-schene.desc": "The color scheme to apply, which changes the colors throughout all the data layers.",
     "config.color-schemes.default": "default colors",
 
+    // TODO
+    "config.legend-alpha-on-hover.name": "Legend opacity on hover",
+    "config.legend-alpha-on-hover.desc": "How see-through the legend info box should be when the cursor is over it, as a value between 0 (transparent) and 1 (opaque).",
+
     // main controls
     "config.toggle-layer-key.name": "Toggle data layers",
     "config.toggle-layer-key.desc": "The key binding which shows or hides the data layer overlay.",

--- a/DataLayers/i18n/tr.json
+++ b/DataLayers/i18n/tr.json
@@ -93,6 +93,10 @@
     "config.color-schene.desc": "Tüm veri katmanlarındaki renkleri değiştiren, uygulanacak renk şeması.",
     "config.color-schemes.default": "varsayılan renkler",
 
+    // TODO
+    "config.legend-alpha-on-hover.name": "Legend opacity on hover",
+    "config.legend-alpha-on-hover.desc": "How see-through the legend info box should be when the cursor is over it, as a value between 0 (transparent) and 1 (opaque).",
+
     // main controls
     "config.toggle-layer-key.name": "Veri katmanını gizle/göster",
     "config.toggle-layer-key.desc": "Veri katmanını gizlemek veya göstermek için kullanılacak tuş.",

--- a/DataLayers/i18n/uk.json
+++ b/DataLayers/i18n/uk.json
@@ -94,6 +94,10 @@
     "config.color-schene.desc": "The color scheme to apply, which changes the colors throughout all the data layers.",
     "config.color-schemes.default": "default colors",
 
+    // TODO
+    "config.legend-alpha-on-hover.name": "Legend opacity on hover",
+    "config.legend-alpha-on-hover.desc": "How see-through the legend info box should be when the cursor is over it, as a value between 0 (transparent) and 1 (opaque).",
+
     // main controls
     "config.toggle-layer-key.name": "Toggle data layers",
     "config.toggle-layer-key.desc": "The key binding which shows or hides the data layer overlay.",

--- a/DataLayers/i18n/zh.json
+++ b/DataLayers/i18n/zh.json
@@ -93,6 +93,10 @@
     "config.color-schene.desc": "要应用的颜色方案，它可以改变所有数据图层的颜色。",
     "config.color-schemes.default": "默认颜色方案",
 
+    // TODO
+    "config.legend-alpha-on-hover.name": "Legend opacity on hover",
+    "config.legend-alpha-on-hover.desc": "How see-through the legend info box should be when the cursor is over it, as a value between 0 (transparent) and 1 (opaque).",
+
     // main controls
     "config.toggle-layer-key.name": "打开数据图层快捷键",
     "config.toggle-layer-key.desc": "显示或隐藏数据图层的快捷键。",


### PR DESCRIPTION
Allows users to fade-out the DataLayers Legend component, excluding clickable buttons, by hovering it with the mouse.

### Changes
- Adds field `LegendComponent.Opacity` for alpha fade-in-fade-out
- Updates `Common.CommonHelper` draw methods for `alpha` param (default 1f, same behaviour)
- Adds a new config entry `LegendOpacityOnMouseOver` for the minimum opacity on hover, default 20%, ranging from 0% (fully hidden) to 100% (fully visible; no change in appearance on hover).
- Adds new translation strings for GenericModConfigMenu:
```
"config.legend-opacity.name": "Legend min. opacity",  
"config.legend-opacity.desc": "The opacity set on the legend info box on mouse-over."
```
Feel free to change as preferred or required 🌄