### PR TITLE
[Lookup Anything] Add count planted for seeds and saplings

### DIFF
--- a/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
+++ b/LookupAnything/Framework/Lookups/Items/ItemSubject.cs
@@ -399,6 +399,87 @@ internal class ItemSubject : BaseSubject
             // owned
             yield return new GenericField(I18n.Item_NumberOwned(), this.GetNumberOwnedText(item));
 
+            // crops planted
+            if (isSeed)
+            {
+                int cropsPlanted = 0;
+                Utility.ForEachCrop((crop) =>
+                {
+                    if (crop.netSeedIndex.Value == item.ItemId ||
+                            (CommonHelper.IsItemId(crop.whichForageCrop.Value, allowZero: false) && crop.whichForageCrop.Value == item.ItemId))
+                    {
+                        cropsPlanted++;
+                    }
+                    return true;
+                });
+                yield return new GenericField(I18n.Item_NumberPlanted(), I18n.Item_CropCount_Summary(count: cropsPlanted));
+            }
+
+            // wild tree seeds planted
+            if (obj?.IsWildTreeSapling() is true)
+            {
+                int seedsPlanted = 0;
+                Utility.ForEachLocation((location) =>
+                {
+                    // Only considers plantable locations (ie. ignore wild trees spawned on non-plantable locations)
+                    if (!this.IsLocationPlantable(location))
+                    {
+                        return true;
+                    }
+                    foreach (var terrainFeature in location.terrainFeatures.Values)
+                    {
+                        if (terrainFeature is Tree tree &&
+                                 ItemRegistry.QualifyItemId(tree.GetData()?.SeedItemId) == item.QualifiedItemId)
+                        {
+                            seedsPlanted++;
+                        }
+                    }
+                    return true;
+                });
+                yield return new GenericField(I18n.Item_NumberPlanted(), I18n.Item_WildTreeCount_Summary(count: seedsPlanted));
+            }
+
+            // fruit tree saplings planted
+            if (obj?.IsFruitTreeSapling() is true)
+            {
+                int saplingsPlanted = 0;
+                Utility.ForEachLocation((location) =>
+                {
+                    // Only considers plantable locations (ie. ignore "wild" fruit trees spawned on non-plantable locations by mods)
+                    if (!this.IsLocationPlantable(location))
+                    {
+                        return true;
+                    }
+                    foreach (var terrainFeature in location.terrainFeatures.Values)
+                    {
+                        if (terrainFeature is FruitTree fruitTree &&
+                                 fruitTree.treeId.Value == item.ItemId)
+                        {
+                            saplingsPlanted++;
+                        }
+                    }
+                    return true;
+                });
+                yield return new GenericField(I18n.Item_NumberPlanted(), I18n.Item_FruitTreeCount_Summary(count: saplingsPlanted));
+            }
+
+            if (obj?.IsTeaSapling() is true)
+            {
+                int bushesPlanted = 0;
+                Utility.ForEachLocation((location) =>
+                {
+                    foreach (var bush in this.GetEveryBushInLocation(location))
+                    {
+                        if (item.QualifiedItemId == this.GetSaplingQualifiedIdForBush(bush))
+                        {
+                            bushesPlanted++;
+                        }
+                    }
+                    return true;
+                });
+                yield return new GenericField(I18n.Item_NumberPlanted(), I18n.Item_BushCount_Summary(count: bushesPlanted));
+            }
+
             // times crafted
             RecipeModel[] recipes = this.GameHelper
                 .GetRecipes()
@@ -1088,6 +1169,52 @@ internal class ItemSubject : BaseSubject
             .Where(p => this.IsIngredientNeeded(bundle, p))
             .Sum(p => p.Stack);
     }
+
+    /// <summary>Returns whether this location is normally plantable by the farmer. We want to only check these locations when counting trees planted and to ignore "wild" trees spawned by other mods.</summary>
+    /// <param name="location">The location to check.</param>
+    private bool IsLocationPlantable(GameLocation location)
+    {
+        return location.GetData()?.CanPlantHere ?? location.IsFarm;
+    }
+
+    private string? GetSaplingQualifiedIdForBush(Bush bush)
+    {
+        // Is modded bush from Custom Bush
+        if (this.GameHelper.CustomBush.IsLoaded
+                && this.GameHelper.CustomBush.TryGetCustomBush(bush, out string? id))
+        {
+            return id;
+        }
+        // Is vanilla tea bush
+        else if (bush.size.Value == Bush.greenTeaBush)
+        {
+            return "(O)251";
+        }
+        return null;
+    }
+
+    /// <summary>Returns an iterator over every bush in the location, on the ground or in garden pots. The former will only be checked if the location is plantable.</summary>
+    private IEnumerable<Bush> GetEveryBushInLocation(GameLocation location)
+    {
+        if (this.IsLocationPlantable(location))
+        {
+            foreach (var terrainFeature in location.terrainFeatures.Values)
+            {
+                if (terrainFeature is Bush bush)
+                {
+                    yield return bush;
+                }
+            }
+        }
+        foreach (var obj in location.Objects.Values)
+        {
+            if (obj is IndoorPot pot && pot.bush.Value is not null)
+            {
+                yield return pot.bush.Value;
+            }
+        }
+    }
+
 
     /// <summary>The basic metadata for a recipe.</summary>
     /// <param name="Type">The recipe type.</param>

--- a/LookupAnything/i18n/default.json
+++ b/LookupAnything/i18n/default.json
@@ -352,6 +352,7 @@
     "item.needed-for": "Needed for",
     "item.flavor": "Flavor", // links to the flavor item (e.g. 'Blueberry' for Blueberry Wine)
     "item.number-owned": "Owned",
+    "item.number-planted": "Planted",
     "item.number-cooked": "Cooked",
     "item.number-crafted": "Crafted",
     "item.recipes": "Recipes",
@@ -386,6 +387,10 @@
     "item.number-owned-flavored.summary": "you own {{count}} ({{name}}) or {{baseCount}} ({{baseName}}) of these", // e.g. "you own 5 (Sturgeon Roe) or 20 (Roe) of these"
     "item.number-crafted.summary": "you made {{count}} of these",
     "item.internal-id.summary": "{{itemId}} (globally unique 'qualified ID': {{qualifiedItemId}})",
+    "item.crop-count.summary": "you have {{count}} of this crop planted",
+    "item.fruit-tree-count.summary": "you have {{count}} of this fruit tree planted",
+    "item.wild-tree-count.summary": "you have {{count}} of this tree planted",
+    "item.bush-count.summary": "you have {{count}} of this bush planted",
 
 
     /*********


### PR DESCRIPTION
Looking up seeds (include crop seeds, wild tree seeds, fruit tree saplings, and bush saplings, including bushes from Custom Bushes) now show the count of said seeds that are planted on the player's farm(s).

For wild trees, fruit trees and bushes, this excludes non-plantable locations (except for bushes inside garden pots), since the game or other mods can spawn "wild" version of those entities on non-plantable maps.

<details>
<summary>Preview screenshots</summary>
<img width="2560" height="1440" alt="2026-07-13T22:29:49,674314441-04:00" src="https://github.com/user-attachments/assets/be9f1c71-b65a-4f16-9944-12715c966326" />
<img width="2560" height="1440" alt="2026-07-13T22:17:39,908788386-04:00" src="https://github.com/user-attachments/assets/915cde96-0718-4128-a95a-5ad2ff72ea8c" />
<img width="2560" height="1440" alt="2026-07-13T22:17:25,342815831-04:00" src="https://github.com/user-attachments/assets/0a0a8581-6c00-43bf-b1a2-ab832737a688" />
<img width="2560" height="1440" alt="2026-07-13T22:17:10,046264945-04:00" src="https://github.com/user-attachments/assets/c9a161e2-f2ab-403d-9205-9b9c2797edf1" />
</details>