### PR TITLE
[Content Patcher] Cache list keys (and the editors) to reduce lookup times

### DIFF
--- a/ContentPatcher/Framework/Patches/EditData/KeyValueEditorFactory.cs
+++ b/ContentPatcher/Framework/Patches/EditData/KeyValueEditorFactory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace ContentPatcher.Framework.Patches.EditData;
 
@@ -14,6 +15,9 @@ internal class KeyValueEditorFactory
     *********/
     /// <summary>A cache of editor constructors by data type.</summary>
     private static readonly Dictionary<Type, Func<object, IKeyValueEditor>?> CachedConstructors = [];
+
+    // TODO: Cache expiry
+    private static readonly ConditionalWeakTable<object, IKeyValueEditor> CachedEditors = new();
 
 
     /*********
@@ -30,6 +34,11 @@ internal class KeyValueEditorFactory
         if (data == null || type == null)
             return false;
 
+        if (CachedEditors.TryGetValue(data, out editor))
+        {
+            return true;
+        }
+
         // get factory
         if (!KeyValueEditorFactory.CachedConstructors.TryGetValue(type, out Func<object, IKeyValueEditor>? getEditor))
         {
@@ -42,6 +51,7 @@ internal class KeyValueEditorFactory
         if (getEditor != null)
         {
             editor = getEditor(data);
+            CachedEditors.Add(data, editor);
             return true;
         }
 

--- a/ContentPatcher/Framework/Patches/EditData/ListKeyValueEditor.cs
+++ b/ContentPatcher/Framework/Patches/EditData/ListKeyValueEditor.cs
@@ -18,6 +18,8 @@ internal class ListKeyValueEditor<TValue> : BaseDataEditor
     /// <summary>Get the unique key for an entry, if available.</summary>
     private readonly Lazy<Func<TValue, string?>?> GetAssetKeyImpl;
 
+    private Dictionary<string, int> KeyCache = [];
+
 
     /*********
     ** Public methods
@@ -61,16 +63,30 @@ internal class ListKeyValueEditor<TValue> : BaseDataEditor
     public override void RemoveEntry(object key)
     {
         if (this.TryGetEntry(key, out _, out int index))
+        {
             this.Data.RemoveAt(index);
+            // TODO: Modify entries to offset their values
+            this.KeyCache.Clear();
+        }
     }
 
     /// <inheritdoc />
     public override void SetEntry(object key, object value)
     {
-        if (this.TryGetEntry(key, out _, out int index))
+        if (this.TryGetEntry(key, out var oldVal, out int index))
+        {
             this.Data[index] = (TValue)value;
+
+            // TODO: Add null handling
+            this.KeyCache.Remove(this.GetKey(oldVal));
+            this.KeyCache[this.GetKey((TValue)value)] = index;
+        }
         else
+        {
             this.Data.Add((TValue)value);
+            this.KeyCache[this.GetKey((TValue)value)] = this.Data.Count - 1;
+        }
+            
     }
 
     /// <inheritdoc />
@@ -84,11 +100,13 @@ internal class ListKeyValueEditor<TValue> : BaseDataEditor
         switch (toPosition)
         {
             case MoveEntryPosition.Top:
+                this.KeyCache.Clear();
                 this.Data.RemoveAt(index);
                 this.Data.Insert(0, entry);
                 break;
 
             case MoveEntryPosition.Bottom:
+                this.KeyCache.Clear();
                 this.Data.RemoveAt(index);
                 this.Data.Add(entry);
                 break;
@@ -113,6 +131,8 @@ internal class ListKeyValueEditor<TValue> : BaseDataEditor
             return MoveResult.AnchorNotFound;
         if (entryIndex == anchorIndex)
             return MoveResult.AnchorIsMain;
+
+        this.KeyCache.Clear();
 
         // move to position
         int newIndex = afterAnchor
@@ -161,11 +181,28 @@ internal class ListKeyValueEditor<TValue> : BaseDataEditor
                 break;
 
             case string key:
+                if (this.KeyCache.TryGetValue(key, out int cachedIndex))
+                {
+                    value = this.Data[cachedIndex]!;
+                    index = cachedIndex;
+                    return true;
+                }
+                if (this.KeyCache.Count == this.Data.Count)
+                {
+                    // all entries are cached, so the key doesn't exist
+                    break;
+                }
                 for (int i = 0; i < this.Data.Count; i++)
                 {
                     value = this.Data[i]!;
 
-                    if (this.GetKey(value) == key)
+                    string? actualKey = this.GetKey(value);
+                    if (actualKey != null)
+                    {
+                        this.KeyCache[actualKey] = i;
+                    }
+
+                    if (actualKey == key)
                     {
                         index = i;
                         return true;


### PR DESCRIPTION
For heavily modified List assets like Data/TriggerActions the act of simply working out to insert or modify becomes a performance bottleneck.

For heavily modded TriggerActions it adds up significantly.

https://discord.com/channels/137344473976799233/1359454014319755294/1534274579000725634
With this baseline it took ~450ms to load Data/TriggerActions but varied up to ~700ms

And in another case in the wild they were spending 200ms on TriggerActions https://smapi.io/log/ed445a31e8da429b8b97c877c374ff89?Mods=Profiler&Levels=trace%7Edebug%7Einfo%7Ewarn%7Eerror%7Ealert%7Ecritical&Filter=timechange

For the first case, this PR reduces it down to ~10ms
https://discord.com/channels/137344473976799233/1359454014319755294/1535269211537150052