### PR TITLE
[Content Patcher] Documentation consistency fix

### DIFF
--- a/ContentPatcher/docs/author-guide/config.md
+++ b/ContentPatcher/docs/author-guide/config.md
@@ -40,7 +40,7 @@ field               | meaning
 Config names and fields are not case-sensitive.
 
 ### Examples
-This `content.json` defines a `BillboardMaterial` config field and uses it to change which patch is
+This `content.json` defines a `Material` config field and uses it to change which patch is
 applied:
 
 ```js


### PR DESCRIPTION
Just changes one word in the Content Patcher config documentation to make the explanatory text consistent with the example.