### PR TITLE
[ContentPatcher] Add animal & building support to MigrateIds

### DIFF
--- a/ContentPatcher/Framework/TriggerActions/MigrateIdType.cs
+++ b/ContentPatcher/Framework/TriggerActions/MigrateIdType.cs
@@ -3,7 +3,7 @@ namespace ContentPatcher.Framework.TriggerActions;
 /// <summary>A data ID type which can be migrated using <see cref="MigrateIdsAction"/>.</summary>
 public enum MigrateIdType
 {
-    /// <summary>Migrate buildings.</summary>
+    /// <summary>Migrate building types.</summary>
     Buildings,
 
     /// <summary>Migrate cooking recipe IDs.</summary>
@@ -15,7 +15,7 @@ public enum MigrateIdType
     /// <summary>Migrate event IDs.</summary>
     Events,
 
-    /// <summary>Migrate farm animals.</summary>
+    /// <summary>Migrate farm animal types.</summary>
     FarmAnimals,
 
     /// <summary>Migrate item local IDs.</summary>

--- a/ContentPatcher/Framework/TriggerActions/MigrateIdType.cs
+++ b/ContentPatcher/Framework/TriggerActions/MigrateIdType.cs
@@ -3,6 +3,9 @@ namespace ContentPatcher.Framework.TriggerActions;
 /// <summary>A data ID type which can be migrated using <see cref="MigrateIdsAction"/>.</summary>
 public enum MigrateIdType
 {
+    /// <summary>Migrate buildings.</summary>
+    Buildings,
+
     /// <summary>Migrate cooking recipe IDs.</summary>
     CookingRecipes,
 
@@ -12,6 +15,9 @@ public enum MigrateIdType
     /// <summary>Migrate event IDs.</summary>
     Events,
 
+    /// <summary>Migrate farm animals.</summary>
+    FarmAnimals,
+
     /// <summary>Migrate item local IDs.</summary>
     Items,
 
@@ -19,12 +25,6 @@ public enum MigrateIdType
     Mail,
 
     /// <summary>Migrate songs-heard cue names.</summary>
-    Songs,
-
-    /// <summary>Migrate farm animals.</summary>
-    FarmAnimals,
-
-    /// <summary>Migrate buildings.</summary>
-    Buildings,
+    Songs
 
 }

--- a/ContentPatcher/Framework/TriggerActions/MigrateIdType.cs
+++ b/ContentPatcher/Framework/TriggerActions/MigrateIdType.cs
@@ -19,5 +19,12 @@ public enum MigrateIdType
     Mail,
 
     /// <summary>Migrate songs-heard cue names.</summary>
-    Songs
+    Songs,
+
+    /// <summary>Migrate farm animals.</summary>
+    FarmAnimals,
+
+    /// <summary>Migrate buildings.</summary>
+    Buildings,
+
 }

--- a/ContentPatcher/Framework/TriggerActions/MigrateIdsAction.cs
+++ b/ContentPatcher/Framework/TriggerActions/MigrateIdsAction.cs
@@ -7,6 +7,8 @@ using Newtonsoft.Json;
 using Pathoschild.Stardew.Common;
 using StardewValley;
 using StardewValley.Delegates;
+using StardewValley.GameData.Buildings;
+using StardewValley.GameData.FarmAnimals;
 using StardewValley.ItemTypeDefinitions;
 using StardewValley.Triggers;
 using SObject = StardewValley.Object;
@@ -92,6 +94,12 @@ internal class MigrateIdsAction
 
             case MigrateIdType.Songs:
                 return this.TryMigrateSongIds(players, mapIds, out error);
+
+            case MigrateIdType.FarmAnimals:
+                return this.TryMigrateFarmAnimals(players, mapIds, out error);
+
+            case MigrateIdType.Buildings:
+                return this.TryMigrateBuildings(players, mapIds, out error);
 
             default:
                 error = $"required index 1 has unknown ID type '{type}'";
@@ -390,6 +398,76 @@ internal class MigrateIdsAction
                 }
             }
         }
+
+        error = null;
+        return true;
+    }
+
+    /// <summary>Try to migrate farm animals.</summary>
+    private bool TryMigrateFarmAnimals(IEnumerable<Farmer> players, IDictionary<string, string> mapIds, [NotNullWhen(false)] out string? error)
+    {
+        Dictionary<string, FarmAnimalData> farmAnimalData = DataLoader.FarmAnimals(Game1.content);
+        mapIds = mapIds.Where(kv => farmAnimalData.ContainsKey(kv.Value)).ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        Utility.ForEachBuilding(building =>
+        {
+            if (building.GetIndoors() is not AnimalHouse house)
+            {
+                return true;
+            }
+            GameLocation parentLocation = building.GetParentLocation();
+            foreach (long animalId in house.animalsThatLiveHere)
+            {
+                if (!house.animals.TryGetValue(animalId, out FarmAnimal animal)
+                    && !parentLocation.animals.TryGetValue(animalId, out animal))
+                {
+                    continue;
+                }
+                if (animal.type.Value == null || !mapIds.TryGetValue(animal.type.Value, out string? newType))
+                {
+                    continue;
+                }
+                animal.type.Value = newType;
+                animal.ReloadTextureIfNeeded(forceReload: true);
+            }
+            return true;
+        });
+
+        error = null;
+        return true;
+    }
+
+    /// <summary>Try to migrate buildings.</summary>
+    private bool TryMigrateBuildings(Farmer[] players, Dictionary<string, string> mapIds, out string? error)
+    {
+        Dictionary<string, BuildingData> buildingData = DataLoader.Buildings(Game1.content);
+        Dictionary<string, (string, BuildingData)> mappedBuildingData = [];
+        foreach ((string oldId, string newId) in mapIds)
+        {
+            if (buildingData.TryGetValue(newId, out BuildingData? bldData))
+            {
+                mappedBuildingData[oldId] = new(newId, bldData);
+            }
+        }
+        // mapToNewBuildings = mapIds.Where(kv => buildingData.ContainsKey(kv.Value)).ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        Utility.ForEachBuilding(building =>
+        {
+            if (building.buildingType.Value == null
+                || !mappedBuildingData.TryGetValue(building.buildingType.Value, out (string, BuildingData) newTypeAndData))
+            {
+                return true;
+            }
+
+            if (building.GetIndoors() is not null && newTypeAndData.Item2.IndoorMap == null)
+            {
+                building.indoors.Value = null;
+                building.nonInstancedIndoorsName.Value = null;
+            }
+            building.buildingType.Value = newTypeAndData.Item1;
+
+            return true;
+        });
 
         error = null;
         return true;

--- a/ContentPatcher/Framework/TriggerActions/MigrateIdsAction.cs
+++ b/ContentPatcher/Framework/TriggerActions/MigrateIdsAction.cs
@@ -7,8 +7,8 @@ using Newtonsoft.Json;
 using Pathoschild.Stardew.Common;
 using StardewValley;
 using StardewValley.Delegates;
+using StardewValley.Extensions;
 using StardewValley.GameData.Buildings;
-using StardewValley.GameData.FarmAnimals;
 using StardewValley.ItemTypeDefinitions;
 using StardewValley.Triggers;
 using SObject = StardewValley.Object;
@@ -78,7 +78,7 @@ internal class MigrateIdsAction
         switch (type)
         {
             case MigrateIdType.Buildings:
-                return this.TryMigrateBuildings(players, mapIds, out error);
+                return this.TryMigrateBuildings(mapIds, out error);
 
             case MigrateIdType.CookingRecipes:
                 return this.TryMigrateCookingRecipeIds(players, mapIds, out error);
@@ -90,7 +90,7 @@ internal class MigrateIdsAction
                 return this.TryMigrateEventIds(players, mapIds, out error);
 
             case MigrateIdType.FarmAnimals:
-                return this.TryMigrateFarmAnimals(players, mapIds, out error);
+                return this.TryMigrateFarmAnimals(mapIds, out error);
 
             case MigrateIdType.Items:
                 return this.TryMigrateItemIds(mapIds, out error);
@@ -112,33 +112,34 @@ internal class MigrateIdsAction
     ** Private methods
     *********/
     /// <summary>Try to migrate buildings.</summary>
-    private bool TryMigrateBuildings(Farmer[] players, Dictionary<string, string> mapIds, out string? error)
+    /// <param name="mapIds">The old and new IDs to map.</param>
+    /// <param name="error">An error indicating why the migration failed.</param>
+    private bool TryMigrateBuildings(Dictionary<string, string> mapIds, out string? error)
     {
-        Dictionary<string, BuildingData> buildingData = DataLoader.Buildings(Game1.content);
-        Dictionary<string, (string, BuildingData)> mappedBuildingData = [];
-        foreach ((string oldId, string newId) in mapIds)
+        // filter & validate
+        mapIds.RemoveWhere(pair => Game1.buildingData.ContainsKey(pair.Key));
+        foreach (string newId in mapIds.Values)
         {
-            if (buildingData.TryGetValue(newId, out BuildingData? bldData))
+            if (!Game1.buildingData.ContainsKey(newId))
             {
-                mappedBuildingData[oldId] = new(newId, bldData);
+                error = $"the new building type \"{newId}\" doesn't match an existing building";
+                return false;
             }
         }
-        // mapToNewBuildings = mapIds.Where(kv => buildingData.ContainsKey(kv.Value)).ToDictionary(kv => kv.Key, kv => kv.Value);
 
+        // apply
         Utility.ForEachBuilding(building =>
         {
-            if (building.buildingType.Value == null
-                || !mappedBuildingData.TryGetValue(building.buildingType.Value, out (string, BuildingData) newTypeAndData))
+            if (building.buildingType.Value is {} oldType && mapIds.TryGetValue(oldType, out string? newType) && Game1.buildingData.TryGetValue(newType, out BuildingData? newData))
             {
-                return true;
-            }
+                building.buildingType.Value = newType;
 
-            if (building.GetIndoors() is not null && newTypeAndData.Item2.IndoorMap == null)
-            {
-                building.indoors.Value = null;
-                building.nonInstancedIndoorsName.Value = null;
+                if (building.GetIndoors() is not null && newData.IndoorMap == null)
+                {
+                    building.indoors.Value = null;
+                    building.nonInstancedIndoorsName.Value = null;
+                }
             }
-            building.buildingType.Value = newTypeAndData.Item1;
 
             return true;
         });
@@ -225,32 +226,33 @@ internal class MigrateIdsAction
     }
 
     /// <summary>Try to migrate farm animals.</summary>
-    private bool TryMigrateFarmAnimals(IEnumerable<Farmer> players, IDictionary<string, string> mapIds, [NotNullWhen(false)] out string? error)
+    /// <param name="mapIds">The old and new IDs to map.</param>
+    /// <param name="error">An error indicating why the migration failed.</param>
+    private bool TryMigrateFarmAnimals(IDictionary<string, string> mapIds, [NotNullWhen(false)] out string? error)
     {
-        Dictionary<string, FarmAnimalData> farmAnimalData = DataLoader.FarmAnimals(Game1.content);
-        mapIds = mapIds.Where(kv => farmAnimalData.ContainsKey(kv.Value)).ToDictionary(kv => kv.Key, kv => kv.Value);
-
-        Utility.ForEachBuilding(building =>
+        // validate & filter
+        mapIds.RemoveWhere(pair => Game1.farmAnimalData.ContainsKey(pair.Key));
+        foreach (string newId in mapIds.Values)
         {
-            if (building.GetIndoors() is not AnimalHouse house)
+            if (!Game1.farmAnimalData.ContainsKey(newId))
             {
-                return true;
+                error = $"the new farm animal type \"{newId}\" doesn't match an existing animal";
+                return false;
             }
-            GameLocation parentLocation = building.GetParentLocation();
-            foreach (long animalId in house.animalsThatLiveHere)
+        }
+
+        // apply
+        Utility.ForEachLocation(location =>
+        {
+            foreach (FarmAnimal animal in location.animals.Values)
             {
-                if (!house.animals.TryGetValue(animalId, out FarmAnimal animal)
-                    && !parentLocation.animals.TryGetValue(animalId, out animal))
+                if (animal.type.Value != null && mapIds.TryGetValue(animal.type.Value, out string? newType))
                 {
-                    continue;
+                    animal.type.Value = newType;
+                    animal.ReloadTextureIfNeeded(forceReload: true);
                 }
-                if (animal.type.Value == null || !mapIds.TryGetValue(animal.type.Value, out string? newType))
-                {
-                    continue;
-                }
-                animal.type.Value = newType;
-                animal.ReloadTextureIfNeeded(forceReload: true);
             }
+
             return true;
         });
 

--- a/ContentPatcher/Framework/TriggerActions/MigrateIdsAction.cs
+++ b/ContentPatcher/Framework/TriggerActions/MigrateIdsAction.cs
@@ -77,6 +77,9 @@ internal class MigrateIdsAction
         Farmer[] players = Game1.getAllFarmers().ToArray();
         switch (type)
         {
+            case MigrateIdType.Buildings:
+                return this.TryMigrateBuildings(players, mapIds, out error);
+
             case MigrateIdType.CookingRecipes:
                 return this.TryMigrateCookingRecipeIds(players, mapIds, out error);
 
@@ -86,6 +89,9 @@ internal class MigrateIdsAction
             case MigrateIdType.Events:
                 return this.TryMigrateEventIds(players, mapIds, out error);
 
+            case MigrateIdType.FarmAnimals:
+                return this.TryMigrateFarmAnimals(players, mapIds, out error);
+
             case MigrateIdType.Items:
                 return this.TryMigrateItemIds(mapIds, out error);
 
@@ -94,12 +100,6 @@ internal class MigrateIdsAction
 
             case MigrateIdType.Songs:
                 return this.TryMigrateSongIds(players, mapIds, out error);
-
-            case MigrateIdType.FarmAnimals:
-                return this.TryMigrateFarmAnimals(players, mapIds, out error);
-
-            case MigrateIdType.Buildings:
-                return this.TryMigrateBuildings(players, mapIds, out error);
 
             default:
                 error = $"required index 1 has unknown ID type '{type}'";
@@ -111,6 +111,42 @@ internal class MigrateIdsAction
     /*********
     ** Private methods
     *********/
+    /// <summary>Try to migrate buildings.</summary>
+    private bool TryMigrateBuildings(Farmer[] players, Dictionary<string, string> mapIds, out string? error)
+    {
+        Dictionary<string, BuildingData> buildingData = DataLoader.Buildings(Game1.content);
+        Dictionary<string, (string, BuildingData)> mappedBuildingData = [];
+        foreach ((string oldId, string newId) in mapIds)
+        {
+            if (buildingData.TryGetValue(newId, out BuildingData? bldData))
+            {
+                mappedBuildingData[oldId] = new(newId, bldData);
+            }
+        }
+        // mapToNewBuildings = mapIds.Where(kv => buildingData.ContainsKey(kv.Value)).ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        Utility.ForEachBuilding(building =>
+        {
+            if (building.buildingType.Value == null
+                || !mappedBuildingData.TryGetValue(building.buildingType.Value, out (string, BuildingData) newTypeAndData))
+            {
+                return true;
+            }
+
+            if (building.GetIndoors() is not null && newTypeAndData.Item2.IndoorMap == null)
+            {
+                building.indoors.Value = null;
+                building.nonInstancedIndoorsName.Value = null;
+            }
+            building.buildingType.Value = newTypeAndData.Item1;
+
+            return true;
+        });
+
+        error = null;
+        return true;
+    }
+
     /// <summary>Try to migrate cooking recipe IDs.</summary>
     /// <param name="players">The players to edit.</param>
     /// <param name="mapIds">The old and new IDs to map.</param>
@@ -183,6 +219,40 @@ internal class MigrateIdsAction
                 }
             }
         }
+
+        error = null;
+        return true;
+    }
+
+    /// <summary>Try to migrate farm animals.</summary>
+    private bool TryMigrateFarmAnimals(IEnumerable<Farmer> players, IDictionary<string, string> mapIds, [NotNullWhen(false)] out string? error)
+    {
+        Dictionary<string, FarmAnimalData> farmAnimalData = DataLoader.FarmAnimals(Game1.content);
+        mapIds = mapIds.Where(kv => farmAnimalData.ContainsKey(kv.Value)).ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        Utility.ForEachBuilding(building =>
+        {
+            if (building.GetIndoors() is not AnimalHouse house)
+            {
+                return true;
+            }
+            GameLocation parentLocation = building.GetParentLocation();
+            foreach (long animalId in house.animalsThatLiveHere)
+            {
+                if (!house.animals.TryGetValue(animalId, out FarmAnimal animal)
+                    && !parentLocation.animals.TryGetValue(animalId, out animal))
+                {
+                    continue;
+                }
+                if (animal.type.Value == null || !mapIds.TryGetValue(animal.type.Value, out string? newType))
+                {
+                    continue;
+                }
+                animal.type.Value = newType;
+                animal.ReloadTextureIfNeeded(forceReload: true);
+            }
+            return true;
+        });
 
         error = null;
         return true;
@@ -398,76 +468,6 @@ internal class MigrateIdsAction
                 }
             }
         }
-
-        error = null;
-        return true;
-    }
-
-    /// <summary>Try to migrate farm animals.</summary>
-    private bool TryMigrateFarmAnimals(IEnumerable<Farmer> players, IDictionary<string, string> mapIds, [NotNullWhen(false)] out string? error)
-    {
-        Dictionary<string, FarmAnimalData> farmAnimalData = DataLoader.FarmAnimals(Game1.content);
-        mapIds = mapIds.Where(kv => farmAnimalData.ContainsKey(kv.Value)).ToDictionary(kv => kv.Key, kv => kv.Value);
-
-        Utility.ForEachBuilding(building =>
-        {
-            if (building.GetIndoors() is not AnimalHouse house)
-            {
-                return true;
-            }
-            GameLocation parentLocation = building.GetParentLocation();
-            foreach (long animalId in house.animalsThatLiveHere)
-            {
-                if (!house.animals.TryGetValue(animalId, out FarmAnimal animal)
-                    && !parentLocation.animals.TryGetValue(animalId, out animal))
-                {
-                    continue;
-                }
-                if (animal.type.Value == null || !mapIds.TryGetValue(animal.type.Value, out string? newType))
-                {
-                    continue;
-                }
-                animal.type.Value = newType;
-                animal.ReloadTextureIfNeeded(forceReload: true);
-            }
-            return true;
-        });
-
-        error = null;
-        return true;
-    }
-
-    /// <summary>Try to migrate buildings.</summary>
-    private bool TryMigrateBuildings(Farmer[] players, Dictionary<string, string> mapIds, out string? error)
-    {
-        Dictionary<string, BuildingData> buildingData = DataLoader.Buildings(Game1.content);
-        Dictionary<string, (string, BuildingData)> mappedBuildingData = [];
-        foreach ((string oldId, string newId) in mapIds)
-        {
-            if (buildingData.TryGetValue(newId, out BuildingData? bldData))
-            {
-                mappedBuildingData[oldId] = new(newId, bldData);
-            }
-        }
-        // mapToNewBuildings = mapIds.Where(kv => buildingData.ContainsKey(kv.Value)).ToDictionary(kv => kv.Key, kv => kv.Value);
-
-        Utility.ForEachBuilding(building =>
-        {
-            if (building.buildingType.Value == null
-                || !mappedBuildingData.TryGetValue(building.buildingType.Value, out (string, BuildingData) newTypeAndData))
-            {
-                return true;
-            }
-
-            if (building.GetIndoors() is not null && newTypeAndData.Item2.IndoorMap == null)
-            {
-                building.indoors.Value = null;
-                building.nonInstancedIndoorsName.Value = null;
-            }
-            building.buildingType.Value = newTypeAndData.Item1;
-
-            return true;
-        });
 
         error = null;
         return true;

--- a/ContentPatcher/docs/author-guide/trigger-actions.md
+++ b/ContentPatcher/docs/author-guide/trigger-actions.md
@@ -25,7 +25,7 @@ The argument format is `<type> [<old id> <new id>]+`:
 <td><code>&lt;type&gt;</code></td>
 <td>
 
-One of `CookingRecipes`, `CraftingRecipes`, `Events`, `Items`, `Mail`, or `Songs`.
+One of `Buildings`, `CookingRecipes`, `CraftingRecipes`, `Events`, `FarmAnimals`, `Items`, `Mail`, or `Songs`.
 
 </td>
 </tr>

--- a/ContentPatcher/docs/zh/author-guide/trigger-actions.md
+++ b/ContentPatcher/docs/zh/author-guide/trigger-actions.md
@@ -22,7 +22,7 @@
 <td><code>&lt;类型&gt;</code></td>
 <td>
 
-必须是以下之一：`CookingRecipes`、`CraftingRecipes`、`Events`、`Items`、`Mail`、`Songs`。
+必须是以下之一：`Buildings`、`CookingRecipes`、`CraftingRecipes`、`Events`、`FarmAnimals`、`Items`、`Mail`、`Songs`。
 
 </td>
 </tr>


### PR DESCRIPTION
Add 2 new type options to `Pathoschild.ContentPatcher_MigrateIds`

- `FarmAnimals`: migrate farm animals owned by the player
- `Buildings`: migrate farm buildings, note that going from a building with interior map to building without map destroys the interior map.
