### PR TITLE
[ContentPatcher] Support includes for dynamic tokens

### DIFF
--- a/Common/Utilities/IInvariantSet.cs
+++ b/Common/Utilities/IInvariantSet.cs
@@ -14,7 +14,7 @@ internal interface IInvariantSet : IReadOnlySet<string>
 
     /// <summary>Get an invariant set with the given values added to this set's values.</summary>
     /// <param name="other">The values to add.</param>
-    IInvariantSet GetWith(ICollection<string> other);
+    IInvariantSet GetWith(IEnumerable<string> other);
 
     /// <summary>Get an invariant set with the given value removed from this set's values.</summary>
     /// <param name="other">The value to remove.</param>

--- a/Common/Utilities/InvariantSet.cs
+++ b/Common/Utilities/InvariantSet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Linq;
 
 namespace Pathoschild.Stardew.Common.Utilities;
 
@@ -139,9 +140,9 @@ internal class InvariantSet : IInvariantSet
     }
 
     /// <inheritdoc cref="IInvariantSet" />
-    public IInvariantSet GetWith(ICollection<string> other)
+    public IInvariantSet GetWith(IEnumerable<string> other)
     {
-        if (other.Count == 0)
+        if (!other.Any())
             return this;
 
         if (this.Count == 0)

--- a/ContentPatcher/Framework/AggregateContextual.cs
+++ b/ContentPatcher/Framework/AggregateContextual.cs
@@ -132,6 +132,12 @@ internal class AggregateContextual : IContextual
         );
     }
 
+    /// <summary>Get the token names used by this entity as mutable invariant set.</summary>
+    public MutableInvariantSet GetMutableTokensUsed()
+    {
+        return [.. this.ValuesImpl.SelectMany(p => p.GetTokensUsed())];
+    }
+
     /// <inheritdoc />
     public IContextualState GetDiagnosticState()
     {

--- a/ContentPatcher/Framework/ConfigModels/ContentConfig.cs
+++ b/ContentPatcher/Framework/ConfigModels/ContentConfig.cs
@@ -1,4 +1,7 @@
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Pathoschild.Stardew.Common;
 using Pathoschild.Stardew.Common.Utilities;
 using StardewModdingAPI;
@@ -48,5 +51,25 @@ internal class ContentConfig
         this.CustomLocations = customLocations ?? [];
         this.Changes = changes?.WhereNotNull().ToArray() ?? [];
         this.ConfigSchema = configSchema ?? new InvariantDictionary<ConfigSchemaFieldConfig?>();
+    }
+
+
+    /// <summary>Get the content fields which aren't allowed for a secondary file which were set.</summary>
+    /// <param name="content">The content to validate.</param>
+    public IEnumerable<string> GetInvalidFieldsForSubFile(params string[] allowedFields)
+    {
+        foreach (PropertyInfo property in typeof(ContentConfig).GetProperties())
+        {
+            if (allowedFields.Contains(property.Name))
+                continue;
+
+            object? value = property.GetValue(this);
+            bool hasValue = value is IEnumerable list
+                ? list.Cast<object>().Any()
+                : value != null;
+
+            if (hasValue)
+                yield return property.Name;
+        }
     }
 }

--- a/ContentPatcher/Framework/ConfigModels/DynamicTokenConfig.cs
+++ b/ContentPatcher/Framework/ConfigModels/DynamicTokenConfig.cs
@@ -1,4 +1,5 @@
 using Pathoschild.Stardew.Common.Utilities;
+using StardewModdingAPI.Utilities;
 
 namespace ContentPatcher.Framework.ConfigModels;
 
@@ -14,6 +15,9 @@ internal class DynamicTokenConfig
     /// <summary>The value to set.</summary>
     public string? Value { get; }
 
+    /// <summary>If set, include tokens from a dynamic token include file.</summary>
+    public string? IncludeFromFile { get; }
+
     /// <summary>The criteria to apply. See the README for valid values.</summary>
     public InvariantDictionary<string?> When { get; }
 
@@ -25,10 +29,11 @@ internal class DynamicTokenConfig
     /// <param name="name">The name of the token to set.</param>
     /// <param name="value">The value to set.</param>
     /// <param name="when">The criteria to apply. See the README for valid values.</param>
-    public DynamicTokenConfig(string name, string value, InvariantDictionary<string?>? when)
+    public DynamicTokenConfig(string name, string value, string? includeFromFile, InvariantDictionary<string?>? when)
     {
         this.Name = name;
         this.Value = value;
+        this.IncludeFromFile = PathUtilities.NormalizePath(includeFromFile);
         this.When = when ?? new();
     }
 }

--- a/ContentPatcher/Framework/ModTokenContext.cs
+++ b/ContentPatcher/Framework/ModTokenContext.cs
@@ -31,9 +31,12 @@ internal class ModTokenContext : IContext
     /// <summary>The dynamic tokens stored in the <see cref="DynamicContext"/>.</summary>
     private readonly InvariantDictionary<ManagedManualToken> DynamicTokens = new();
 
-    /// <summary>The possible values for the <see cref="DynamicTokens"/>.</summary>
-    /// <remarks>These must be stored in registration order, since each token value may affect the value of subsequent tokens.</remarks>
-    private readonly List<DynamicTokenValue> DynamicTokenValues = [];
+    /// <summary>
+    /// The contextual entities for the <see cref="DynamicTokens"/> that can receive context updates in <see cref="UpdateContext"/>.
+    /// They are either associated with a particular <see cref="DynamicTokens"/>, or serves only as parent to subsequent values.
+    /// </summary>
+    /// <remarks>These must be stored in registration order, since each contextual value may affect the value of subsequent tokens.</remarks>
+    private readonly List<DynamicTokenContextual> DynamicTokenContextualList = [];
 
     /// <summary>The alias token names defined for the content pack.</summary>
     private readonly InvariantDictionary<string> AliasTokenNames = new();
@@ -104,7 +107,8 @@ internal class ModTokenContext : IContext
     /// <param name="name">The token name.</param>
     /// <param name="rawValue">The token value to set.</param>
     /// <param name="conditions">The conditions that must match to set this value.</param>
-    public void AddDynamicToken(string name, IManagedTokenString rawValue, Condition[] conditions)
+    /// <param name="parent">The parent contextual entity of this dynamic token value.</param>
+    public void AddDynamicToken(string name, IManagedTokenString rawValue, Condition[] conditions, DynamicTokenContextual? parent)
     {
         // validate
         if (this.ParentContext.Contains(name, enforceContext: false))
@@ -121,7 +125,7 @@ internal class ModTokenContext : IContext
         }
 
         // create token value handler
-        var tokenValue = new DynamicTokenValue(managed, rawValue, conditions);
+        var tokenValue = new DynamicTokenValue(managed, rawValue, conditions, parent);
         IInvariantSet tokensUsed = tokenValue.GetTokensUsed().GetWithout(name);
 
         // save value info
@@ -132,8 +136,29 @@ internal class ModTokenContext : IContext
             managed.ValueProvider.SetValue(tokenValue.Value);
             managed.ValueProvider.SetReady(true);
         }
-        this.DynamicTokenValues.Add(tokenValue);
 
+        this.AddDynamicTokenContextual(tokenValue, tokensUsed);
+    }
+
+    /// <summary>Add a dynamic token value to the context.</summary>
+    /// <param name="name">The include name.</param>
+    /// <param name="conditions">The conditions to be updated in this context.</param>
+    /// <param name="parent">The parent contextual entity of this dynamic token value.</param>
+    /// <returns></returns>
+    public DynamicTokenContextual AddDynamicTokenInclude(string name, Condition[] conditions, DynamicTokenContextual? parent)
+    {
+        var tokenGroup = new DynamicTokenContextual(name, conditions, parent);
+        this.AddDynamicTokenContextual(tokenGroup, tokenGroup.GetTokensUsed().GetWithout(name));
+        return tokenGroup;
+    }
+
+    /// <summary>Add a dynamic token contextual entity.</summary>
+    /// <param name="tokenCtx">Token contextual entity to add</param>
+    /// <param name="tokensUsed">Tokens this contextual entity depends on</param>
+    private void AddDynamicTokenContextual(DynamicTokenContextual tokenCtx, IInvariantSet tokensUsed)
+    {
+        this.DynamicTokenContextualList.Add(tokenCtx);
+        string name = tokenCtx.Name;
         // track token dependencies
         if (tokensUsed.Any())
         {
@@ -152,7 +177,6 @@ internal class ModTokenContext : IContext
                 {
                     if (!this.DynamicTokenDependents.TryGetValue(dependency, out MutableInvariantSet? dependents))
                         this.DynamicTokenDependents[dependency] = dependents = [];
-
                     dependents.Add(name);
                 }
 
@@ -260,18 +284,22 @@ internal class ModTokenContext : IContext
                     }
                 }
 
-                foreach (DynamicTokenValue tokenValue in this.DynamicTokenValues)
+                foreach (DynamicTokenContextual tokenCtx in this.DynamicTokenContextualList)
                 {
-                    if (!resetDynamicTokens && !updateDynamicTokens!.Contains(tokenValue.Name))
-                        continue;
-
-                    tokenValue.UpdateContext(this);
-                    if (tokenValue.IsReady && tokenValue.Conditions.All(p => p.IsMatch))
+                    if (!resetDynamicTokens && !updateDynamicTokens!.Contains(tokenCtx.Name))
                     {
-                        ManualValueProvider valueProvider = tokenValue.ParentToken.ValueProvider;
+                        continue;
+                    }
+                    tokenCtx.UpdateContext(this);
+                    if (tokenCtx is DynamicTokenValue tokenValue)
+                    {
+                        if (tokenValue.IsReady && tokenValue.AllConditionsMatch())
+                        {
+                            ManualValueProvider valueProvider = tokenValue.ParentToken.ValueProvider;
 
-                        valueProvider.SetValue(tokenValue.Value);
-                        valueProvider.SetReady(true);
+                            valueProvider.SetValue(tokenValue.Value);
+                            valueProvider.SetReady(true);
+                        }
                     }
                 }
             }

--- a/ContentPatcher/Framework/PatchLoader.cs
+++ b/ContentPatcher/Framework/PatchLoader.cs
@@ -144,27 +144,26 @@ internal class PatchLoader
     /// <param name="tokenParser">Handles low-level parsing and validation for tokens.</param>
     /// <param name="path">The path to the value from the root content file.</param>
     /// <param name="conditions">The normalized conditions.</param>
-    /// <param name="immutableRequiredModIds">The immutable mod IDs always required by these conditions (if they're <see cref="ConditionType.HasMod"/> and immutable).</param>
+    /// <param name="requiredModIds">Mutable set of mod IDs always required by these conditions (if they're <see cref="ConditionType.HasMod"/> and immutable).</param>
     /// <param name="error">An error message indicating why normalization failed.</param>
-    public bool TryParseConditions(IDictionary<string, string?>? raw, TokenParser tokenParser, LogPathBuilder path, out Condition[] conditions, out IInvariantSet immutableRequiredModIds, [NotNullWhen(false)] out string? error)
+    public bool TryParseConditions(IDictionary<string, string?>? raw, TokenParser tokenParser, LogPathBuilder path, out Condition[] conditions, ref MutableInvariantSet? requiredModIds, [NotNullWhen(false)] out string? error)
     {
         // no conditions
         if (raw == null || !raw.Any())
         {
-            immutableRequiredModIds = InvariantSets.Empty;
             conditions = [];
             error = null;
             return true;
         }
 
         // parse conditions
-        MutableInvariantSet requiredModIds = [];
+        requiredModIds ??= [];
         InvariantDictionary<Condition> parsed = new();
         foreach ((string key, string? value) in raw.OrderBy(p => this.GetConditionParseOrder(p.Key, p.Value)))
         {
             if (!this.TryParseCondition(key, value, tokenParser, path.With(key), out Condition? condition, ref requiredModIds, out error))
             {
-                immutableRequiredModIds = InvariantSets.Empty;
+                requiredModIds = null;
                 conditions = [];
                 return false;
             }
@@ -172,10 +171,24 @@ internal class PatchLoader
             parsed[key] = condition;
         }
 
-        immutableRequiredModIds = requiredModIds.Lock();
         conditions = parsed.Values.ToArray();
         error = null;
         return true;
+    }
+
+    /// <summary>Normalize and parse the given condition values.</summary>
+    /// <param name="raw">The raw condition values to normalize.</param>
+    /// <param name="tokenParser">Handles low-level parsing and validation for tokens.</param>
+    /// <param name="path">The path to the value from the root content file.</param>
+    /// <param name="conditions">The normalized conditions.</param>
+    /// <param name="immutableRequiredModIDs">The immutable mod IDs always required by these conditions (if they're <see cref="ConditionType.HasMod"/> and immutable).</param>
+    /// <param name="error">An error message indicating why normalization failed.</param>
+    public bool TryParseConditions(IDictionary<string, string?>? raw, TokenParser tokenParser, LogPathBuilder path, out Condition[] conditions, out IInvariantSet immutableRequiredModIDs, [NotNullWhen(false)] out string? error)
+    {
+        MutableInvariantSet? requiredModIDs = null;
+        bool result = this.TryParseConditions(raw, tokenParser, path, out conditions, ref requiredModIDs, out error);
+        immutableRequiredModIDs = requiredModIDs?.Lock() ?? InvariantSet.Empty;
+        return result;
     }
 
     /// <summary>Normalize and parse the given update rate.</summary>

--- a/ContentPatcher/Framework/Patches/IncludePatch.cs
+++ b/ContentPatcher/Framework/Patches/IncludePatch.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using ContentPatcher.Framework.Conditions;
 using ContentPatcher.Framework.ConfigModels;
 using ContentPatcher.Framework.Tokens;
@@ -144,10 +142,10 @@ internal class IncludePatch : Patch
                 }
 
                 // validate fields
-                string[] invalidFields = this.GetInvalidFields(content).ToArray();
+                var invalidFields = content.GetInvalidFieldsForSubFile(nameof(ContentConfig.Changes));
                 if (invalidFields.Any())
                 {
-                    this.WarnForPatch($"file contains fields which aren't allowed for a secondary file ({string.Join(", ", invalidFields.OrderByHuman())}).");
+                    this.WarnForPatch($"file contains fields which aren't allowed for a content include file ({string.Join(", ", invalidFields.OrderByHuman())}).");
                     return;
                 }
 
@@ -204,25 +202,6 @@ internal class IncludePatch : Patch
         left = PathUtilities.NormalizeAssetName(left);
         right = PathUtilities.NormalizeAssetName(right);
         return left.EqualsIgnoreCase(right);
-    }
-
-    /// <summary>Get the content fields which aren't allowed for a secondary file which were set.</summary>
-    /// <param name="content">The content to validate.</param>
-    private IEnumerable<string> GetInvalidFields(ContentConfig content)
-    {
-        foreach (PropertyInfo property in typeof(ContentConfig).GetProperties())
-        {
-            if (property.Name == nameof(ContentConfig.Changes))
-                continue;
-
-            object? value = property.GetValue(content);
-            bool hasValue = value is IEnumerable list
-                ? list.Cast<object>().Any()
-                : value != null;
-
-            if (hasValue)
-                yield return property.Name;
-        }
     }
 
     /// <summary>Get the root log path for included patches.</summary>

--- a/ContentPatcher/Framework/ScreenManager.cs
+++ b/ContentPatcher/Framework/ScreenManager.cs
@@ -14,6 +14,7 @@ using StardewModdingAPI;
 using StardewModdingAPI.Enums;
 using StardewModdingAPI.Events;
 using StardewValley;
+using StardewValley.Extensions;
 
 namespace ContentPatcher.Framework;
 
@@ -248,72 +249,10 @@ internal class ScreenManager
                     foreach (KeyValuePair<string, ConfigField> pair in config)
                         this.AddConfigToken(pair.Key, pair.Value, modContext, current);
 
-                    // load dynamic tokens
                     IDictionary<string, int> dynamicTokenCountByName = new InvariantDictionary<int>();
                     foreach (DynamicTokenConfig entry in content.DynamicTokens)
                     {
-                        void LogSkip(string reason) => this.Monitor.Log($"Ignored {current.Manifest.Name} > dynamic token '{entry.Name}': {reason}", LogLevel.Warn);
-
-                        // get path
-                        LogPathBuilder localPath = current.LogPath.With(nameof(content.DynamicTokens));
-                        {
-                            string label = string.IsNullOrWhiteSpace(entry.Name)
-                                ? "unnamed"
-                                : entry.Name;
-
-                            dynamicTokenCountByName.TryAdd(label, -1);
-                            int discriminator = ++dynamicTokenCountByName[label];
-                            localPath = localPath.With($"{entry.Name} {discriminator}");
-                        }
-
-                        // validate token name
-                        if (string.IsNullOrWhiteSpace(entry.Name))
-                        {
-                            LogSkip("the token name can't be empty.");
-                            continue;
-                        }
-                        if (entry.Name.Contains(InternalConstants.PositionalInputArgSeparator))
-                        {
-                            LogSkip($"the token name can't have positional input arguments ({InternalConstants.PositionalInputArgSeparator} character).");
-                            continue;
-                        }
-                        if (Enum.TryParse<ConditionType>(entry.Name, true, out _))
-                        {
-                            LogSkip("the token name is already used by a global token.");
-                            continue;
-                        }
-                        if (config.ContainsKey(entry.Name))
-                        {
-                            LogSkip("the token name is already used by a config token.");
-                            continue;
-                        }
-
-                        // parse conditions
-                        Condition[] conditions;
-                        IInvariantSet immutableRequiredModIds;
-                        {
-                            if (!this.PatchLoader.TryParseConditions(entry.When, tokenParser, localPath.With(nameof(entry.When)), out conditions, out immutableRequiredModIds, out string? conditionError))
-                            {
-                                this.Monitor.Log($"Ignored {current.Manifest.Name} > '{entry.Name}' token: its {nameof(DynamicTokenConfig.When)} field is invalid: {conditionError}.", LogLevel.Warn);
-                                continue;
-                            }
-                        }
-
-                        // parse values
-                        IManagedTokenString? values;
-                        if (!string.IsNullOrWhiteSpace(entry.Value))
-                        {
-                            if (!tokenParser.TryParseString(entry.Value, immutableRequiredModIds, localPath.With(nameof(entry.Value)), out string? valueError, out values))
-                            {
-                                LogSkip($"the token value is invalid: {valueError}");
-                                continue;
-                            }
-                        }
-                        else
-                            values = new LiteralString("", localPath.With(nameof(entry.Value)));
-
-                        // add token
-                        modContext.AddDynamicToken(entry.Name, values, conditions);
+                        this.AddDynamicToken(current, config, modContext, tokenParser, dynamicTokenCountByName, entry);
                     }
                 }
 
@@ -366,6 +305,156 @@ internal class ScreenManager
         }
 
         this.CustomLocationManager.EnforceUniqueNames();
+    }
+
+    /// <summary>Register a dynamic token for a content pack, possibly one with includes.</summary>
+    /// <param name="current">Content pack</param>
+    /// <param name="config">Registered config tokens</param>
+    /// <param name="modContext">Token context</param>
+    /// <param name="tokenParser">Token parser</param>
+    /// <param name="dynamicTokenCountByName">Counter for number of times a specific dynamic token has been referenced</param>
+    /// <param name="entry">Dynamic token info</param>
+    /// <param name="parent">Parent dynamic token contextual entity</param>
+    /// <param name="requiredModIDs">Parent required mod IDs</param>
+    /// <returns></returns>
+    private bool AddDynamicToken(LoadedContentPack current, InvariantDictionary<ConfigField> config, ModTokenContext modContext, TokenParser tokenParser, IDictionary<string, int> dynamicTokenCountByName, DynamicTokenConfig entry, DynamicTokenContextual? parent = null, MutableInvariantSet? requiredModIDs = null)
+    {
+        void LogSkip(string reason) => this.Monitor.Log($"Ignored {current.Manifest.Name} > dynamic token '{entry.Name}': {reason}", LogLevel.Warn);
+
+        // validate token
+        if (!string.IsNullOrWhiteSpace(entry.IncludeFromFile))
+        {
+            if (!current.ContentPack.HasFile(entry.IncludeFromFile))
+            {
+                LogSkip($"the token include from file '{entry.IncludeFromFile}' does not exist.");
+                return false;
+            }
+            if (dynamicTokenCountByName.ContainsKey(entry.IncludeFromFile))
+            {
+                LogSkip($"the token include from file '{entry.IncludeFromFile}' has already been included once.");
+                return false;
+            }
+            if (entry.IncludeFromFile.StartsWith(DynamicTokenContextual.DynamicTokenIncludePrefix))
+            {
+                LogSkip($"the token include from file cannot start with '{DynamicTokenContextual.DynamicTokenIncludePrefix}'.");
+                return false;
+            }
+            var includeContent = current.ContentPack.ModContent.Load<ContentConfig>(entry.IncludeFromFile);
+            if (!includeContent.DynamicTokens.Any())
+            {
+                LogSkip($"the file '{entry.IncludeFromFile}' doesn't have anything in the {nameof(includeContent.Changes)} field. Is the file formatted correctly?.");
+                return false;
+            }
+            {
+                var invalidFields = includeContent.GetInvalidFieldsForSubFile(nameof(ContentConfig.DynamicTokens));
+                if (invalidFields.Any())
+                {
+                    LogSkip($"the file '{entry.IncludeFromFile}' contains fields which aren't allowed for a dynamic token include file ({string.Join(", ", invalidFields.OrderByHuman())}).");
+                    return false;
+                }
+            }
+
+            // Case 1: Dynamic token include group
+
+            LogPathBuilder localPath = MakeDynamicTokenLocalPath(current, dynamicTokenCountByName, entry, entry.IncludeFromFile);
+            // parse conditions
+            Condition[] conditions;
+            {
+                if (!this.PatchLoader.TryParseConditions(entry.When, tokenParser, localPath.With(nameof(entry.When)), out conditions, ref requiredModIDs, out string? conditionError))
+                {
+                    LogSkip($"its {nameof(DynamicTokenConfig.When)} field is invalid: {conditionError}.");
+                    return false;
+                }
+            }
+            // add token group if it has conditions
+            DynamicTokenContextual? tokenInclude = null;
+            if (parent != null || conditions.Any())
+            {
+                tokenInclude = modContext.AddDynamicTokenInclude(entry.IncludeFromFile, conditions, parent);
+            }
+            // add tokens
+            foreach (DynamicTokenConfig subEntry in includeContent.DynamicTokens)
+            {
+                this.AddDynamicToken(current, config, modContext, tokenParser, dynamicTokenCountByName, subEntry, tokenInclude, requiredModIDs);
+            }
+            return true;
+
+        }
+        else if (!string.IsNullOrWhiteSpace(entry.Name))
+        {
+            if (entry.Name.Contains(InternalConstants.PositionalInputArgSeparator))
+            {
+                LogSkip($"the token name can't have positional input arguments ({InternalConstants.PositionalInputArgSeparator} character).");
+                return false;
+            }
+            if (Enum.TryParse<ConditionType>(entry.Name, true, out _))
+            {
+                LogSkip("the token name is already used by a global token.");
+                return false;
+            }
+            if (config.ContainsKey(entry.Name))
+            {
+                LogSkip("the token name is already used by a config token.");
+                return false;
+            }
+            if (entry.Name.StartsWith(DynamicTokenContextual.DynamicTokenIncludePrefix))
+            {
+                LogSkip($"the token name cannot start with '{DynamicTokenContextual.DynamicTokenIncludePrefix}'.");
+                return false;
+            }
+
+            // CASE 2: Concrete dynamic token
+
+            LogPathBuilder localPath = MakeDynamicTokenLocalPath(current, dynamicTokenCountByName, entry, entry.Name);
+            // parse conditions
+            MutableInvariantSet? thisRequiredModIDs = requiredModIDs != null ? new(requiredModIDs) : null;
+            Condition[] conditions;
+            {
+                if (!this.PatchLoader.TryParseConditions(entry.When, tokenParser, localPath.With(nameof(entry.When)), out conditions, ref thisRequiredModIDs, out string? conditionError))
+                {
+                    LogSkip($"its {nameof(DynamicTokenConfig.When)} field is invalid: {conditionError}.");
+                    return false;
+                }
+            }
+            IInvariantSet assumeModIds = thisRequiredModIDs?.Lock() ?? InvariantSets.Empty;
+
+            // parse values
+            IManagedTokenString? values;
+            if (!string.IsNullOrWhiteSpace(entry.Value))
+            {
+                if (!tokenParser.TryParseString(entry.Value, assumeModIds, localPath.With(nameof(entry.Value)), out string? valueError, out values))
+                {
+                    LogSkip($"the token value is invalid: {valueError}");
+                    return false;
+                }
+            }
+            else
+                values = new LiteralString("", localPath.With(nameof(entry.Value)));
+
+            // add token
+            modContext.AddDynamicToken(entry.Name, values, conditions, parent);
+            return true;
+        }
+        else
+        {
+            LogSkip("the token entry must have either 'Name' or 'IncludeFromFile'.");
+            return false;
+        }
+    }
+
+    /// <summary>Create dynamic token specific log path builder.</summary>
+    /// <param name="current">Current content pack</param>
+    /// <param name="dynamicTokenCountByName">Counter for number of times a specific dynamic token has been referenced</param>
+    /// <param name="entry">Dynamic token config entry</param>
+    /// <param name="logPathLabel">Label to use in log</param>
+    /// <returns></returns>
+    private static LogPathBuilder MakeDynamicTokenLocalPath(LoadedContentPack current, IDictionary<string, int> dynamicTokenCountByName, DynamicTokenConfig entry, string logPathLabel)
+    {
+        LogPathBuilder localPath = current.LogPath.With(nameof(current.Content.DynamicTokens));
+        dynamicTokenCountByName.TryAdd(logPathLabel, -1);
+        int discriminator = ++dynamicTokenCountByName[logPathLabel];
+        localPath = localPath.With($"{logPathLabel} {discriminator}");
+        return localPath;
     }
 
     /// <summary>Reapply a content pack when its configuration changes.</summary>

--- a/ContentPatcher/Framework/TokenParser.cs
+++ b/ContentPatcher/Framework/TokenParser.cs
@@ -107,6 +107,24 @@ internal class TokenParser
             : InputArguments.Empty;
     }
 
+    /// <summary>Fetch iterator of required but not loaded mods.</summary>
+    /// <param name="requiredModIDs">Mod IDs required</param>
+    /// <param name="notInstalledRequiredModIDs">Iterator of not installed mod ID</param>
+    /// <returns>True if there are any required but not loaded Mod IDs</returns>
+    public bool TryGetRequiredNotInstalledModIDs(ISet<string>? requiredModIDs, [NotNullWhen(true)] out IEnumerable<string>? notInstalledRequiredModIDs)
+    {
+        notInstalledRequiredModIDs = null;
+        if (requiredModIDs != null)
+        {
+            notInstalledRequiredModIDs = requiredModIDs.Where(modId => !this.InstalledMods.Contains(modId));
+            if (notInstalledRequiredModIDs.Any())
+                return true;
+            else
+                notInstalledRequiredModIDs = null;
+        }
+        return false;
+    }
+
     /// <summary>Parse a string which can contain tokens or be null, and validate that it's valid.</summary>
     /// <param name="rawValue">The raw string which may contain tokens.</param>
     /// <param name="assumeModIds">Mod IDs to assume are installed for purposes of token validation.</param>

--- a/ContentPatcher/Framework/Tokens/DynamicTokenContextual.cs
+++ b/ContentPatcher/Framework/Tokens/DynamicTokenContextual.cs
@@ -1,0 +1,94 @@
+using System.Linq;
+using ContentPatcher.Framework.Conditions;
+using Pathoschild.Stardew.Common.Utilities;
+using StardewValley.Extensions;
+
+namespace ContentPatcher.Framework.Tokens;
+
+/// <summary>A holder for dynamic token conditions.</summary>
+internal class DynamicTokenContextual : IContextual
+{
+    /// <summary>Namespace used for dynamic token includes</summary>
+    internal const string DynamicTokenIncludePrefix = "<CP-DT-Include>";
+
+    /*********
+    ** Fields
+    *********/
+    /// <summary>Backing field for name</summary>
+    private readonly string NameImpl = string.Empty;
+
+    /// <summary>The underlying contextual values.</summary>
+    protected readonly AggregateContextual Contextuals = new();
+
+    /*********
+    ** Accessors
+    *********/
+    /// <summary>The conditions that must match to set this value.</summary>
+    public Condition[] Conditions { get; }
+
+    /// <summary>The name of the token whose value to set.</summary>
+    public virtual string Name => this.NameImpl;
+
+    /// <summary>A parent contextual whose conditions must all match as well</summary>
+    public DynamicTokenContextual? Parent { get; }
+
+    /// <inheritdoc />
+    public bool IsMutable => (this.Parent?.IsMutable ?? false) || this.Contextuals.IsMutable;
+
+    /// <inheritdoc />
+    public bool IsReady => (this.Parent?.IsReady ?? true) && this.Contextuals.IsReady;
+
+    /*********
+    ** Protected methods
+    *********/
+    /// <summary>Create a new DynamicTokenContextual</summary>
+    /// <param name="conditions">list of conditions</param>
+    /// <param name="parent">parent contextual</param>
+    protected DynamicTokenContextual(Condition[] conditions, DynamicTokenContextual? parent)
+    {
+        this.Parent = parent;
+        this.Conditions = conditions;
+        this.Contextuals.Add(this.Conditions);
+    }
+    /*********
+    ** Public methods
+    *********/
+    /// <summary>Create a new DynamicTokenContextual that is named</summary>
+    /// <param name="name">name of this context</param>
+    /// <param name="conditions">list of conditions</param>
+    /// <param name="parent">parent contextual</param>
+    public DynamicTokenContextual(string name, Condition[] conditions, DynamicTokenContextual? parent) : this(conditions, parent)
+    {
+        this.NameImpl = string.Concat(DynamicTokenIncludePrefix, name);
+    }
+
+    /// <summary>Check that all conditions of this contextual as it's parent matches</summary>
+    /// <returns>match state</returns>
+    public bool AllConditionsMatch()
+    {
+        return (this.Parent?.AllConditionsMatch() ?? true) && this.Conditions.All(p => p.IsMatch);
+    }
+
+    /// <inheritdoc />
+    public bool UpdateContext(IContext context)
+    {
+        return this.Contextuals.UpdateContext(context);
+    }
+
+    /// <inheritdoc />
+    public IInvariantSet GetTokensUsed()
+    {
+        MutableInvariantSet tokensUsed = this.Contextuals.GetMutableTokensUsed();
+        if (this.Parent != null)
+        {
+            tokensUsed.AddRange(this.Parent.Contextuals.GetMutableTokensUsed());
+        }
+        return tokensUsed.Lock();
+    }
+
+    /// <inheritdoc />
+    public IContextualState GetDiagnosticState()
+    {
+        return this.Contextuals.GetDiagnosticState();
+    }
+}

--- a/ContentPatcher/Framework/Tokens/DynamicTokenValue.cs
+++ b/ContentPatcher/Framework/Tokens/DynamicTokenValue.cs
@@ -1,39 +1,21 @@
 using ContentPatcher.Framework.Conditions;
-using Pathoschild.Stardew.Common.Utilities;
 
 namespace ContentPatcher.Framework.Tokens;
 
 /// <summary>A conditional value for a dynamic token.</summary>
-internal class DynamicTokenValue : IContextual
+internal class DynamicTokenValue : DynamicTokenContextual
 {
-    /*********
-    ** Fields
-    *********/
-    /// <summary>The underlying contextual values.</summary>
-    private readonly AggregateContextual Contextuals;
-
-
     /*********
     ** Accessors
     *********/
     /// <summary>The token for which this value is registered.</summary>
     public ManagedManualToken ParentToken { get; }
 
-    /// <summary>The name of the token whose value to set.</summary>
-    public string Name => this.ParentToken.ValueProvider.Name;
+    /// <inheritdoc/>
+    public override string Name => this.ParentToken.ValueProvider.Name;
 
     /// <summary>The token value to set.</summary>
     public ITokenString Value { get; }
-
-    /// <summary>The conditions that must match to set this value.</summary>
-    public Condition[] Conditions { get; }
-
-    /// <inheritdoc />
-    public bool IsMutable => this.Contextuals.IsMutable;
-
-    /// <inheritdoc />
-    public bool IsReady => this.Contextuals.IsReady;
-
 
     /*********
     ** Public methods
@@ -42,31 +24,10 @@ internal class DynamicTokenValue : IContextual
     /// <param name="parentToken">The token whose value to set.</param>
     /// <param name="value">The token value to set.</param>
     /// <param name="conditions">The conditions that must match to set this value.</param>
-    public DynamicTokenValue(ManagedManualToken parentToken, IManagedTokenString value, Condition[] conditions)
+    public DynamicTokenValue(ManagedManualToken parentToken, IManagedTokenString value, Condition[] conditions, DynamicTokenContextual? parent) : base(conditions, parent)
     {
         this.ParentToken = parentToken;
         this.Value = value;
-        this.Conditions = conditions;
-        this.Contextuals = new AggregateContextual()
-            .Add(value)
-            .Add(this.Conditions);
-    }
-
-    /// <inheritdoc />
-    public bool UpdateContext(IContext context)
-    {
-        return this.Contextuals.UpdateContext(context);
-    }
-
-    /// <inheritdoc />
-    public IInvariantSet GetTokensUsed()
-    {
-        return this.Contextuals.GetTokensUsed();
-    }
-
-    /// <inheritdoc />
-    public IContextualState GetDiagnosticState()
-    {
-        return this.Contextuals.GetDiagnosticState();
+        this.Contextuals.Add(value);
     }
 }


### PR DESCRIPTION
## Summary
Add a way to include dynamic tokens from another file like so:
```
{
  "$schema": "https://smapi.io/schemas/content-patcher.json",
  "Format": "2.9.0",
  "DynamicTokens": [
    {
      "IncludeFromFile": "dt_include/standard.json"
    },
  ]
}
```
The file `dt_include/standard.json` is only allowed to have `DynamicTokens` section, and dynamic tokens defined inside will behaves as if they were defined at the position of the include in `content.json`. You can have nested includes, but not repeated include of same file (at the moment).

`When` is supported for dynamic token includes, and tokens within a include is only evaluated if the include's conditions are all true.

```
{
  "DynamicTokens": [
    {
      "IncludeFromFile": "dt_include/conditional.json",
      "When": { "Season": "Spring" }
    },
  ]
}
```

If the `When` section on an include contains a `HasMod` condition that will never be true (i.e. mod not installed), the tokens inside will not be added.

In this example, if the dynamic token `"MyTok"` is defined within `dt_include/cmct.json` and nowhere else, it will be valid only if `Spiderbuttons.CMCT` is installed and invalid otherwise.
```
{
  "DynamicTokens": [
    {
      "IncludeFromFile": "dt_include/cmct.json",
      "When": { "HasMod": "Spiderbuttons.CMCT" }
    },
  ]
}
```

On the other hand if `MyTok` is defined like this in content.json, it will only be unready if `Spiderbuttons.CMCT` is not installed, rather than invalid.
```
{
  "DynamicTokens": [
    {
      "Name": "MyTok",
      "Value": "Token Value Goes Here",
      "When": { "HasMod": "Spiderbuttons.CMCT" }
    },
  ]
}
```

## Examples
[DT_Includes.zip](https://github.com/user-attachments/files/24756725/DT_Includes.zip)