### PR TITLE
[Content Patcher] Add step argument to Range token

### DIFF
--- a/ContentPatcher/Framework/Tokens/ValueProviders/RangeValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/RangeValueProvider.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using ContentPatcher.Framework.Conditions;
 
 namespace ContentPatcher.Framework.Tokens.ValueProviders;
@@ -54,9 +53,18 @@ internal class RangeValueProvider : BaseValueProvider
     {
         this.AssertInput(input);
 
-        return this.TryParseRange(input, out int min, out int max, out int step, out _)
-            ? Enumerable.Range(start: 0, count: (max - min) / step + 1).Select(p => (min + step * p).ToString())
-            : InvariantSets.Empty; // error will be shown in validation
+        if (this.TryParseRange(input, out int min, out int max, out int step, out _))
+        {
+            int count = (max - min) / step + 1;
+            string[] range = new string[count];
+
+            for (int i = 0; i < count; i++)
+                range[i] = (min + step * i).ToString();
+
+            return range;
+        }
+
+        return InvariantSets.Empty; // error will be shown in validation
     }
 
 

--- a/ContentPatcher/Framework/Tokens/ValueProviders/RangeValueProvider.cs
+++ b/ContentPatcher/Framework/Tokens/ValueProviders/RangeValueProvider.cs
@@ -23,6 +23,7 @@ internal class RangeValueProvider : BaseValueProvider
         : base(ConditionType.Range, mayReturnMultipleValuesForRoot: true, isDeterministicForInput: true)
     {
         this.EnableInputArguments(required: true, mayReturnMultipleValues: true, maxPositionalArgs: 2);
+        this.ValidNamedArguments = InvariantSets.FromValue("step");
         this.MarkReady(true);
     }
 
@@ -42,7 +43,7 @@ internal class RangeValueProvider : BaseValueProvider
         {
             return
                 base.TryValidateInput(input, out error)
-                && this.TryParseRange(input, out _, out _, out error);
+                && this.TryParseRange(input, out _, out _, out _, out error);
         }
 
         return true;
@@ -53,8 +54,8 @@ internal class RangeValueProvider : BaseValueProvider
     {
         this.AssertInput(input);
 
-        return this.TryParseRange(input, out int min, out int max, out _)
-            ? Enumerable.Range(start: min, count: max - min + 1).Select(p => p.ToString())
+        return this.TryParseRange(input, out int min, out int max, out int step, out _)
+            ? Enumerable.Range(start: 0, count: (max - min) / step + 1).Select(p => (min + step * p).ToString())
             : InvariantSets.Empty; // error will be shown in validation
     }
 
@@ -62,15 +63,17 @@ internal class RangeValueProvider : BaseValueProvider
     /*********
     ** Private methods
     *********/
-    /// <summary>Parse the numeric min/max values from a range specifier if it's valid.</summary>
+    /// <summary>Parse the numeric min/max values and step value from a range specifier if it's valid.</summary>
     /// <param name="input">The input arguments containing the range specifier.</param>
     /// <param name="min">The parsed min value, if valid.</param>
     /// <param name="max">The parsed max value, if valid.</param>
+    /// <param name="step">The parsed step value, if valid.</param>
     /// <param name="error">The error indicating why the range is invalid, if applicable.</param>
-    private bool TryParseRange(IInputArguments input, out int min, out int max, [NotNullWhen(false)] out string? error)
+    private bool TryParseRange(IInputArguments input, out int min, out int max, out int step, [NotNullWhen(false)] out string? error)
     {
         min = 0;
         max = 0;
+        step = 1;
 
         // check if input provided
         if (!input.HasPositionalArgs)
@@ -86,11 +89,19 @@ internal class RangeValueProvider : BaseValueProvider
         if (!int.TryParse(input.PositionalArgs[1], out max))
             return this.ParseError(input, $"can't parse max value '{input.PositionalArgs[1]}' as an integer", out error);
 
+        // parse step value if it exists
+        if (input.NamedArgs.TryGetValue("step", out IInputArgumentValue? stepArg) && !int.TryParse(stepArg.Raw, out step))
+            return this.ParseError(input, $"can't parse step argument '{stepArg.Raw}' as an integer", out error);
+
+        // validate step
+        if (step <= 0)
+            return this.ParseError(input, $"step argument must be a positive integer greater than 0", out error);
+
         // validate range
         if (min > max)
             return this.ParseError(input, $"min value '{min}' can't be greater than max value '{max}'", out error);
 
-        int count = (max - min) + 1;
+        int count = (max - min) / step + 1;
         if (count > RangeValueProvider.MaxCount)
             return this.ParseError(input, $"range can't exceed {RangeValueProvider.MaxCount} numbers (specified range would contain {count} numbers)", out error);
 

--- a/ContentPatcher/docs/author-guide/tokens.md
+++ b/ContentPatcher/docs/author-guide/tokens.md
@@ -829,12 +829,13 @@ for more info.
 <td>Range</td>
 <td>
 
-A list of integers between the specified min/max integers (inclusive). This is mainly meant for
+A list of integers between the specified min/max integers (inclusive). You may optionally specify an integer `step` argument to change how much each integer in the resulting list will differ by. This is mainly meant for
 comparing values; for example:
 
 ```js
 "When": {
    "Hearts:Abigail": "{{Range: 6, 14}}" // equivalent to "6, 7, 8, 9, 10, 11, 12, 13, 14"
+   "Time": "{{Range: 2000, 2300, step=100}}" // equivalent to "2000, 2100, 2200, 2300"
 }
 ```
 

--- a/ContentPatcher/docs/author-guide/tokens.md
+++ b/ContentPatcher/docs/author-guide/tokens.md
@@ -829,17 +829,24 @@ for more info.
 <td>Range</td>
 <td>
 
-A list of integers between the specified min/max integers (inclusive). You may optionally specify an integer `step` argument to change how much each integer in the resulting list will differ by. This is mainly meant for
-comparing values; for example:
+A list of integers between the specified min/max integers (inclusive). This is mainly meant for
+comparing values. For example:
 
 ```js
 "When": {
    "Hearts:Abigail": "{{Range: 6, 14}}" // equivalent to "6, 7, 8, 9, 10, 11, 12, 13, 14"
-   "Time": "{{Range: 2000, 2300, step=100}}" // equivalent to "2000, 2100, 2200, 2300"
 }
 ```
 
-You can use tokens for the individual numbers (like `{{Range:6, {{MaxHearts}}}}`) or both (like
+You can optionally set a `step` value, which is the amount to increment between each value (default
+1). For example:
+```js
+"When": {
+   "Hearts:Abigail": "{{Range: 2, 10 |step=2}}" // equivalent to "2, 4, 6, 8, 10"
+}
+```
+
+You can also use tokens for the individual numbers (like `{{Range:6, {{MaxHearts}}}}`) or both (like
 `{{Range:{{FriendshipRange}}}})`, as long as the final parsed input has the form `min, max`.
 
 To minimise the possible performance impact, the range can't exceed 5000 numbers and should be much

--- a/ContentPatcher/docs/zh/author-guide/tokens.md
+++ b/ContentPatcher/docs/zh/author-guide/tokens.md
@@ -795,6 +795,14 @@ _自定义农场ID_ | 模组里自定义农场类型的`ID`。
 }
 ```
 
+You can optionally set a `step` value, which is the amount to increment between each value (default
+1). For example:
+```js
+"When": {
+   "Hearts:Abigail": "{{Range: 2, 10 |step=2}}" //等同于"2, 4, 6, 8, 10"
+}
+```
+
 可在单个数值上使用令牌（比如`{{Range:6, {{MaxHearts}}}}`）或者一整个都用令牌（比如
 `{{Range:{{FriendshipRange}}}})`）只要符合`最小值, 最大值`的格式。
 


### PR DESCRIPTION
This PR adds an optional new named argument to the Range token called "step." This argument will change how much each element in the resulting set of the range differs by, rather than the Range token always creating a list whose numbers increment strictly by 1. The step argument is optional, as mentioned, and will default to 1 if it is omitted, which means the Range token will behave as it always has for existing content packs.

For example, consider the following two uses of the Range token:
`{{Range: 1, 5}}`
`{{Range: 1, 5 |step=1}}`

Both of these will result in the following list: `1, 2, 3, 4, 5`. However, with this PR, we can now change the step argument to create a different list:
`{{Range: 1, 5 |step=2}}`

This will result in the list `1, 3, 5`, having started from the `min` input and incremented (or 'stepped') up 2 numbers for each subsequent value up to and including the `max` of 5. If we were to instead write the following:
`{{Range: 1, 5 |step=3}}`

The resulting list would be `1, 4`, as it will still respect the `max` and not exceed it.

The calculation for how many numbers are in the resulting range has of course been adjusted as well, which means the limit of 5,000 numbers in one range still applies. The following usage will work:
`{{Range: 0, 6000 |step=100}}`

This will result in a list like `0, 100, 200, 300 [...]`, which clearly won't have more than 5,000 values. However, writing `{{Range: 0, 10000 |step=2}}` will _not_ work because the resulting list would be 5,001 values long.

The documentation has also been adjusted in this PR to describe this new functionality.