### PR TITLE
Change `patch reload` to fully reload the content pack

### DIFF
--- a/ContentPatcher/Framework/Commands/CommandHandler.cs
+++ b/ContentPatcher/Framework/Commands/CommandHandler.cs
@@ -57,6 +57,7 @@ internal class CommandHandler : GenericCommandHandler
                 monitor: monitor,
                 getPatchLoader: () => screenManager.Value.PatchLoader,
                 getPatchManager: () => screenManager.Value.PatchManager,
+                getScreenManager: () => screenManager.Value,
                 contentPacks: contentPacks,
                 updateContext: updateContext
             ),

--- a/ContentPatcher/Framework/Commands/Commands/ReloadCommand.cs
+++ b/ContentPatcher/Framework/Commands/Commands/ReloadCommand.cs
@@ -21,6 +21,9 @@ internal class ReloadCommand : BaseCommand
     /// <summary>Manages loaded patches.</summary>
     private readonly Func<PatchManager> GetPatchManager;
 
+    /// <summary>Manages content assets for a screen.</summary>
+    private readonly Func<ScreenManager> GetScreenManager;
+
     /// <summary>The loaded content packs.</summary>
     private readonly LoadedContentPack[] ContentPacks;
 
@@ -37,11 +40,12 @@ internal class ReloadCommand : BaseCommand
     /// <param name="getPatchManager">Manages loaded patches.</param>
     /// <param name="contentPacks">The loaded content packs.</param>
     /// <param name="updateContext">A callback which immediately updates the current condition context.</param>
-    public ReloadCommand(IMonitor monitor, Func<PatchLoader> getPatchLoader, Func<PatchManager> getPatchManager, LoadedContentPack[] contentPacks, Action updateContext)
+    public ReloadCommand(IMonitor monitor, Func<PatchLoader> getPatchLoader, Func<PatchManager> getPatchManager, Func<ScreenManager> getScreenManager, LoadedContentPack[] contentPacks, Action updateContext)
         : base(monitor, "reload")
     {
         this.GetPatchLoader = getPatchLoader;
         this.GetPatchManager = getPatchManager;
+        this.GetScreenManager = getScreenManager;
         this.ContentPacks = contentPacks;
         this.UpdateContext = updateContext;
     }
@@ -65,6 +69,7 @@ internal class ReloadCommand : BaseCommand
     {
         var patchLoader = this.GetPatchLoader();
         var patchManager = this.GetPatchManager();
+        var screenManager = this.GetScreenManager();
 
         // get args
         string packId = ArgUtility.Get(args, 0, allowBlank: false);
@@ -76,7 +81,7 @@ internal class ReloadCommand : BaseCommand
         }
 
         // get pack
-        RawContentPack? pack = this.ContentPacks.SingleOrDefault(p => p.Manifest.UniqueID == packId);
+        LoadedContentPack? pack = this.ContentPacks.SingleOrDefault(p => p.Manifest.UniqueID == packId);
         if (pack == null)
         {
             this.Monitor.Log($"No Content Patcher content pack with the unique ID \"{packId}\".", LogLevel.Error);
@@ -121,15 +126,16 @@ internal class ReloadCommand : BaseCommand
                 return;
             }
 
-            // reload patches
-            patchLoader.LoadPatches(
-                contentPack: pack,
-                rawPatches: pack.Content.Changes,
-                inheritLocalTokens: null,
-                rootIndexPath: [pack.Index],
-                path: new LogPathBuilder(pack.Manifest.Name),
-                parentPatch: null
-            );
+            try
+            {
+                pack.ReloadConfig();
+            }
+            catch (Exception ex)
+            {
+                this.Monitor.Log($"Error reloading configuration for content pack '{pack.ContentPack.Manifest.Name}'. Technical details:\n{ex}", LogLevel.Error);
+            }
+
+            screenManager.ReloadContentPack(pack);
         }
 
         // make the changes apply

--- a/ContentPatcher/Framework/ConfigFileHandler.cs
+++ b/ContentPatcher/Framework/ConfigFileHandler.cs
@@ -54,7 +54,7 @@ internal class ConfigFileHandler
     /// <param name="contentPack">The content pack.</param>
     /// <param name="config">The configuration to save.</param>
     /// <param name="modHelper">The mod helper through which to save the file.</param>
-    public void Save(IContentPack contentPack, InvariantDictionary<ConfigField> config, IModHelper modHelper)
+    public void Save(IContentPack contentPack, InvariantDictionary<ConfigField> config)
     {
         // save if settings valid
         if (config.Any())

--- a/ContentPatcher/Framework/GenericModConfigMenuIntegrationForContentPack.cs
+++ b/ContentPatcher/Framework/GenericModConfigMenuIntegrationForContentPack.cs
@@ -20,7 +20,7 @@ internal class GenericModConfigMenuIntegrationForContentPack : IGenericModConfig
     private readonly IContentPack ContentPack;
 
     /// <summary>The config model.</summary>
-    private readonly InvariantDictionary<ConfigField> Config;
+    public InvariantDictionary<ConfigField> Config { get; set; }
 
     /// <summary>Parse a comma-delimited set of case-insensitive condition values.</summary>
     private readonly Func<string, IInvariantSet> ParseCommaDelimitedField;

--- a/ContentPatcher/Framework/LoadedContentPack.cs
+++ b/ContentPatcher/Framework/LoadedContentPack.cs
@@ -1,5 +1,7 @@
 using ContentPatcher.Framework.ConfigModels;
+using Pathoschild.Stardew.Common.Integrations.GenericModConfigMenu;
 using Pathoschild.Stardew.Common.Utilities;
+using StardewModdingAPI;
 
 namespace ContentPatcher.Framework;
 
@@ -13,8 +15,10 @@ internal class LoadedContentPack : RawContentPack
     public ConfigFileHandler ConfigFileHandler { get; }
 
     /// <summary>The content pack's configuration.</summary>
-    public InvariantDictionary<ConfigField> Config { get; }
-
+    public InvariantDictionary<ConfigField> Config { get; private set; }
+    public GenericModConfigMenuIntegrationForContentPack GMCMConfigMenu { get; internal set; }
+    public GenericModConfigMenuIntegration<InvariantDictionary<ConfigField>> GMCMAPI { get; internal set; }
+    private IMonitor Monitor { get; }
 
     /*********
     ** Public methods
@@ -23,10 +27,21 @@ internal class LoadedContentPack : RawContentPack
     /// <param name="contentPack">The raw content pack instance.</param>
     /// <param name="configFileHandler">Handles reading, normalizing, and saving the configuration for the content pack.</param>
     /// <param name="config">The content pack's configuration.</param>
-    public LoadedContentPack(RawContentPack contentPack, ConfigFileHandler configFileHandler, InvariantDictionary<ConfigField> config)
+    public LoadedContentPack(RawContentPack contentPack, ConfigFileHandler configFileHandler, InvariantDictionary<ConfigField> config, IMonitor monitor)
         : base(contentPack)
     {
         this.ConfigFileHandler = configFileHandler;
         this.Config = config;
+        this.Monitor = monitor;
+    }
+
+    public void ReloadConfig()
+    {
+        var config = this.ConfigFileHandler.Read(this.ContentPack, this.Content.ConfigSchema, this.Content.Format!);
+        this.ConfigFileHandler.Save(this.ContentPack, config);
+        this.Config = config;
+
+        this.GMCMConfigMenu.Config = config;
+        this.GMCMConfigMenu.Register(this.GMCMAPI, this.Monitor);
     }
 }

--- a/ContentPatcher/Framework/Locations/CustomLocationManager.cs
+++ b/ContentPatcher/Framework/Locations/CustomLocationManager.cs
@@ -7,6 +7,7 @@ using ContentPatcher.Framework.ConfigModels;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
+using StardewValley.Extensions;
 using StardewValley.GameData.Locations;
 using xTile;
 
@@ -64,6 +65,11 @@ internal class CustomLocationManager
             this.CustomLocationsByMapPath[this.ContentHelper.ParseAssetName(parsed.PublicMapPath)] = parsed;
 
         return true;
+    }
+
+    public int ClearContentPack(IContentPack contentPack)
+    {
+        return this.CustomLocations.RemoveWhere(location => location.ContentPack.Manifest.UniqueID == contentPack.Manifest.UniqueID);
     }
 
     /// <summary>Enforce that custom location maps have a unique name.</summary>

--- a/ContentPatcher/Framework/PatchLoader.cs
+++ b/ContentPatcher/Framework/PatchLoader.cs
@@ -137,6 +137,7 @@ internal class PatchLoader
     public void UnloadPatchesLoadedBy(RawContentPack pack)
     {
         this.UnloadPatches(patch => patch.ContentPack == pack.ContentPack);
+        this.PatchManager.ClearPermanentlyDisabledPatchesForPack(pack.ContentPack);
     }
 
     /// <summary>Normalize and parse the given condition values.</summary>

--- a/ContentPatcher/Framework/PatchManager.cs
+++ b/ContentPatcher/Framework/PatchManager.cs
@@ -408,6 +408,11 @@ internal class PatchManager
         return this.PermanentlyDisabledPatches;
     }
 
+    public void ClearPermanentlyDisabledPatchesForPack(IContentPack contentPack)
+    {
+        this.PermanentlyDisabledPatches.RemoveWhere(patch => patch.ContentPack.Manifest.UniqueID == contentPack.Manifest.UniqueID);
+    }
+
     /// <summary>Get patches which load the given asset in the current context.</summary>
     /// <param name="request">The asset request being intercepted.</param>
     public IEnumerable<LoadPatch> GetCurrentLoaders(AssetRequestedEventArgs request)

--- a/ContentPatcher/Framework/ScreenManager.cs
+++ b/ContentPatcher/Framework/ScreenManager.cs
@@ -55,6 +55,8 @@ internal class ScreenManager
     /// <summary>Whether <see cref="Initialize"/> has been called for this instance.</summary>
     public bool IsInitialized { get; private set; }
 
+    private IInvariantSet InstalledMods;
+
 
     /*********
     ** Public methods
@@ -70,6 +72,7 @@ internal class ScreenManager
     {
         this.Helper = helper;
         this.Monitor = monitor;
+        this.InstalledMods = installedMods;
         this.TokenManager = new TokenManager(helper.GameContent, installedMods, modTokens);
         this.PatchManager = new PatchManager(this.Monitor, this.TokenManager, assetValidators, profiler);
         this.PatchLoader = new PatchLoader(this.PatchManager, this.TokenManager, this.Monitor, installedMods, helper.GameContent.ParseAssetName);
@@ -215,6 +218,20 @@ internal class ScreenManager
         this.PatchManager.UpdateContext(this.Helper.GameContent, changedGlobalTokens, updateType);
     }
 
+    public void ReloadContentPack(LoadedContentPack contentPack)
+    {
+        this.TokenManager.ClearLocalToken(contentPack.ContentPack);
+        int oldLocations = this.CustomLocationManager.ClearContentPack(contentPack.ContentPack);
+
+        this.LoadContentPacks([contentPack], this.InstalledMods);
+
+        int newLocations = this.CustomLocationManager.GetCustomLocationData().Where(location => location.ContentPack.Manifest.UniqueID == contentPack.Manifest.UniqueID).Count();
+
+        if (oldLocations > 0 || newLocations > 0)
+        {
+            this.Helper.GameContent.InvalidateCache("Data/Locations");
+        }
+    }
 
     /*********
     ** Private methods

--- a/ContentPatcher/Framework/TokenManager.cs
+++ b/ContentPatcher/Framework/TokenManager.cs
@@ -76,6 +76,12 @@ internal class TokenManager : IContext
             this.GlobalContext.Save(new Token(valueProvider));
     }
 
+    public bool ClearLocalToken(IContentPack pack)
+    {
+        string scope = pack.Manifest.UniqueID.Trim();
+        return this.LocalTokens.Remove(scope);
+    }
+
     /// <summary>Get the tokens which are defined for a specific content pack. This returns a reference to the list, which can be held for a live view of the tokens. If the content pack isn't currently tracked, this will add it.</summary>
     /// <param name="pack">The content pack to manage.</param>
     public ModTokenContext TrackLocalTokens(IContentPack pack)

--- a/ContentPatcher/ModEntry.cs
+++ b/ContentPatcher/ModEntry.cs
@@ -325,6 +325,8 @@ internal class ModEntry : Mod
                     break;
 
                 var configMenu = new GenericModConfigMenuIntegrationForContentPack(contentPack.ContentPack, this.ParseCommaDelimitedField, config);
+                contentPack.GMCMAPI = api;
+                contentPack.GMCMConfigMenu = configMenu;
                 configMenu.Register(api, this.Monitor);
             }
         }
@@ -371,7 +373,7 @@ internal class ModEntry : Mod
     private void OnContentPackConfigChanged(LoadedContentPack contentPack)
     {
         // re-save config.json
-        contentPack.ConfigFileHandler.Save(contentPack.ContentPack, contentPack.Config, this.Helper);
+        contentPack.ConfigFileHandler.Save(contentPack.ContentPack, contentPack.Config);
 
         // update tokens
         foreach (var screenManager in this.ScreenManager.GetActiveValues())
@@ -476,7 +478,7 @@ internal class ModEntry : Mod
             {
                 configFileHandler = new ConfigFileHandler("config.json", this.ParseCommaDelimitedField, (pack, label, reason) => this.Monitor.Log($"Ignored {pack.Manifest.Name} > {label}: {reason}", LogLevel.Warn));
                 config = configFileHandler.Read(contentPack, rawContentPack.Content.ConfigSchema, rawContentPack.Content.Format!);
-                configFileHandler.Save(contentPack, config, this.Helper);
+                configFileHandler.Save(contentPack, config);
             }
             catch (Exception ex)
             {
@@ -485,7 +487,7 @@ internal class ModEntry : Mod
             }
 
             // build content pack
-            yield return new LoadedContentPack(rawContentPack, configFileHandler, config);
+            yield return new LoadedContentPack(rawContentPack, configFileHandler, config, this.Monitor);
         }
     }
 


### PR DESCRIPTION
This enables the reload command to work on ConfigSchema, CustomLocations, Token Aliases and Dynamic Tokens

https://youtu.be/TGmLqEWS7T4


The changes in PatchLoader and PatchManager are technically unrelated but is for a separate issue where if a patch is permanently disabled from being invalid, patch reload doesn't remove it. This fixes the common case where you invalidate the entire content pack, but not the lesser case when invalidating a specific patch and its descendents.
